### PR TITLE
docs(lakerunner): remove KEDA and Kafka references

### DIFF
--- a/lakerunner/DEVELOPMENT.md
+++ b/lakerunner/DEVELOPMENT.md
@@ -44,5 +44,4 @@ When making changes to the chart:
 1. Update tests as needed in the `tests/` directory
 2. Run `make test` to ensure all tests pass
 3. Update documentation if configuration options change
-4. Test with both HPA and KEDA scaling modes
-5. Verify backward compatibility for existing configurations
+4. Verify backward compatibility for existing configurations

--- a/lakerunner/README.md
+++ b/lakerunner/README.md
@@ -5,8 +5,6 @@
 * A Kubernetes cluster running a modern version of Kubernetes, at least 1.28.
 * A PostgreSQL database, at least version 16.
 * An S3 (or compatible) object store configured to send object create notifications either via SQS or a web hook.
-* Kafka.  Our use of Kafka is small (we send metadata only, not the telemetmry itself) but you will want at least two brokers in produciton.
-* (Optional but **recommended for production use**) [KEDA](https://keda.sh/) installed in your cluster for intelligent autoscaling.
 
 For AWS S3, SQS queues for bucket notifications should be used.  Other systems may have
 other mechanisms, and a webhook-style receiver can be enabled to support them.
@@ -40,94 +38,6 @@ Items you may want to change, but are not required:
 
 The settings in the values.yaml file are suitable for a small to medium installation,
 but for a very small or larger installation, you will need to make adjustments.
-
-## KEDA Autoscaling
-
-LakeRunner supports intelligent work queue-based autoscaling through [KEDA](https://keda.sh/). KEDA is **highly recommended for production environments** as it provides superior scaling behavior compared to CPU-based HPA for micro-batch workloads.
-
-### Installing KEDA
-
-If KEDA is not already installed in your cluster, install it:
-
-```bash
-helm repo add kedacore https://kedacore.github.io/charts
-helm repo update
-helm install keda kedacore/keda --namespace keda-system --create-namespace
-```
-
-### Enabling KEDA Scaling
-
-To enable KEDA-based scaling in LakeRunner:
-
-```yaml
-global:
-  autoscaling:
-    mode: "keda"
-```
-
-### Scaling Modes
-
-LakeRunner supports three scaling modes:
-
-* **`hpa`** (default): CPU-based horizontal pod autoscaling. Suitable for development but insufficient for production micro-batch workloads.
-* **`keda`**: Work queue-based scaling using PostgreSQL queries. **Recommended for production** as it scales based on actual workload backlog.
-* **`disabled`**: No autoscaling; uses static replica counts.
-
-You can set a global scaling mode and disable it for individual components:
-
-```yaml
-global:
-  autoscaling:
-    mode: "keda"
-
-ingestLogs:
-  autoscaling:
-    enabled: false  # Disable autoscaling for this component only
-```
-
-### How KEDA Scaling Works
-
-KEDA scales components based on actual workload backlog rather than CPU usage:
-
-* **Queue-based scaling**: Components scale up when work is pending, scale down when idle
-* **Intelligent thresholds**: Pre-configured to prevent over-scaling while ensuring responsiveness
-* **Cooldown periods**: Prevent scaling flapping during batch processing cycles
-
-### KEDA Configuration
-
-Each scalable component supports KEDA configuration:
-
-```yaml
-ingestLogs:
-  autoscaling:
-    minReplicas: 1         # Used by both HPA and KEDA
-    maxReplicas: 10        # Used by both HPA and KEDA
-    keda:
-      pollingInterval: 30    # How often to check queue (seconds)
-      cooldownPeriod: 300    # Wait before scaling down (seconds)
-```
-
-KEDA scaling thresholds are pre-configured with sensible defaults but can be customized if needed.
-
-### KEDA Database Integration
-
-KEDA automatically uses the same database credentials configured in the `database.lrdb` section - no additional configuration is required. When you enable KEDA mode, it will:
-
-* Use the same PostgreSQL connection details as your LakeRunner components
-* Automatically create the necessary TriggerAuthentication resource
-* Scale based on the actual work queue depth in your database
-
-Simply ensure your database configuration is complete:
-
-```yaml
-database:
-  lrdb:
-    host: "your-postgres-host"      # Required
-    port: 5432                      # Default: 5432
-    name: "lakerunner"             # Default: "lakerunner"
-    username: "lakerunner"         # Default: "lakerunner"
-    password: "your-password"      # Required if not from a pre-defined secret
-```
 
 ## Security Context and Distroless Compatibility
 


### PR DESCRIPTION
## Summary
- Drop Kafka and KEDA bullets from the LakeRunner requirements list
- Remove the full "KEDA Autoscaling" section from `lakerunner/README.md`
- Remove the "Test with both HPA and KEDA scaling modes" step from `lakerunner/DEVELOPMENT.md`

## Test plan
- [ ] `helm lint lakerunner`
- [ ] Visually verify rendered README/DEVELOPMENT markdown