### PR TITLE
maestro: emit OIDC_CLIENT_ID env var

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.6"
+version: "0.5.7"
 appVersion: "v1.0.4"
 keywords:
   - maestro

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -392,6 +392,8 @@ and locked in for OIDC_ISSUER_URL specifically by dex_test.yaml).
   value: {{ include "maestro.dexInternalJwksUrl" . | quote }}
 - name: OIDC_AUDIENCE
   value: {{ $cfg.clientId | quote }}
+- name: OIDC_CLIENT_ID
+  value: {{ $cfg.clientId | quote }}
 - name: OIDC_SUPERADMIN_GROUP
   value: {{ $cfg.superadminGroup | quote }}
 - name: MAESTRO_BASE_URL

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -36,8 +36,12 @@ maestro:
   # env:
   #   - name: OIDC_ISSUER_URL
   #     value: https://auth.example.com/realms/cardinal
-  #   - name: OIDC_AUDIENCE
+  #   - name: OIDC_AUDIENCE                   # expected `aud` claim on issued tokens
   #     value: maestro-ui
+  #   - name: OIDC_CLIENT_ID                   # OAuth client_id the SPA sends in authorize
+  #     value: maestro-ui                      # requests; for Okta custom auth servers this
+  #                                            # differs from OIDC_AUDIENCE. Defaults to
+  #                                            # OIDC_AUDIENCE when unset.
   #   - name: OIDC_SUPERADMIN_EMAILS
   #     value: admin@example.com
   #   # Claim mapping (override only when your IdP's token shape differs from


### PR DESCRIPTION
## Summary
- Bundled-Dex path in `maestro.oidcEnv` now emits `OIDC_CLIENT_ID` alongside `OIDC_AUDIENCE` (both set to `dex.clientId`, since Dex issues `aud == client_id`).
- `values.yaml` OIDC comment example documents the split: operators on Okta with a custom authorization server set `OIDC_CLIENT_ID` separately from `OIDC_AUDIENCE`.

## Why
Maestro was using `OIDC_AUDIENCE` for two distinct things: validating the `aud` claim on incoming tokens **and** as the OAuth `client_id` the SPA sends in `/authorize`. Okta tenants with a custom authorization server have these as different values (token `aud` = a resource URI like `api://maestro`, client_id = the SPA app's Okta client ID), which the old shape couldn't express.

Companion PRs:
- conductor: https://github.com/cardinalhq/conductor/pull/new/oidc-split-client-id-from-audience
- cardinal-docs: https://github.com/cardinalhq/cardinal-docs/pull/new/oidc-client-id-env

## Test plan
- [x] `helm lint maestro` clean
- [x] `helm unittest maestro` — 20/20 existing tests pass (dex_test.yaml and env_test.yaml only assert `OIDC_ISSUER_URL` shape, so the added env var doesn't regress them)
- [ ] Render `maestro.oidcEnv` with `dex.enabled=true` and confirm both `OIDC_AUDIENCE` and `OIDC_CLIENT_ID` appear in the maestro container env