### PR TITLE
maestro: optional bundled Dex install for POC deployments (chart 0.5.3)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.2"
+version: "0.5.3"
 appVersion: "v1.0.0"
 keywords:
   - maestro

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -52,3 +52,35 @@ With that in place, the rendered pod `securityContext` emits only `runAsNonRoot:
 ### Ingress / Routes
 
 The chart uses a standard `networking.k8s.io/v1` `Ingress` resource with a configurable `ingressClassName`. The OpenShift HAProxy router handles it out of the box; no nginx-specific annotations are emitted.
+
+## Bundled Dex (POC only)
+
+For demos and proof-of-concept installs, the chart can spin up a [Dex](https://dexidp.io) OIDC provider alongside Maestro. **This is not for production** — Dex is configured with in-memory storage, so signing keys rotate and all sessions drop on every Dex pod restart, and only a single replica is supported. Use a real IdP (Keycloak, Okta, Auth0, etc.) for anything beyond a POC.
+
+When enabled, the chart renders a Dex `Deployment` + `Service` + `ConfigMap`, routes the path under `dex.pathPrefix` (default `/dex`) on the maestro `Ingress` to Dex, and auto-injects the OIDC env vars on the maestro container so OIDC works end-to-end without a separate IdP. Static users live in `dex.staticUsers` with bcrypt-hashed passwords; users in the group named by `dex.superadminGroup` (default `maestro-superadmin`) become Maestro superadmins.
+
+Minimal overlay:
+
+```yaml
+maestro:
+  baseUrl: https://maestro.example.com   # or set ingress.host and the chart derives this
+ingress:
+  enabled: true
+  host: maestro.example.com
+  tls:
+    - hosts: [maestro.example.com]
+      secretName: maestro-tls
+dex:
+  enabled: true
+  staticUsers:
+    - email: admin@example.com
+      username: admin
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+      hash: "$2a$10$..."   # htpasswd -bnBC 10 "" yourpass | tr -d ':\n'
+      groups:
+        - maestro-superadmin
+```
+
+Install will fail loudly if you set `dex.enabled: true` without a usable base URL, without any static users, or with `dex.replicas > 1`.
+
+Note: `dex.superadminGroup` only takes effect once the SPA requests the OIDC `groups` scope (tracked in [conductor#370](https://github.com/cardinalhq/conductor/issues/370)). Until that ships in a Maestro release, grant superadmin via `OIDC_SUPERADMIN_EMAILS` in `maestro.env` instead.

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -241,6 +241,165 @@ securityContext:
 {{- end }}
 
 {{/*
+Resolve the public base URL of the Maestro UI.
+Precedence:
+  1. .Values.maestro.baseUrl (explicit)
+  2. derived from .Values.ingress.host with https when ingress.tls is
+     non-empty, otherwise http
+Returns empty string when neither is available.
+
+Both branches normalize the input host: any leading scheme
+(http://, https://) is stripped and any trailing slash is removed
+before composition, so common operator typos like
+`ingress.host: https://maestro.example.com/` produce a clean
+`https://maestro.example.com` instead of `http://https://...//`.
+*/}}
+{{- define "maestro.baseUrl" -}}
+{{- $explicit := default "" (dig "baseUrl" "" .Values.maestro) -}}
+{{- if $explicit -}}
+{{- $explicit | trimSuffix "/" -}}
+{{- else if .Values.ingress.host -}}
+{{- $scheme := "http" -}}
+{{- if .Values.ingress.tls -}}
+{{- $scheme = "https" -}}
+{{- end -}}
+{{- $host := .Values.ingress.host | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- printf "%s://%s" $scheme $host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Same as maestro.baseUrl but fails template rendering when the result is
+empty. Use everywhere a dex-related URL is composed so a missing base
+URL produces an explicit install-time error rather than a silent `/`
+or `/dex` value that breaks at runtime.
+*/}}
+{{- define "maestro.baseUrlOrFail" -}}
+{{- $base := include "maestro.baseUrl" . -}}
+{{- if not $base -}}
+{{- fail "dex.enabled=true requires either maestro.baseUrl to be set or ingress.host to be set so the Dex issuer URL can be derived" -}}
+{{- end -}}
+{{- $base -}}
+{{- end -}}
+
+{{/*
+Fully qualified name of the bundled Dex Deployment / Service.
+*/}}
+{{- define "maestro.dexFullname" -}}
+{{- printf "%s-dex" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Defaulted view of .Values.dex. Returns a dict with the scalar/image
+fields shared across the dex templates, falling back to documented
+defaults when fields are absent. Per-template fields like staticUsers,
+podSecurityContext, containerSecurityContext, nodeSelector, tolerations,
+affinity, and resources are read directly from .Values.dex via inline
+`dig` in the consuming template.
+
+The point of routing through this helper is to make `--set dex.enabled=true`
+sufficient on its own (every default lives in one place) and to keep
+the values surface light enough that linters don't strip an empty
+`dex:` block on every chart change.
+*/}}
+{{- define "maestro.dexConfig" -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $img := dig "image" dict $d -}}
+enabled: {{ dig "enabled" false $d }}
+replicas: {{ dig "replicas" 1 $d }}
+port: {{ dig "port" 5556 $d }}
+pathPrefix: {{ dig "pathPrefix" "/dex" $d | quote }}
+clientId: {{ dig "clientId" "maestro-ui" $d | quote }}
+superadminGroup: {{ dig "superadminGroup" "maestro-superadmin" $d | quote }}
+image:
+  repository: {{ dig "repository" "ghcr.io/dexidp/dex" $img | quote }}
+  tag: {{ dig "tag" "v2.41.1" $img | quote }}
+  pullPolicy: {{ dig "pullPolicy" "IfNotPresent" $img | quote }}
+{{- end -}}
+
+{{/*
+Validate that dex.enabled=true is paired with the inputs Dex actually
+needs to be useful. Today:
+  - non-empty staticUsers (otherwise Dex starts with no login options)
+  - replicas <= 1 (storage.type=memory is per-pod; multiple replicas
+    diverge on signing keys and session state, so login flows break
+    on any pod that didn't issue the session cookie)
+
+Call this from each dex template (and from maestro.oidcEnv) before
+emitting any dex-dependent output.
+*/}}
+{{- define "maestro.dexValidate" -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $users := dig "staticUsers" list $d -}}
+{{- if not $users -}}
+{{- fail "dex.enabled=true requires dex.staticUsers to be a non-empty list (otherwise the bundled Dex starts with no login options)" -}}
+{{- end -}}
+{{- $replicas := dig "replicas" 1 $d -}}
+{{- if gt (int $replicas) 1 -}}
+{{- fail "dex.replicas > 1 is incompatible with the bundled Dex's in-memory storage; sessions and signing keys diverge across pods. Use a single replica or replace the bundled Dex with an external OIDC provider for HA." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Browser-visible Dex issuer URL (used as OIDC_ISSUER_URL on maestro and as
+the `issuer` field in Dex's own config). Path prefix included.
+Fails template rendering when no base URL is available.
+*/}}
+{{- define "maestro.dexIssuerUrl" -}}
+{{- $base := include "maestro.baseUrlOrFail" . -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- printf "%s%s" $base $cfg.pathPrefix -}}
+{{- end -}}
+
+{{/*
+SPA's redirect URI as Dex must whitelist it. Routed through
+baseUrlOrFail so a misconfigured install fails loudly rather than
+silently registering "/" as an allowed redirect — see auth-provider.tsx
+which uses `redirect_uri: window.location.origin + "/"`.
+*/}}
+{{- define "maestro.dexRedirectUri" -}}
+{{- printf "%s/" (include "maestro.baseUrlOrFail" .) -}}
+{{- end -}}
+
+{{/*
+In-cluster JWKS URL for maestro to verify tokens against, bypassing the
+ingress and any TLS termination. The `/keys` suffix is Dex's well-known
+JWKS endpoint per its discovery doc; if Dex ever moves it, switch to
+discovery-based resolution (fetch /.well-known/openid-configuration and
+read jwks_uri) instead of hardcoding here.
+*/}}
+{{- define "maestro.dexInternalJwksUrl" -}}
+{{- $svc := include "maestro.dexFullname" . -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- printf "http://%s.%s.svc:%v%s/keys" $svc .Release.Namespace $cfg.port $cfg.pathPrefix -}}
+{{- end -}}
+
+{{/*
+OIDC + base URL env vars to inject into the maestro container when the
+bundled Dex install is enabled. Emits nothing when dex.enabled is false.
+Built-ins are emitted before the user's `maestro.env` list; Kubernetes
+keeps the first occurrence on duplicate names, so the built-ins win
+(matching the chart's existing convention exercised in env_test.yaml,
+and locked in for OIDC_ISSUER_URL specifically by dex_test.yaml).
+*/}}
+{{- define "maestro.oidcEnv" -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+- name: OIDC_ISSUER_URL
+  value: {{ include "maestro.dexIssuerUrl" . | quote }}
+- name: OIDC_JWKS_URL
+  value: {{ include "maestro.dexInternalJwksUrl" . | quote }}
+- name: OIDC_AUDIENCE
+  value: {{ $cfg.clientId | quote }}
+- name: OIDC_SUPERADMIN_GROUP
+  value: {{ $cfg.superadminGroup | quote }}
+- name: MAESTRO_BASE_URL
+  value: {{ include "maestro.baseUrlOrFail" . | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Reference image for the wait-for-mcp-gateway init container.
 Appends the multi-arch manifest list digest when set so image resolution is
 reproducible but still picks the right per-arch variant at pull time.

--- a/maestro/templates/dex-configmap.yaml
+++ b/maestro/templates/dex-configmap.yaml
@@ -1,0 +1,39 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $users := dig "staticUsers" list $d -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  config.yaml: |
+    issuer: {{ include "maestro.dexIssuerUrl" . }}
+    # In-memory storage is per-pod. Sessions and signing keys do not
+    # survive pod restart and will diverge across replicas, so this
+    # setup is single-replica POC only — see dex.replicas guard above.
+    storage:
+      type: memory
+    web:
+      http: 0.0.0.0:{{ $cfg.port }}
+    oauth2:
+      skipApprovalScreen: true
+    enablePasswordDB: true
+    staticClients:
+      # public:true means PKCE-only (no client secret); matches what
+      # the SPA uses via react-oidc-context. Do NOT switch to a
+      # confidential client without also wiring a client_secret on
+      # the SPA side.
+      - id: {{ $cfg.clientId }}
+        name: "Maestro UI"
+        public: true
+        redirectURIs:
+          - {{ include "maestro.dexRedirectUri" . }}
+    staticPasswords:
+      {{- toYaml $users | nindent 6 }}
+{{- end }}

--- a/maestro/templates/dex-deployment.yaml
+++ b/maestro/templates/dex-deployment.yaml
@@ -1,0 +1,85 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+{{- $d := .Values.dex | default dict -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ $cfg.replicas }}
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dex
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: dex
+      annotations:
+        # Roll the pod when the rendered Dex config changes so static
+        # users / clients edits don't require a manual restart.
+        checksum/config: {{ include (print $.Template.BasePath "/dex-configmap.yaml") . | sha256sum }}
+        {{- with .Values.global.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" (dig "podSecurityContext" dict $d)) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: dex
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" (dig "containerSecurityContext" dict $d)) | nindent 8 }}
+        image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+        imagePullPolicy: {{ $cfg.image.pullPolicy }}
+        command: ["/usr/local/bin/dex"]
+        args: ["serve", "/etc/dex/config.yaml"]
+        ports:
+        - containerPort: {{ $cfg.port }}
+          name: http
+        env:
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        # Dex 2.x serves /healthz at the issuer path root (/<pathPrefix>/healthz).
+        # Pin the dex image tag carefully — older or much newer versions may
+        # change this path.
+        readinessProbe:
+          httpGet:
+            path: {{ printf "%s/healthz" $cfg.pathPrefix | quote }}
+            port: http
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: {{ printf "%s/healthz" $cfg.pathPrefix | quote }}
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml (dig "resources" (dict "requests" (dict "cpu" "100m" "memory" "64Mi") "limits" (dict "memory" "128Mi")) $d) | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex
+          readOnly: true
+        # Dex writes templated web assets to /tmp at startup, so it
+        # needs a writable scratch dir under the chart's default
+        # readOnlyRootFilesystem: true container security context.
+        - name: tmp
+          mountPath: /tmp
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector (dig "nodeSelector" dict $d)) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  (dig "tolerations" list $d))  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     (dig "affinity" dict $d))     | nindent 6 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "maestro.dexFullname" . }}
+      - name: tmp
+        emptyDir: {}
+{{- end }}

--- a/maestro/templates/dex-service.yaml
+++ b/maestro/templates/dex-service.yaml
@@ -1,0 +1,20 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $cfg.port }}
+      targetPort: http
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+{{- end }}

--- a/maestro/templates/ingress.yaml
+++ b/maestro/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -21,6 +22,18 @@ spec:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
+      {{- if $cfg.enabled }}
+      # NGINX-ingress and Traefik select by longest-prefix match, so
+      # path order here doesn't change which backend serves /dex/*.
+      # Listed first only for readability.
+      - path: {{ $cfg.pathPrefix }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "maestro.dexFullname" . }}
+            port:
+              name: http
+      {{- end }}
       - path: /
         pathType: Prefix
         backend:

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -45,6 +45,7 @@ spec:
             value: "http://{{ include "maestro.fullname" . }}-mcp-gateway:{{ .Values.mcpGateway.port }}"
           - name: PORT
             value: {{ .Values.maestro.port | quote }}
+          {{- include "maestro.oidcEnv" . | nindent 10 }}
           {{- with .Values.global.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/maestro/tests/dex_test.yaml
+++ b/maestro/tests/dex_test.yaml
@@ -1,0 +1,278 @@
+suite: bundled dex install
+templates:
+  - dex-configmap.yaml
+  - dex-deployment.yaml
+  - dex-service.yaml
+  - ingress.yaml
+  - maestro-deployment.yaml
+tests:
+  - it: emits no dex resources and no OIDC env when disabled
+    set:
+      ingress.enabled: true
+      ingress.host: m.example.com
+    asserts:
+      - template: dex-configmap.yaml
+        hasDocuments: { count: 0 }
+      - template: dex-deployment.yaml
+        hasDocuments: { count: 0 }
+      - template: dex-service.yaml
+        hasDocuments: { count: 0 }
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+
+  - it: derives https issuer from ingress.host + ingress.tls
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      ingress.tls:
+        - hosts: [m.example.com]
+          secretName: tls
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+            value: https://m.example.com/dex
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAESTRO_BASE_URL
+            value: https://m.example.com
+
+  - it: derives http issuer when ingress.tls absent
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+            value: http://m.example.com/dex
+
+  - it: explicit maestro.baseUrl wins over ingress.host
+    set:
+      dex.enabled: true
+      maestro.baseUrl: https://override.example.com/
+      ingress.enabled: true
+      ingress.host: ignored.example.com
+      ingress.tls:
+        - hosts: [ignored.example.com]
+          secretName: tls
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+            value: https://override.example.com/dex
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAESTRO_BASE_URL
+            value: https://override.example.com
+
+  - it: normalizes a scheme prefix in ingress.host
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: https://m.example.com/
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      # scheme stripped, trailing / stripped, scheme reapplied from
+      # ingress.tls (absent here, so http)
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+            value: http://m.example.com/dex
+
+  - it: fails when dex enabled with no base URL
+    set:
+      dex.enabled: true
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "dex.enabled=true requires either maestro.baseUrl to be set or ingress.host to be set so the Dex issuer URL can be derived"
+
+  - it: fails when dex enabled with empty staticUsers
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+    template: maestro-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "dex.enabled=true requires dex.staticUsers to be a non-empty list (otherwise the bundled Dex starts with no login options)"
+
+  - it: fails when dex.replicas > 1
+    set:
+      dex.enabled: true
+      dex.replicas: 2
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: maestro-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "dex.replicas > 1 is incompatible with the bundled Dex's in-memory storage; sessions and signing keys diverge across pods. Use a single replica or replace the bundled Dex with an external OIDC provider for HA."
+
+  - it: built-in OIDC_ISSUER_URL wins over a user maestro.env duplicate
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+      maestro.env:
+        - name: OIDC_ISSUER_URL
+          value: https://attacker.example.com/dex
+    template: maestro-deployment.yaml
+    asserts:
+      # Both entries exist; built-in is emitted first so Kubernetes
+      # picks it over the user-supplied duplicate.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_ISSUER_URL
+            value: http://m.example.com/dex
+      # Lock in the ordering: built-in OIDC_ISSUER_URL is emitted
+      # immediately after PORT (env[8]), so it lands at env[9] —
+      # comfortably before any user maestro.env entry, and Kubernetes
+      # picks the first occurrence on duplicates.
+      - equal:
+          path: spec.template.spec.containers[0].env[9].name
+          value: OIDC_ISSUER_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[9].value
+          value: http://m.example.com/dex
+
+  - it: ingress lists /dex before / when dex enabled
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: ingress.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /dex
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-maestro-dex
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: RELEASE-NAME-maestro-maestro
+
+  - it: ingress omits /dex path when dex disabled
+    set:
+      ingress.enabled: true
+      ingress.host: m.example.com
+    template: ingress.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+
+  - it: embeds the static user in the dex configmap
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: admin@example.com
+          hash: "$2a$10$abc"
+          userID: 00000000-0000-0000-0000-000000000001
+          username: admin
+          groups:
+            - maestro-superadmin
+    template: dex-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "issuer: http://m.example.com/dex"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "redirectURIs:\\s*\\n\\s*- http://m.example.com/"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "email: admin@example.com"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "userID: 00000000-0000-0000-0000-000000000001"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "- maestro-superadmin"
+
+  - it: dex deployment mounts a writable /tmp emptyDir
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: dex-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}


### PR DESCRIPTION
## Summary

- Adds a disabled-by-default Dex (OIDC provider) install behind `dex.enabled`. When enabled, the chart renders a Dex `Deployment` + `Service` + `ConfigMap`, routes `/dex` (configurable via `dex.pathPrefix`) on the maestro `Ingress` to Dex, and auto-injects OIDC env vars on the maestro container so end-to-end OIDC works without an external IdP.
- Static users live in `dex.staticUsers` with bcrypt hashes; users in `dex.superadminGroup` (default `maestro-superadmin`) become Maestro superadmins. Browser-visible issuer URL derived from `maestro.baseUrl` or `ingress.host` + `ingress.tls`; JWKS verification uses the in-cluster Service URL to avoid an ingress round-trip.
- Fails loudly at install time when `dex.enabled=true` is paired with no usable base URL, no static users, or `replicas > 1` (in-memory storage is single-replica only).

## Not for production

Dex storage is in-memory: sessions and signing keys drop on every Dex pod restart, and replicas can't share state. This is a POC / demo path only — for production, point Maestro at Keycloak / Okta / Auth0 / etc. via the existing `maestro.env` OIDC overrides.

## Companion change

`dex.superadminGroup` only takes effect once the SPA requests the OIDC `groups` scope, tracked in cardinalhq/conductor#370. Until that ships in a Maestro release, grant superadmin via `OIDC_SUPERADMIN_EMAILS` in `maestro.env` instead.

## Test plan

- [x] `make -C maestro test` — helm lint + template render + 20/20 unit tests (13 new in `tests/dex_test.yaml`, 7 existing in `tests/env_test.yaml`)
- [x] Render with `dex.enabled=false` produces no dex resources and no OIDC env on the maestro container
- [x] Render with `dex.enabled=true` + `ingress.host` derives correct issuer URL (https vs http based on `ingress.tls`), in-cluster JWKS URL, and `MAESTRO_BASE_URL`
- [x] Install fails clearly when `dex.enabled=true` is paired with no base URL, empty `dex.staticUsers`, or `dex.replicas > 1`
- [x] Built-in `OIDC_ISSUER_URL` is emitted before user-supplied `maestro.env` so the chart's "first-occurrence wins" convention prevents tenant override (locked in by `dex_test.yaml`)
- [x] `ingress.host: https://m.example.com/` is normalized (scheme stripped, trailing slash trimmed) so common operator typos don't produce malformed URLs
- [ ] Reviewer sanity-checks the README "Bundled Dex (POC only)" section