### PR TITLE
feat(lakerunner): perch managed collectors RBAC + values

### DIFF
--- a/lakerunner/templates/perch-collectors-clusterrole.yaml
+++ b/lakerunner/templates/perch-collectors-clusterrole.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.perch.enabled .Values.perch.collectors.enabled .Values.perch.collectors.watchCRs -}}
+{{- /*
+  Cluster-scoped read of OpenTelemetryCollector CRs. The OTel Operator's CR is
+  cluster-scoped in the sense that CRD discovery is not namespaced — we need
+  this binding so Perch can enumerate operator-managed collectors across
+  namespaces without one RoleBinding per namespace (which wouldn't even work
+  for CR list/watch). Read-only.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-perch-collectors-cr
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: perch-collectors
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+rules:
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["opentelemetrycollectors"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-perch-collectors-cr
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: perch-collectors
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "lakerunner.fullname" . }}-perch-collectors-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "lakerunner.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/lakerunner/templates/perch-collectors-role.yaml
+++ b/lakerunner/templates/perch-collectors-role.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.perch.enabled .Values.perch.collectors.enabled -}}
+{{- /*
+  One namespace-scoped Role + RoleBinding per watched namespace. Customers see
+  exactly which namespaces Perch can read ConfigMaps in and can reject the
+  chart if the list is unexpected. Cluster-wide ConfigMap read is NOT granted.
+*/}}
+{{- range $ns := .Values.perch.collectors.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lakerunner.fullname" $ }}-perch-collectors
+  namespace: {{ $ns }}
+  labels:
+    {{- include "lakerunner.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: perch-collectors
+  {{ include "lakerunner.annotations" $ | nindent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lakerunner.fullname" $ }}-perch-collectors
+  namespace: {{ $ns }}
+  labels:
+    {{- include "lakerunner.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: perch-collectors
+  {{ include "lakerunner.annotations" $ | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "lakerunner.fullname" $ }}-perch-collectors
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "lakerunner.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/lakerunner/templates/perch-configmap.yaml
+++ b/lakerunner/templates/perch-configmap.yaml
@@ -26,6 +26,24 @@ data:
         label_selector: {{ .labelSelector | quote }}
         {{- end }}
     {{- end }}
+    {{- if .Values.perch.collectors.enabled }}
+    collectors:
+      enabled: true
+      ship_config_body: {{ .Values.perch.collectors.shipConfigBody }}
+      watch_crs: {{ .Values.perch.collectors.watchCRs }}
+      heartbeat_interval: {{ .Values.perch.collectors.heartbeatInterval | default "5m" }}
+      reconcile_interval: {{ .Values.perch.collectors.reconcileInterval | default "15m" }}
+      namespaces:
+      {{- range .Values.perch.collectors.namespaces }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- with .Values.perch.collectors.imageAllowlist }}
+      image_allowlist:
+      {{- range . }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
     health:
       port: {{ .Values.global.healthProbes.healthcheckPort }}
 {{- end }}

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -587,6 +587,31 @@ perch:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Read-only OpenTelemetry collector discovery. Disabled by default — customers
+  # opt in by setting enabled=true and listing the namespaces Perch should
+  # watch for collector workloads. When enabled, Perch discovers collectors via
+  # three paths (CR / image allowlist / label opt-in), reads their ConfigMap
+  # bodies, redacts obvious secrets, and ships them to Maestro for read-only
+  # DAG visualization at /settings/collectors. No write path is enabled.
+  collectors:
+    enabled: false
+    # Namespaces to watch for collector workloads. Each entry gets its own
+    # namespace-scoped Role + RoleBinding; cluster-wide ConfigMap read is NOT
+    # granted.
+    namespaces: []
+    # When true, Perch ships the redacted YAML body back to Maestro. When
+    # false, only topology (structural DAG data) is shipped — the UI shows the
+    # pipeline graph but no raw YAML view. Use false for regulated customers.
+    shipConfigBody: true
+    # Watch OpenTelemetryCollector CRs (from the upstream OTel Operator). Set
+    # to false if the CRD is installed but you don't want Perch to read CRs.
+    # CRD-absent clusters gracefully skip regardless of this flag.
+    watchCRs: true
+    # Extends (does not replace) the default image allowlist. Use this to add
+    # custom / internal collector distributions by repo prefix.
+    imageAllowlist: []
+    heartbeatInterval: "5m"
+    reconcileInterval: "15m"
 
 # Admin API configuration
 adminApi:


### PR DESCRIPTION
## Summary

Helm chart half of the Perch Managed Collectors deliverable. Adds the read-only RBAC and config plumbing for the new collector-discovery path in the Perch operator.

Companion PRs:
- [cardinalhq/lakerunner#654](https://github.com/cardinalhq/lakerunner/pull/654) — operator-side discovery, config redaction, reporter
- [cardinalhq/conductor#395](https://github.com/cardinalhq/conductor/pull/395) — Maestro routes + read-only DAG UI at \`/settings/collectors\`

## What's in

- \`lakerunner/templates/perch-collectors-role.yaml\` — one \`Role\` + \`RoleBinding\` per namespace in \`values.perch.collectors.namespaces\`. Grants get/list/watch on \`configmaps\`, \`deployments\`, \`daemonsets\`, \`statefulsets\` in that namespace only. **No cluster-wide ConfigMap read.**
- \`lakerunner/templates/perch-collectors-clusterrole.yaml\` — cluster-scoped read of \`opentelemetrycollectors.opentelemetry.io\`. Gated on \`watchCRs\` (default true). Skipped entirely if the OTel Operator CRD is absent from the cluster (operator-side feature detection handles this).
- \`lakerunner/templates/perch-configmap.yaml\` — renders a \`collectors:\` block into the operator's config.yaml only when enabled. Propagates \`namespaces\`, \`shipConfigBody\`, \`watchCRs\`, \`heartbeatInterval\`, \`reconcileInterval\`, and the optional \`imageAllowlist\` extension.
- \`lakerunner/values.yaml\` — \`perch.collectors.*\` block, disabled by default. \`shipConfigBody: true\` is the recommended mode; regulated customers can flip to \`false\` to ship topology only (no raw YAML).

## What's not in

No write verbs anywhere. No \`patch\`/\`update\`/\`create\`/\`delete\` on ConfigMaps, CRs, or workloads.

## Test plan

- [x] \`helm lint lakerunner\` — green
- [x] \`helm template\` with two namespaces produces 2 Roles + 2 RoleBindings + 1 ClusterRole + 1 ClusterRoleBinding

## Landing order

1. Operator PR [cardinalhq/lakerunner#654](https://github.com/cardinalhq/lakerunner/pull/654) merges → image builds via release workflow → tag ships
2. Conductor PR [cardinalhq/conductor#395](https://github.com/cardinalhq/conductor/pull/395) merges (independent, feature flag keeps operator dark)
3. This PR merges referencing the new operator appVersion
4. kubernetes-clusters bump deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)