### PR TITLE
lakerunner: configurable pod/container securityContext

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.5.4"
+version: "3.6.0"
 appVersion: "v1.18.2"
 keywords:
   - lakerunner

--- a/lakerunner/Makefile
+++ b/lakerunner/Makefile
@@ -18,15 +18,15 @@ lint:  ## Run helm lint on the chart
 	helm lint . --values tests/test-values.yaml
 
 template:  ## Test template rendering with various configurations
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set global.image.tag=v1.2.3 --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set queryApi.enabled=false --set grafana.enabled=false --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set grafana.cardinalPlugin.url="https://internal.example.com/plugin.zip;cardinalhq-lakerunner-datasource" --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set grafana.additionalPlugins="grafana-clock-panel" --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set queryApi.replicas=3 --set processLogs.replicas=5 --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set database.lrdb.host=postgres.example.com --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set monitoring.autoscaler.observeOnly=true --dry-run > /dev/null 2>&1
-	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set processLogs.autoscaling.minReplicas=0 --set processLogs.autoscaling.maxReplicas=0 --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set global.image.tag=v1.2.3 --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set queryApi.enabled=false --set grafana.enabled=false --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set grafana.cardinalPlugin.url="https://internal.example.com/plugin.zip;cardinalhq-lakerunner-datasource" --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set grafana.additionalPlugins="grafana-clock-panel" --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set queryApi.replicas=3 --set processLogs.replicas=5 --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set database.lrdb.host=postgres.example.com --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set monitoring.autoscaler.observeOnly=true --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set aws.region=us-west-2 --set-string license.data=test --set processLogs.autoscaling.minReplicas=0 --set processLogs.autoscaling.maxReplicas=0 --dry-run > /dev/null 2>&1
 
 unittest:  ## Run helm unittest tests
 	@echo "Running unit tests..."

--- a/lakerunner/README.md
+++ b/lakerunner/README.md
@@ -341,3 +341,55 @@ The following table summarizes the default resource requirements for each LakeRu
 * Components with autoscaling enabled can scale between configured min/max replicas
 * Temporary storage is used for processing intermediate data and caching and will benefit from fast local epheremal storage.
 * PubSub components are mutually exclusive - typically only one is enabled based on your cloud provider
+
+## Security context / Pod Security Standards
+
+Every workload runs under a hardened `securityContext` by default:
+
+* `runAsNonRoot: true`, `runAsUser`/`runAsGroup`/`fsGroup: 65532` at the pod level (Grafana overrides these to `472` because its upstream image requires that user)
+* `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`, and `readOnlyRootFilesystem: true` at the container level (Grafana sets `readOnlyRootFilesystem: false` because it writes to `/var/lib/grafana`)
+
+The defaults satisfy Kubernetes Pod Security Standards `restricted`. The full map lives in `values.yaml` under `global.podSecurityContext` and `global.containerSecurityContext`; per-component overrides can be added as `<component>.podSecurityContext` / `<component>.containerSecurityContext` and the chart will shallow-merge (component wins over global).
+
+## Deploying on OpenShift
+
+The chart renders cleanly under the `restricted-v2` SCC with two adjustments:
+
+### 1. Let the SCC assign UIDs
+
+OpenShift's `restricted-v2` SCC rejects pods whose `runAsUser`/`runAsGroup`/`fsGroup` fall outside the namespace's assigned UID range (it wants to inject them from the range itself). Null the fields in your `values-local.yaml`:
+
+```yaml
+global:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+grafana:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+```
+
+With those in place, the pod `securityContext` emits only `runAsNonRoot: true` and the SCC fills in the rest. All other hardening (no-privilege-escalation, drop ALL, RuntimeDefault seccomp, read-only rootfs) stays in effect.
+
+### 2. Grafana needs an SCC that permits UID 472
+
+The upstream `grafana/grafana` image expects UID 472 to own `/var/lib/grafana`. Because that UID almost never falls inside a namespace's restricted-v2 range, Grafana needs either a custom SCC or an OpenShift-compatible image. The simplest path is:
+
+```sh
+oc adm policy add-scc-to-user nonroot-v2 -z <release>-lakerunner -n <namespace>
+```
+
+and then keep Grafana's defaults (UID 472). If you prefer to avoid the SCC grant, swap `grafana.image.repository` for an image that supports random UIDs.
+
+### 3. Perch needs elevated RBAC
+
+The Perch component already ships with a `ClusterRole` that includes `patch` on `apps/deployments` cluster-wide — this is its legitimate function (cross-namespace deployment management), but it counts as a privileged grant. On clusters with strict RBAC review you may need admin approval or an `oc adm policy add-role-to-user edit` against the chart's ServiceAccount.
+
+### 4. Ingress / Routes
+
+The chart uses standard `networking.k8s.io/v1` `Ingress` resources. They work with the OpenShift HAProxy router out of the box; no nginx-specific annotations are emitted.

--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -1049,3 +1049,53 @@ Usage:
 {{ toYaml . | nindent 2 -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Pod-level securityContext for a workload.
+Shallow-merges global.podSecurityContext with an optional per-component override;
+component fields win over global. Uses explicit `set` instead of sprig's `merge`
+to avoid mergo's quirk where falsy zero values (false, 0, "") get overwritten.
+Emits nothing when the resulting map is empty.
+Usage:
+  {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.grafana.podSecurityContext) | nindent 6 }}
+Components without an override can omit the "override" key.
+*/}}
+{{- define "lakerunner.podSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.podSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Container-level securityContext for a container.
+Same shallow-merge semantics as lakerunner.podSecurityContext.
+Usage:
+  {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.grafana.containerSecurityContext) | nindent 8 }}
+*/}}
+{{- define "lakerunner.containerSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.containerSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}

--- a/lakerunner/templates/admin-api-deployment.yaml
+++ b/lakerunner/templates/admin-api-deployment.yaml
@@ -21,24 +21,14 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.adminApi.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.adminApi.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.adminApi.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.adminApi.affinity)     | nindent 6 }}
       containers:
       - name: admin-api
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.adminApi.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.adminApi.image .) }}
         imagePullPolicy: {{ .Values.adminApi.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/alert-evaluator-deployment.yaml
+++ b/lakerunner/templates/alert-evaluator-deployment.yaml
@@ -24,24 +24,14 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.alertEvaluator.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.alertEvaluator.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.alertEvaluator.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.alertEvaluator.affinity)     | nindent 6 }}
       containers:
       - name: alert-evaluator
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.alertEvaluator.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.alertEvaluator.image .) }}
         imagePullPolicy: {{ .Values.alertEvaluator.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/grafana-deployment.yaml
+++ b/lakerunner/templates/grafana-deployment.yaml
@@ -38,11 +38,7 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 472
-        runAsGroup: 472
-        fsGroup: 472
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.grafana.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.grafana.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.grafana.tolerations)  | nindent 6 }}
@@ -52,12 +48,7 @@ spec:
       - name: install-plugins
         image: {{ include "lakerunner.image" (list .Values.grafana.cardinalPlugin.initContainer.image .) }}
         imagePullPolicy: {{ .Values.grafana.cardinalPlugin.initContainer.image.pullPolicy | default .Values.global.image.pullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.grafana.containerSecurityContext) | nindent 8 }}
         env:
         - name: MODE
           value: install-plugins
@@ -69,12 +60,7 @@ spec:
       {{- end }}
       containers:
       - name: grafana
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.grafana.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.grafana.image .) }}
         imagePullPolicy: {{ .Values.grafana.image.pullPolicy | default .Values.global.image.pullPolicy }}
         ports:

--- a/lakerunner/templates/monitoring-deployment.yaml
+++ b/lakerunner/templates/monitoring-deployment.yaml
@@ -21,24 +21,14 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.monitoring.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.monitoring.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.monitoring.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.monitoring.affinity)     | nindent 6 }}
       containers:
       - name: monitoring
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.monitoring.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.monitoring.image .) }}
         imagePullPolicy: {{ .Values.monitoring.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/perch-deployment.yaml
+++ b/lakerunner/templates/perch-deployment.yaml
@@ -21,24 +21,14 @@ spec:
       {{- include "lakerunner.annotationsWithComponent" (list . .Values.perch.annotations) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.perch.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.perch.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.perch.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.perch.affinity)     | nindent 6 }}
       containers:
       - name: perch
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.perch.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.perch.image .) }}
         imagePullPolicy: {{ .Values.perch.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/process-logs-deployment.yaml
+++ b/lakerunner/templates/process-logs-deployment.yaml
@@ -23,21 +23,11 @@ spec:
       {{- include "lakerunner.annotationsWithComponent" (list . .Values.processLogs.annotations) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processLogs.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: process-logs
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processLogs.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.processLogs.image .) }}
         imagePullPolicy: {{ .Values.processLogs.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/process-metrics-deployment.yaml
+++ b/lakerunner/templates/process-metrics-deployment.yaml
@@ -23,21 +23,11 @@ spec:
       {{- include "lakerunner.annotationsWithComponent" (list . .Values.processMetrics.annotations) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processMetrics.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: process-metrics
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processMetrics.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.processMetrics.image .) }}
         imagePullPolicy: {{ .Values.processMetrics.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/process-traces-deployment.yaml
+++ b/lakerunner/templates/process-traces-deployment.yaml
@@ -23,21 +23,11 @@ spec:
       {{- include "lakerunner.annotationsWithComponent" (list . .Values.processTraces.annotations) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processTraces.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: process-traces
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processTraces.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.processTraces.image .) }}
         imagePullPolicy: {{ .Values.processTraces.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/pubsub-azure-deployment.yaml
+++ b/lakerunner/templates/pubsub-azure-deployment.yaml
@@ -30,21 +30,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.Azure.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: pubsub
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.Azure.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.pubsub.Azure.image .) }}
         imagePullPolicy: {{ .Values.pubsub.Azure.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/pubsub-gcp-deployment.yaml
+++ b/lakerunner/templates/pubsub-gcp-deployment.yaml
@@ -27,21 +27,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.GCP.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: pubsub
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.GCP.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.pubsub.GCP.image .) }}
         imagePullPolicy: {{ .Values.pubsub.GCP.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/pubsub-http-deployment.yaml
+++ b/lakerunner/templates/pubsub-http-deployment.yaml
@@ -21,21 +21,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.HTTP.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: pubsub
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.HTTP.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.pubsub.HTTP.image .) }}
         imagePullPolicy: {{ .Values.pubsub.HTTP.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/pubsub-sqs-deployment.yaml
+++ b/lakerunner/templates/pubsub-sqs-deployment.yaml
@@ -28,21 +28,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.SQS.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: pubsub
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.SQS.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.pubsub.SQS.image .) }}
         imagePullPolicy: {{ .Values.pubsub.SQS.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/query-api-deployment.yaml
+++ b/lakerunner/templates/query-api-deployment.yaml
@@ -24,21 +24,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.queryApi.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: query-api
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.queryApi.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.queryApi.image .) }}
         imagePullPolicy: {{ .Values.queryApi.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/query-worker-deployment.yaml
+++ b/lakerunner/templates/query-worker-deployment.yaml
@@ -24,21 +24,11 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.queryWorker.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: query-worker
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.queryWorker.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.queryWorker.image .) }}
         imagePullPolicy: {{ .Values.queryWorker.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/setup-job.yaml
+++ b/lakerunner/templates/setup-job.yaml
@@ -23,24 +23,14 @@ spec:
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
       restartPolicy: Never
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.setup.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.setup.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.setup.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.setup.affinity)     | nindent 6 }}
       containers:
       - name: run-migrations
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.setup.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.setup.image .) }}
         imagePullPolicy: {{ .Values.setup.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/templates/sweeper-deployment.yaml
+++ b/lakerunner/templates/sweeper-deployment.yaml
@@ -24,24 +24,14 @@ spec:
       {{- include "lakerunner.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.sweeper.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.sweeper.nodeSelector) | nindent 6 }}
       {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.sweeper.tolerations)  | nindent 6 }}
       {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.sweeper.affinity)     | nindent 6 }}
       containers:
       - name: sweeper
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.sweeper.containerSecurityContext) | nindent 8 }}
         image: {{ include "lakerunner.image" (list .Values.sweeper.image .) }}
         imagePullPolicy: {{ .Values.sweeper.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]

--- a/lakerunner/tests/license_test.yaml
+++ b/lakerunner/tests/license_test.yaml
@@ -35,6 +35,10 @@ tests:
           errorMessage: "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName."
 
   - it: should fail with default values (create true, no data)
+    # Explicitly clear license.data in case the suite-level -v test-values.yaml
+    # supplies one; this test asserts behavior on the chart defaults.
+    set:
+      license.data: ""
     templates:
       - license-validation.yaml
     asserts:

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -75,6 +75,27 @@ global:
     #   value: "value1"
     # - name: ENVAR2
     #   value: "value2"
+  # Pod-level securityContext applied to every workload by default.
+  # Components may override individual fields via <component>.podSecurityContext
+  # (component fields win, missing fields fall back to these globals).
+  # For OpenShift's restricted-v2 SCC, set this to {runAsNonRoot: true} (or {})
+  # so the SCC can inject runAsUser/runAsGroup/fsGroup from the namespace's
+  # assigned UID range.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  # Container-level securityContext applied to every container by default.
+  # Components may override individual fields via <component>.containerSecurityContext.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
   # A node selector to apply to all pods.
   # This is standard Kubernetes node selector syntax.
   # Optional.
@@ -755,6 +776,21 @@ queryWorker:
 grafana:
   enabled: false
   replicas: 1 # For replicas > 1, configure external database via grafana.env (see Grafana docs)
+  # Grafana's upstream image requires UID 472 (owns /var/lib/grafana), so it
+  # overrides the chart-wide global.podSecurityContext. On OpenShift the
+  # assigned namespace UID range typically does not include 472; add a custom
+  # SCC (e.g. `oc adm policy add-scc-to-user nonroot-v2 <serviceaccount>`) or
+  # replace this override with {runAsNonRoot: true} and use an OpenShift-
+  # compatible Grafana image.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 472
+    runAsGroup: 472
+    fsGroup: 472
+  # Grafana writes to /var/lib/grafana, so readOnlyRootFilesystem is disabled
+  # here. All other hardening from global.containerSecurityContext is preserved.
+  containerSecurityContext:
+    readOnlyRootFilesystem: false
   # CardinalHQ LakeRunner datasource configuration
   # This provides a simplified way to configure the Cardinal datasource
   # Required.

--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.4.9"
+version: "0.5.0"
 appVersion: "v0.27.1"
 keywords:
   - maestro

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -1,0 +1,54 @@
+# Maestro
+
+Maestro is CardinalHQ's AI agent server with an MCP gateway companion. This chart deploys both components plus an optional `Ingress` for the UI.
+
+## Requirements
+
+* A Kubernetes cluster running a modern version of Kubernetes, at least 1.28.
+* A PostgreSQL database, at least version 13.
+
+## Installation
+
+```sh
+helm install maestro oci://public.ecr.aws/cardinalhq.io/maestro \
+   --values values-local.yaml \
+   --namespace maestro --create-namespace
+```
+
+## `values-local.yaml`
+
+See [`values.yaml`](https://github.com/cardinalhq/charts/blob/main/maestro/values.yaml) for the full set of defaults. The minimum you need to supply:
+
+* `database.host` — PostgreSQL hostname
+* `database.password` (if `database.create: true`) or an existing secret name via `database.secretName` (with `database.create: false`)
+* `mcpGateway.apiKey` if the gateway is enabled
+
+## Security context / Pod Security Standards
+
+Both workloads (`maestro`, `mcp-gateway`) and the `wait-for-mcp-gateway` init container run under a hardened `securityContext` by default:
+
+* `runAsNonRoot: true`, `runAsUser`/`runAsGroup`/`fsGroup: 65532` at the pod level
+* `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`, `readOnlyRootFilesystem: true` at the container level
+
+The defaults satisfy Kubernetes Pod Security Standards `restricted`. The map lives in `values.yaml` under `global.podSecurityContext` and `global.containerSecurityContext`; per-component overrides can be added as `maestro.podSecurityContext` / `mcpGateway.podSecurityContext` (and the `.containerSecurityContext` siblings) — the chart shallow-merges with component fields winning over global.
+
+The `wait-for-mcp-gateway` init container pulls `busybox:1.36` pinned to its multi-arch manifest list digest (`waitContainer.image.digest` in `values.yaml`), so pulls are reproducible but still resolve to the correct per-architecture variant at runtime. Clear the digest or point the repository at an internal mirror if needed.
+
+## Deploying on OpenShift
+
+The chart renders cleanly under the `restricted-v2` SCC once the UID fields are nulled out so the SCC can inject values from the namespace's assigned UID range:
+
+```yaml
+global:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+```
+
+With that in place, the rendered pod `securityContext` emits only `runAsNonRoot: true`; the SCC fills in `runAsUser`, `runAsGroup`, and `fsGroup`. All other hardening (no-privilege-escalation, drop ALL, RuntimeDefault seccomp, read-only rootfs) stays in effect.
+
+### Ingress / Routes
+
+The chart uses a standard `networking.k8s.io/v1` `Ingress` resource with a configurable `ingressClassName`. The OpenShift HAProxy router handles it out of the box; no nginx-specific annotations are emitted.

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -192,3 +192,66 @@ affinity:
 {{ toYaml $m | indent 2 }}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Pod-level securityContext for a workload.
+Shallow-merges global.podSecurityContext with an optional per-component override;
+component fields win over global. Uses explicit `set` instead of sprig's `merge`
+to avoid mergo's quirk where falsy zero values (false, 0, "") get overwritten.
+Emits nothing when the resulting map is empty.
+Usage:
+  {{- include "maestro.podSecurityContext" (dict "root" . "override" .Values.maestro.podSecurityContext) | nindent 6 }}
+*/}}
+{{- define "maestro.podSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.podSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Container-level securityContext for a container.
+Same shallow-merge semantics as maestro.podSecurityContext.
+*/}}
+{{- define "maestro.containerSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.containerSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Reference image for the wait-for-mcp-gateway init container.
+Appends the multi-arch manifest list digest when set so image resolution is
+reproducible but still picks the right per-arch variant at pull time.
+*/}}
+{{- define "maestro.waitContainerImage" -}}
+{{- $repo := .Values.waitContainer.image.repository -}}
+{{- $tag := .Values.waitContainer.image.tag -}}
+{{- $digest := .Values.waitContainer.image.digest -}}
+{{- if $digest -}}
+{{ printf "%s:%s@%s" $repo $tag $digest }}
+{{- else -}}
+{{ printf "%s:%s" $repo $tag }}
+{{- end -}}
+{{- end }}

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -21,33 +21,19 @@ spec:
       {{- include "maestro.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "maestro.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" .Values.maestro.podSecurityContext) | nindent 6 }}
       {{- include "maestro.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.mcpGateway.enabled }}
       initContainers:
       - name: wait-for-mcp-gateway
-        image: busybox:1.36
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        image: {{ include "maestro.waitContainerImage" . }}
+        imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
         command: ['sh', '-c', 'until nc -z {{ include "maestro.fullname" . }}-mcp-gateway {{ .Values.mcpGateway.port }}; do echo waiting for mcp-gateway; sleep 2; done']
       {{- end }}
       containers:
       - name: maestro
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
         image: {{ include "maestro.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/maestro/templates/mcp-gateway-deployment.yaml
+++ b/maestro/templates/mcp-gateway-deployment.yaml
@@ -21,21 +21,11 @@ spec:
       {{- include "maestro.annotations" . | nindent 6 }}
     spec:
       serviceAccountName: {{ include "maestro.serviceAccountName" . }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" .Values.mcpGateway.podSecurityContext) | nindent 6 }}
       {{- include "maestro.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: mcp-gateway
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.mcpGateway.containerSecurityContext) | nindent 8 }}
         image: {{ include "maestro.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/app/entrypoint.sh"]

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -88,6 +88,18 @@ serviceAccount:
   name: ""
   annotations: {}
 
+# Wait-for-mcp-gateway init container image (used by the maestro deployment
+# when mcpGateway.enabled is true). Pinned to the busybox:1.36 multi-arch
+# manifest list digest so image pulls are reproducible while still resolving
+# to the correct per-arch variant at pull time. Clear `digest` to use the
+# floating tag, or override any field to point at a mirror.
+waitContainer:
+  image:
+    repository: busybox
+    tag: "1.36"
+    digest: "sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
+    pullPolicy: IfNotPresent
+
 # Global settings
 global:
   # Global resource configuration
@@ -101,3 +113,24 @@ global:
   env: []
   labels: {}
   annotations: {}
+  # Pod-level securityContext applied to every workload by default.
+  # Per-component overrides can be added at <component>.podSecurityContext
+  # (component fields win, missing fields fall back to these globals).
+  # For OpenShift's restricted-v2 SCC, set this to {runAsNonRoot: true} (or
+  # null the UID/fsGroup fields individually) so the SCC can inject values
+  # from the namespace's assigned UID range.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  # Container-level securityContext applied to every container by default.
+  # Per-component overrides can be added at <component>.containerSecurityContext.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
## Summary

OpenShift / Pod Security Standards hardening across both charts.

**lakerunner**
- New `lakerunner.podSecurityContext` / `lakerunner.containerSecurityContext` helpers that shallow-merge `global.*` defaults with optional per-component overrides. Uses explicit `set` loops instead of sprig `merge` because mergo (what sprig calls under the hood) silently drops falsy overrides like `readOnlyRootFilesystem: false`.
- Surfaces `global.podSecurityContext` and `global.containerSecurityContext` in `values.yaml` with the current hardcoded values as defaults. OpenShift operators null the UID/fsGroup fields to let `restricted-v2` inject from the namespace range.
- Grafana's overrides live in `grafana.podSecurityContext` / `grafana.containerSecurityContext` (UID 472, ROFS off), with an inline comment explaining the SCC requirement.
- Bumps chart to 3.6.0.

**maestro**
- Same helper pattern, same values knobs (`global.podSecurityContext` / `containerSecurityContext`, with per-component overrides available on `maestro.*` and `mcpGateway.*`).
- `wait-for-mcp-gateway` init container is now pinned to `busybox:1.36` at the multi-arch manifest list digest (`sha256:73aaf090...`). Pulls are reproducible but still resolve to the correct per-arch variant at runtime. Exposed via `waitContainer.image` for mirroring / override.
- Bumps chart to 0.5.0.

**docs**
- Adds an OpenShift section to `lakerunner/README.md` covering the UID null-out recipe, Grafana's UID 472 SCC grant, Perch's `ClusterRole` `patch` permission, and Ingress / Router compatibility.
- Creates `maestro/README.md` (didn't exist) with install, security-context, and OpenShift sections.

**pre-existing test / Makefile fixes uncovered while running the suite**
- `tests/license_test.yaml` "default values" case was masked by the suite-level `-v tests/test-values.yaml` injecting `license.data`; now explicitly clears `license.data` so the default-failure assertion actually fires.
- `lakerunner/Makefile`'s `template` target had been silently failing every bare `helm template` run since license-validation was introduced; each invocation now passes `--set-string license.data=test`.

## Static admission check (Pod Security Standards `restricted`)

Rendered both charts with defaults (all components enabled where possible) and with the OpenShift null-override recipe. Across both renders:
- 0 occurrences of `privileged: true`, `hostNetwork: true`, `hostPID: true`, `hostIPC: true`, `hostPath:`, `hostPort:`, `allowPrivilegeEscalation: true`
- 0 `capabilities.add` entries anywhere
- 0 disallowed volume types (hostPath, gitRepo, iscsi, nfs, rbd, cephfs, fc, flexVolume)
- Every pod has `runAsNonRoot: true`; every container has `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, and `seccompProfile.type: RuntimeDefault`
- With the OpenShift override, `runAsUser` / `fsGroup` drop to 0 occurrences while the rest of the hardening remains

## Test plan
- [x] `helm lint` clean for both charts
- [x] `make test` green for lakerunner (lint + 9 template scenarios + 298 unit tests + icon verify)
- [x] `make test` green for maestro (7 tests)
- [x] Default render: 15 non-grafana lakerunner workloads emit UID 65532 + `readOnlyRootFilesystem: true`; grafana emits UID 472 + `readOnlyRootFilesystem: false`; maestro emits UID 65532 + `readOnlyRootFilesystem: true` on both workloads
- [x] OpenShift override (`runAsUser/fsGroup: null`) elides UID fields while keeping all other hardening
- [x] Busybox init container renders with multi-arch digest `@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662`