### PR TITLE
grafana: inject Cardinal plugin via init container

### DIFF
--- a/grafana-init/.dockerignore
+++ b/grafana-init/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+.git
+.gitignore

--- a/grafana-init/Dockerfile
+++ b/grafana-init/Dockerfile
@@ -1,0 +1,42 @@
+# Grafana Init Container
+# Handles Grafana datasource provisioning, data reset, database setup,
+# and (optionally) pre-installing the CardinalHQ LakeRunner datasource plugin
+# into a shared volume so the main Grafana container can load it without
+# a runtime HTTP pull.
+FROM postgres:13-alpine AS base
+
+# Install bash, curl and unzip for scripts and plugin download
+RUN apk add --no-cache bash curl unzip
+
+# --- plugin bake stage ---
+# Downloads the Cardinal datasource plugin at build time so the resulting
+# image can be deployed into air-gapped clusters without runtime network
+# access to github.com.
+FROM base AS plugin
+ARG CARDINAL_PLUGIN_VERSION=v2.4.0
+ARG CARDINAL_PLUGIN_URL=https://github.com/cardinalhq/cardinalhq-lakerunner-datasource/releases/download/${CARDINAL_PLUGIN_VERSION}/cardinalhq-lakerunner-datasource.zip
+RUN mkdir -p /opt/plugins \
+ && curl -fsSL "$CARDINAL_PLUGIN_URL" -o /tmp/plugin.zip \
+ && unzip -q /tmp/plugin.zip -d /opt/plugins \
+ && rm /tmp/plugin.zip
+
+# --- final image ---
+FROM base
+
+# Copy bundled plugin from the bake stage
+COPY --from=plugin /opt/plugins /opt/plugins
+
+# Copy the scripts (COPY automatically creates parent directories)
+COPY init-grafana.sh        /app/scripts/init-grafana.sh
+COPY setup-grafana-db.sh    /app/scripts/setup-grafana-db.sh
+COPY reset-grafana-admin.sh /app/scripts/reset-grafana-admin.sh
+COPY install-plugins.sh     /app/scripts/install-plugins.sh
+
+# Make the scripts executable
+RUN chmod +x /app/scripts/init-grafana.sh \
+             /app/scripts/setup-grafana-db.sh \
+             /app/scripts/reset-grafana-admin.sh \
+             /app/scripts/install-plugins.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/app/scripts/init-grafana.sh"]

--- a/grafana-init/README.md
+++ b/grafana-init/README.md
@@ -1,0 +1,123 @@
+# Grafana Init Container
+
+This directory contains the Dockerfile and scripts for building the Grafana initialization container used in the Lakerunner CloudFormation deployment.
+
+## Purpose
+
+The init container handles three different modes of operation. The mode is
+selected explicitly via the `MODE` environment variable
+(`install-plugins`, `db-setup`, or `datasource-provisioning`). If `MODE` is
+unset, the container falls back to legacy auto-detection based on which
+environment variables are present.
+
+### Plugin Install Mode (`MODE=install-plugins`)
+- Copies plugins bundled into the image at `/opt/plugins` into the
+  shared plugins volume (default `/var/lib/grafana/plugins`)
+- Lets the Grafana container load the Cardinal datasource plugin at
+  startup without an outbound HTTP download — useful for air-gapped
+  clusters or reproducible deployments where the plugin version is
+  pinned to the image tag.
+
+### Database Setup Mode (`MODE=db-setup`)
+- Creates PostgreSQL database for Grafana
+- Creates dedicated database user with appropriate permissions
+- Sets up schema permissions for Grafana to operate
+- Also runs automatically (legacy) when database-related environment
+  variables are present and `MODE` is unset.
+
+### Datasource Provisioning Mode (`MODE=datasource-provisioning`)
+- Setting up Grafana datasource provisioning directories
+- Writing datasource configuration for the Cardinal Lakerunner plugin
+- Implementing data reset functionality via reset tokens
+- Ensuring proper filesystem permissions and directory structure
+
+## Building the Image
+
+To build and push the multi-architecture init container image:
+
+```bash
+# Login to ECR (if not already authenticated)
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+# Build and push multi-architecture image (AMD64 + ARM64)
+./build.sh
+```
+
+For local development and testing:
+
+```bash
+# Build for current architecture only (for local testing)
+docker buildx build --platform linux/amd64 --pull -t public.ecr.aws/cardinalhq.io/lakerunner/initcontainer-grafana:latest --load .
+```
+
+## Usage
+
+This image is used automatically by the Grafana CloudFormation stack as an init container. It runs before the main Grafana container starts and sets up the necessary configuration.
+
+## Environment Variables
+
+### Plugin Install Mode
+Used when pre-installing plugins into the shared Grafana plugins volume:
+- `MODE`: Set to `install-plugins`
+- `GF_PATHS_PLUGINS`: Destination plugins directory (default: `/var/lib/grafana/plugins`)
+
+### Database Setup Mode
+Required when setting up PostgreSQL for Grafana:
+- `GRAFANA_DB_NAME`: Name of the database to create (e.g., "grafana")
+- `GRAFANA_DB_USER`: Username for the Grafana database user (e.g., "grafana") 
+- `GRAFANA_DB_PASSWORD`: Password for the Grafana database user
+- `PGHOST`: PostgreSQL server hostname
+- `PGUSER`: PostgreSQL admin username (with database creation privileges)
+- `PGPASSWORD`: PostgreSQL admin password
+- `PGPORT`: PostgreSQL port (optional, default: 5432)
+- `PGDATABASE`: Admin database name (optional, default: postgres)
+- `PGSSLMODE`: SSL mode (optional, default: require)
+
+### Datasource Provisioning Mode  
+Used when setting up Grafana datasources:
+- `PROVISIONING_DIR`: Grafana provisioning directory (default: `/etc/grafana/provisioning`)
+- `RESET_TOKEN`: Optional token to trigger Grafana data reset
+- `GRAFANA_DATASOURCE_CONFIG`: YAML configuration for the Cardinal datasource
+
+## Container Structure
+
+The container follows CardinalHQ conventions:
+- `/app/scripts/init-grafana.sh`: Main initialization script (entrypoint) - detects mode and delegates
+- `/app/scripts/install-plugins.sh`: Copies bundled plugins into `GF_PATHS_PLUGINS`
+- `/app/scripts/setup-grafana-db.sh`: Database setup script for PostgreSQL configuration
+- `/opt/plugins/`: Plugins baked in at image build time (currently the Cardinal LakeRunner datasource)
+
+## Volumes
+
+The container needs access to these mounted volumes:
+
+- `/var/lib/grafana`: Grafana data directory (for reset token file)
+- `/etc/grafana/provisioning`: Grafana provisioning directory (to write datasource config)
+
+## Air-gapped Deployment
+
+This approach solves air-gapped deployment issues by:
+
+1. Pre-building the init logic into a container image
+2. Using PostgreSQL Alpine image as base for database operations and shell support
+3. Eliminating the need to download packages at runtime
+4. Providing a self-contained initialization solution for both database setup and datasource provisioning
+
+## Operation Mode Detection
+
+Mode selection is explicit via the `MODE` env var
+(`install-plugins` | `db-setup` | `datasource-provisioning`).
+
+If `MODE` is unset, the container falls back to legacy auto-detection:
+- If `GRAFANA_DB_NAME`, `GRAFANA_DB_USER`, and `PGHOST` are all present, it runs in **Database Setup Mode**
+- Otherwise, it runs in **Datasource Provisioning Mode**
+
+Plugin Install Mode is never auto-detected and must be selected with
+`MODE=install-plugins`.
+
+## Build-time Plugin Version
+
+The bundled Cardinal datasource plugin version is controlled by
+`--build-arg CARDINAL_PLUGIN_VERSION=vX.Y.Z` (default in the Dockerfile).
+Tag the built image with the same version (e.g. `initcontainer-grafana:v2.4.0`)
+so chart releases can pin to a known plugin version.

--- a/grafana-init/build.sh
+++ b/grafana-init/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Build script for Grafana Init Container (multi-architecture)
+
+set -e
+
+IMAGE_NAME="public.ecr.aws/cardinalhq.io/lakerunner/initcontainer-grafana:latest"
+
+echo "Building Grafana Init Container for multiple architectures..."
+
+# Create buildx builder if it doesn't exist
+if ! docker buildx inspect multiarch >/dev/null 2>&1; then
+    echo "Creating buildx builder..."
+    docker buildx create --name multiarch --use
+fi
+
+# Use the multiarch builder
+docker buildx use multiarch
+
+# Build for both AMD64 and ARM64
+echo "Building for linux/amd64 and linux/arm64..."
+docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    --pull \
+    -t "$IMAGE_NAME" \
+    --push \
+    .
+
+echo "Build and push complete!"
+echo "Multi-architecture image available at: $IMAGE_NAME"
+
+echo ""
+echo "To use locally for testing (single architecture):"
+echo "  docker buildx build --platform linux/amd64 --pull -t $IMAGE_NAME --load ."

--- a/grafana-init/init-grafana.sh
+++ b/grafana-init/init-grafana.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Grafana Initialization Script
+# Handles datasource provisioning, data reset functionality, and database setup
+
+set -e
+
+echo "Starting Grafana initialization..."
+
+# Explicit mode selection. When MODE is set it wins over auto-detection.
+# Supported values: install-plugins | db-setup | datasource-provisioning
+case "$MODE" in
+    install-plugins)
+        echo "Plugin install mode selected"
+        exec /app/scripts/install-plugins.sh
+        ;;
+    db-setup)
+        echo "Database setup mode selected"
+        exec /app/scripts/setup-grafana-db.sh
+        ;;
+    datasource-provisioning)
+        echo "Datasource provisioning mode selected"
+        ;;
+    "")
+        # No explicit mode - fall through to legacy auto-detection below
+        ;;
+    *)
+        echo "ERROR: Unknown MODE='$MODE' (expected install-plugins|db-setup|datasource-provisioning)"
+        exit 1
+        ;;
+esac
+
+# Legacy auto-detection: database setup when DB env vars are present
+if [ -z "$MODE" ] && [ -n "$GRAFANA_DB_NAME" ] && [ -n "$GRAFANA_DB_USER" ] && [ -n "$PGHOST" ]; then
+    echo "Database setup mode detected - running database setup script"
+    exec /app/scripts/setup-grafana-db.sh
+fi
+
+echo "Datasource provisioning mode - continuing with datasource setup"
+
+# Set up provisioning directory
+PROVISIONING_DIR="${GF_PATHS_PROVISIONING:-/etc/grafana/provisioning}"
+DATASOURCES_DIR="$PROVISIONING_DIR/datasources"
+RESET_TOKEN_FILE="/var/lib/grafana/.grafana_reset_token"
+
+echo "Provisioning directory: $PROVISIONING_DIR"
+echo "Datasources directory: $DATASOURCES_DIR"
+echo "Reset token file: $RESET_TOKEN_FILE"
+
+# Create provisioning directories
+mkdir -p "$DATASOURCES_DIR"
+
+# All containers run as root, so no ownership changes needed
+
+# Handle reset token logic
+if [ -n "$RESET_TOKEN" ] && [ "$RESET_TOKEN" != "" ]; then
+    echo "Reset token provided: $RESET_TOKEN"
+
+    # Check if token file exists and compare
+    if [ -f "$RESET_TOKEN_FILE" ]; then
+        STORED_TOKEN=$(cat "$RESET_TOKEN_FILE")
+        if [ "$STORED_TOKEN" != "$RESET_TOKEN" ]; then
+            echo "Reset token changed from '$STORED_TOKEN' to '$RESET_TOKEN' - wiping Grafana data"
+            # Remove all Grafana data
+            find /var/lib/grafana -mindepth 1 -delete || true
+            # Create new token file
+            echo "$RESET_TOKEN" > "$RESET_TOKEN_FILE"
+        else
+            echo "Reset token unchanged - no reset needed"
+        fi
+    else
+        echo "First time with reset token - storing: $RESET_TOKEN"
+        echo "$RESET_TOKEN" > "$RESET_TOKEN_FILE"
+    fi
+else
+    echo "No reset token provided - skipping reset logic"
+fi
+
+# Write datasource configuration
+echo "Writing Grafana datasource configuration..."
+# The datasource config comes from SSM parameter as YAML, just write it directly
+cat > "$DATASOURCES_DIR/cardinal.yaml" << DATASOURCE_EOF
+$GRAFANA_DATASOURCE_CONFIG
+DATASOURCE_EOF
+
+echo "Grafana datasource configuration written to $DATASOURCES_DIR/cardinal.yaml"
+echo "Grafana initialization complete"
+
+# Verify the configuration was written correctly
+if [ -f "$DATASOURCES_DIR/cardinal.yaml" ]; then
+    echo "Datasource configuration file created successfully"
+    echo "Configuration preview:"
+    head -10 "$DATASOURCES_DIR/cardinal.yaml" || true
+else
+    echo "Failed to create datasource configuration file"
+    exit 1
+fi
+
+echo "Init container completed successfully"

--- a/grafana-init/install-plugins.sh
+++ b/grafana-init/install-plugins.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Grafana Plugin Install
+# Copies plugins baked into this image at /opt/plugins into the shared
+# plugins volume mounted by the Grafana container. Grafana then loads
+# them from GF_PATHS_PLUGINS without needing a runtime HTTP pull.
+
+set -e
+
+SRC="/opt/plugins"
+DEST="${GF_PATHS_PLUGINS:-/var/lib/grafana/plugins}"
+
+if [ ! -d "$SRC" ] || [ -z "$(ls -A "$SRC" 2>/dev/null)" ]; then
+    echo "No plugins bundled at $SRC - nothing to install"
+    exit 0
+fi
+
+echo "Installing bundled Grafana plugins from $SRC to $DEST..."
+mkdir -p "$DEST"
+cp -a "$SRC"/. "$DEST"/
+
+echo "Installed plugins:"
+ls -la "$DEST"
+echo "Plugin install complete"

--- a/grafana-init/reset-grafana-admin.sh
+++ b/grafana-init/reset-grafana-admin.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Grafana Admin Password Reset Script
+# Resets the Grafana admin password in PostgreSQL database when reset token changes
+
+set -e
+
+echo "Starting Grafana admin password reset check..."
+
+# Check for required environment variables
+if [ -z "$RESET_TOKEN" ] || [ "$RESET_TOKEN" = "" ]; then
+    echo "No reset token provided - skipping password reset check"
+    exit 0
+fi
+
+if [ -z "$GRAFANA_DB_NAME" ] || [ -z "$GRAFANA_DB_USER" ] || [ -z "$GRAFANA_DB_PASSWORD" ]; then
+    echo "Database credentials not provided - skipping password reset"
+    exit 0
+fi
+
+if [ -z "$GF_SECURITY_ADMIN_USER" ] || [ -z "$GF_SECURITY_ADMIN_PASSWORD" ]; then
+    echo "Admin credentials not provided - skipping password reset"
+    exit 0
+fi
+
+echo "Reset token provided: $RESET_TOKEN"
+echo "Admin user to reset: $GF_SECURITY_ADMIN_USER"
+
+# Set up PostgreSQL connection for Grafana database
+export PGHOST="${PGHOST}"
+export PGPORT="${PGPORT:-5432}"
+export PGDATABASE="${GRAFANA_DB_NAME}"
+export PGUSER="${GRAFANA_DB_USER}"
+export PGPASSWORD="${GRAFANA_DB_PASSWORD}"
+export PGSSLMODE="${PGSSLMODE:-require}"
+
+# Check if Grafana tables exist
+echo "Checking if Grafana is already initialized..."
+TABLE_EXISTS=$(psql -tc "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='user'" 2>/dev/null | grep -q 1 && echo "yes" || echo "no")
+
+if [ "$TABLE_EXISTS" = "no" ]; then
+    echo "Grafana tables don't exist yet - first run will use environment variables"
+    exit 0
+fi
+
+# Store reset token in database to track changes
+echo "Checking reset token..."
+RESET_TOKEN_TABLE_EXISTS=$(psql -tc "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='reset_token'" 2>/dev/null | grep -q 1 && echo "yes" || echo "no")
+
+if [ "$RESET_TOKEN_TABLE_EXISTS" = "no" ]; then
+    echo "Creating reset token tracking table..."
+    psql -c "CREATE TABLE reset_token (token VARCHAR(255) PRIMARY KEY, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+fi
+
+# Check if this token has been applied before
+TOKEN_EXISTS=$(psql -tc "SELECT 1 FROM reset_token WHERE token = '$RESET_TOKEN'" 2>/dev/null | grep -q 1 && echo "yes" || echo "no")
+
+if [ "$TOKEN_EXISTS" = "yes" ]; then
+    echo "Reset token '$RESET_TOKEN' already applied - skipping password reset"
+    exit 0
+fi
+
+echo "New reset token detected - resetting admin password..."
+
+# Generate bcrypt hash for the password
+# Grafana uses bcrypt with cost 10 by default
+# Since we can't easily generate bcrypt in bash, we'll delete the user and let Grafana recreate it
+echo "Resetting admin user '$GF_SECURITY_ADMIN_USER'..."
+
+# Delete the admin user - Grafana will recreate it on startup with the password from environment
+psql -c "DELETE FROM \"user\" WHERE login = '$GF_SECURITY_ADMIN_USER'" || true
+
+# Also delete any existing sessions to force re-login
+psql -c "DELETE FROM user_auth_token WHERE user_id IN (SELECT id FROM \"user\" WHERE login = '$GF_SECURITY_ADMIN_USER')" || true
+
+# Record that this token has been applied
+psql -c "INSERT INTO reset_token (token) VALUES ('$RESET_TOKEN')"
+
+echo "Admin user deleted from database. Grafana will recreate it with the new password on startup."
+echo "Password reset completed successfully!"

--- a/grafana-init/setup-grafana-db.sh
+++ b/grafana-init/setup-grafana-db.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Grafana Database Setup Script
+# Creates PostgreSQL database and user for Grafana with proper permissions
+
+set -e
+
+echo "Starting Grafana database setup..."
+
+# Validate required environment variables
+if [ -z "$GRAFANA_DB_NAME" ]; then
+    echo "ERROR: GRAFANA_DB_NAME environment variable is required"
+    exit 1
+fi
+
+if [ -z "$GRAFANA_DB_USER" ]; then
+    echo "ERROR: GRAFANA_DB_USER environment variable is required"
+    exit 1
+fi
+
+if [ -z "$GRAFANA_DB_PASSWORD" ]; then
+    echo "ERROR: GRAFANA_DB_PASSWORD environment variable is required"
+    exit 1
+fi
+
+if [ -z "$PGHOST" ]; then
+    echo "ERROR: PGHOST environment variable is required"
+    exit 1
+fi
+
+if [ -z "$PGUSER" ]; then
+    echo "ERROR: PGUSER environment variable is required"
+    exit 1
+fi
+
+if [ -z "$PGPASSWORD" ]; then
+    echo "ERROR: PGPASSWORD environment variable is required"
+    exit 1
+fi
+
+echo "Database setup parameters:"
+echo "  Host: $PGHOST"
+echo "  Port: ${PGPORT:-5432}"
+echo "  Admin DB: ${PGDATABASE:-postgres}"
+echo "  SSL Mode: ${PGSSLMODE:-require}"
+echo "  Grafana DB: $GRAFANA_DB_NAME"
+echo "  Grafana User: $GRAFANA_DB_USER"
+
+# Create database if it doesn't exist
+echo "Checking if database '$GRAFANA_DB_NAME' exists..."
+DB_EXISTS=$(psql -tc "SELECT 1 FROM pg_database WHERE datname = '$GRAFANA_DB_NAME'" | grep -q 1 && echo "yes" || echo "no")
+
+if [ "$DB_EXISTS" = "no" ]; then
+    echo "Creating database '$GRAFANA_DB_NAME'..."
+    psql -c "CREATE DATABASE $GRAFANA_DB_NAME"
+    echo "Database '$GRAFANA_DB_NAME' created successfully"
+else
+    echo "Database '$GRAFANA_DB_NAME' already exists"
+fi
+
+# Create user if it doesn't exist
+echo "Checking if user '$GRAFANA_DB_USER' exists..."
+USER_EXISTS=$(psql -tc "SELECT 1 FROM pg_user WHERE usename = '$GRAFANA_DB_USER'" | grep -q 1 && echo "yes" || echo "no")
+
+if [ "$USER_EXISTS" = "no" ]; then
+    echo "Creating user '$GRAFANA_DB_USER'..."
+    psql -c "CREATE USER $GRAFANA_DB_USER WITH PASSWORD '$GRAFANA_DB_PASSWORD'"
+    echo "User '$GRAFANA_DB_USER' created successfully"
+else
+    echo "User '$GRAFANA_DB_USER' already exists"
+    # Update password in case it changed
+    echo "Updating password for user '$GRAFANA_DB_USER'..."
+    psql -c "ALTER USER $GRAFANA_DB_USER WITH PASSWORD '$GRAFANA_DB_PASSWORD'"
+fi
+
+# Grant database privileges
+echo "Granting privileges on database '$GRAFANA_DB_NAME' to user '$GRAFANA_DB_USER'..."
+psql -c "GRANT ALL PRIVILEGES ON DATABASE $GRAFANA_DB_NAME TO $GRAFANA_DB_USER"
+
+# Connect to the Grafana database to set up schema permissions
+echo "Setting up schema permissions in database '$GRAFANA_DB_NAME'..."
+PGDATABASE=$GRAFANA_DB_NAME psql -c "GRANT ALL ON SCHEMA public TO $GRAFANA_DB_USER"
+PGDATABASE=$GRAFANA_DB_NAME psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $GRAFANA_DB_USER"
+PGDATABASE=$GRAFANA_DB_NAME psql -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO $GRAFANA_DB_USER"
+
+# Set default privileges for future objects
+echo "Setting default privileges for future objects..."
+PGDATABASE=$GRAFANA_DB_NAME psql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO $GRAFANA_DB_USER"
+PGDATABASE=$GRAFANA_DB_NAME psql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO $GRAFANA_DB_USER"
+
+echo "Grafana database setup completed successfully!"
+echo "Database '$GRAFANA_DB_NAME' is ready for Grafana with user '$GRAFANA_DB_USER'"
+
+# Check if we need to reset the admin password
+if [ -f "/app/scripts/reset-grafana-admin.sh" ]; then
+    echo ""
+    echo "Checking for admin password reset..."
+    # Export variables needed by reset script
+    export GF_SECURITY_ADMIN_USER="${GF_SECURITY_ADMIN_USER:-admin}"
+    export GF_SECURITY_ADMIN_PASSWORD="${GF_SECURITY_ADMIN_PASSWORD}"
+    /app/scripts/reset-grafana-admin.sh
+fi

--- a/lakerunner/templates/grafana-deployment.yaml
+++ b/lakerunner/templates/grafana-deployment.yaml
@@ -47,6 +47,26 @@ spec:
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.grafana.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.grafana.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.grafana.affinity)     | nindent 6 }}
+      {{- if .Values.grafana.cardinalPlugin.initContainer.enabled }}
+      initContainers:
+      - name: install-plugins
+        image: {{ include "lakerunner.image" (list .Values.grafana.cardinalPlugin.initContainer.image .) }}
+        imagePullPolicy: {{ .Values.grafana.cardinalPlugin.initContainer.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: MODE
+          value: install-plugins
+        - name: GF_PATHS_PLUGINS
+          value: /var/lib/grafana/plugins
+        volumeMounts:
+        - name: grafana-plugins
+          mountPath: /var/lib/grafana/plugins
+      {{- end }}
       containers:
       - name: grafana
         securityContext:
@@ -73,8 +93,17 @@ spec:
             value: "3000"
           - name: GF_SECURITY_ALLOW_EMBEDDING
             value: "true"
+          {{- if .Values.grafana.cardinalPlugin.initContainer.enabled }}
+          {{- if .Values.grafana.additionalPlugins }}
+          - name: GF_INSTALL_PLUGINS
+            value: {{ .Values.grafana.additionalPlugins | quote }}
+          {{- end }}
+          - name: GF_PATHS_PLUGINS
+            value: /var/lib/grafana/plugins
+          {{- else }}
           - name: GF_INSTALL_PLUGINS
             value: {{ if .Values.grafana.additionalPlugins }}{{ printf "%s,%s" .Values.grafana.cardinalPlugin.url .Values.grafana.additionalPlugins | quote }}{{ else }}{{ .Values.grafana.cardinalPlugin.url | quote }}{{ end }}
+          {{- end }}
           - name: GF_SERVER_ROOT_URL
             value: "%(protocol)s://%(domain)s:%(http_port)s"
           {{- include "lakerunner.injectEnv" (list . .Values.grafana) | nindent 8 }}
@@ -86,11 +115,19 @@ spec:
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/lib/grafana
+        {{- if .Values.grafana.cardinalPlugin.initContainer.enabled }}
+        - name: grafana-plugins
+          mountPath: /var/lib/grafana/plugins
+        {{- end }}
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources
           readOnly: true
       volumes:
       {{- include "lakerunner.ephemeralVolumeBasic" (list "grafana-storage" .) | nindent 6 }}
+      {{- if .Values.grafana.cardinalPlugin.initContainer.enabled }}
+      - name: grafana-plugins
+        emptyDir: {}
+      {{- end }}
       - name: grafana-datasources
         configMap:
           name: {{ include "lakerunner.fullname" . }}-grafana-datasources

--- a/lakerunner/tests/grafana_test.yaml
+++ b/lakerunner/tests/grafana_test.yaml
@@ -239,3 +239,119 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not add plugin init container by default
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: grafana-plugins
+            mountPath: /var/lib/grafana/plugins
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: grafana-plugins
+            emptyDir: {}
+
+  - it: should add plugin init container when enabled
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+      grafana.cardinalPlugin.initContainer.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: install-plugins
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: MODE
+            value: install-plugins
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GF_PATHS_PLUGINS
+            value: /var/lib/grafana/plugins
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: grafana-plugins
+            mountPath: /var/lib/grafana/plugins
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: grafana-plugins
+            mountPath: /var/lib/grafana/plugins
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: grafana-plugins
+            emptyDir: {}
+
+  - it: should drop cardinal plugin from GF_INSTALL_PLUGINS when init container enabled
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+      grafana.cardinalPlugin.initContainer.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GF_INSTALL_PLUGINS
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GF_PATHS_PLUGINS
+            value: /var/lib/grafana/plugins
+
+  - it: should keep GF_INSTALL_PLUGINS for additionalPlugins when init container enabled
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+      grafana.cardinalPlugin.initContainer.enabled: true
+      grafana.additionalPlugins: "grafana-clock-panel"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GF_INSTALL_PLUGINS
+            value: "grafana-clock-panel"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GF_PATHS_PLUGINS
+            value: /var/lib/grafana/plugins
+
+  - it: should use chart appVersion as default init container tag
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+      grafana.cardinalPlugin.initContainer.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].image
+          pattern: "^public\\.ecr\\.aws/cardinalhq\\.io/lakerunner/initcontainer-grafana:.+$"
+
+  - it: should honor override of init container image repository and tag
+    templates:
+      - grafana-deployment.yaml
+    set:
+      grafana.enabled: true
+      grafana.cardinalPlugin.initContainer.enabled: true
+      grafana.cardinalPlugin.initContainer.image.repository: "internal-registry.company.com/grafana-init"
+      grafana.cardinalPlugin.initContainer.image.tag: "v9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "internal-registry.company.com/grafana-init:v9.9.9"

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -794,8 +794,23 @@ grafana:
   # This plugin is REQUIRED for LakeRunner to function properly
   cardinalPlugin:
     # URL to the CardinalHQ LakeRunner datasource plugin
-    # air-gapped deployments should download the plugin and provide a local path
+    # Used only when initContainer.enabled is false (legacy HTTP-pull mode):
+    # Grafana downloads the plugin zip at startup via GF_INSTALL_PLUGINS.
+    # Air-gapped deployments should either host the zip internally and point
+    # this at it, or enable initContainer mode below.
     url: "https://github.com/cardinalhq/cardinalhq-lakerunner-datasource/releases/download/v2.4.0/cardinalhq-lakerunner-datasource.zip;cardinalhq-lakerunner-datasource"
+    # Pre-install the Cardinal datasource plugin via an init container that
+    # carries the plugin baked into its image, instead of relying on Grafana
+    # pulling it over HTTP at startup. Recommended for air-gapped clusters
+    # and for reproducible deployments where the plugin version is pinned
+    # to the chart release.
+    initContainer:
+      enabled: false
+      image:
+        repository: public.ecr.aws/cardinalhq.io/lakerunner/initcontainer-grafana
+        # Tag defaults to the chart's appVersion if left empty
+        tag: ""
+        pullPolicy: ""
   # Additional optional Grafana plugins (semicolon-separated list)
   # These will be installed in addition to the required CardinalHQ plugin
   additionalPlugins: ""


### PR DESCRIPTION
## Summary
- Adds an opt-in init container mode (`grafana.cardinalPlugin.initContainer.enabled`) that pre-installs the CardinalHQ LakeRunner datasource plugin into a shared `emptyDir` at `/var/lib/grafana/plugins`, letting Grafana load it from disk without HTTP-pulling the zip from GitHub at pod startup.
- Extends `grafana-init/` with a multi-stage `Dockerfile` that bakes the plugin zip into `/opt/plugins` at build time, plus a new `install-plugins.sh` script and a `MODE=install-plugins` branch in `init-grafana.sh`. Legacy auto-detection (db-setup / datasource-provisioning) is preserved when `MODE` is unset.
- Existing HTTP-pull behavior (`GF_INSTALL_PLUGINS` with the GitHub release URL) remains the default — flag is off unless you turn it on.

## Why
Air-gapped clusters and reproducible deployments: when the init container is enabled, the plugin version is pinned to the init-container image tag, and no egress to github.com is required at pod startup. `additionalPlugins` still flow through `GF_INSTALL_PLUGINS` so non-Cardinal plugins pulled from grafana.com continue to work.

## Behavior matrix
| Mode | `GF_INSTALL_PLUGINS` | init container | shared plugins volume |
| --- | --- | --- | --- |
| `initContainer.enabled: false` (default) | Cardinal URL (+ `additionalPlugins`) | — | — |
| `initContainer.enabled: true` | only `additionalPlugins` (if any) | `install-plugins` | `grafana-plugins` emptyDir mounted on both containers at `/var/lib/grafana/plugins` |

## Test plan
- [x] `helm lint` clean
- [x] `helm unittest` — 6 new grafana tests pass; all other previously-passing suites still pass (only pre-existing `license_test.yaml` failure on main is unaffected)
- [x] `helm template` renders both modes end-to-end
- [ ] Build the init image with `./grafana-init/build.sh` and verify `kubectl exec ... ls /var/lib/grafana/plugins` shows `cardinalhq-lakerunner-datasource` in a live cluster
- [ ] Verify Grafana loads the plugin without `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS` (expected, since the unpacked signed plugin preserves its signature)

## Notes / follow-ups
- Init-container image tag defaults to chart `appVersion`; override via `grafana.cardinalPlugin.initContainer.image.tag`.
- When the init container is enabled, `emptyDir` is used for the plugins volume (rebuilt on every pod start) — avoids PVC churn and keeps the plugin dir in sync with the image tag.
- Default behavior is unchanged; this is purely additive.