### PR TITLE
maestro: default CPU+memory limits on all containers (0.5.17)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.16"
+version: "0.5.17"
 appVersion: "v1.7.7"
 keywords:
   - maestro

--- a/maestro/templates/dex-deployment.yaml
+++ b/maestro/templates/dex-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           periodSeconds: 10
         {{- if .Values.global.resources.enabled }}
         resources:
-          {{- toYaml (dig "resources" (dict "requests" (dict "cpu" "100m" "memory" "64Mi") "limits" (dict "memory" "128Mi")) $d) | nindent 10 }}
+          {{- toYaml (dig "resources" (dict "requests" (dict "cpu" "200m" "memory" "128Mi") "limits" (dict "cpu" "200m" "memory" "128Mi")) $d) | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: config

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -30,6 +30,15 @@ spec:
         imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
         {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
         command: ['sh', '-c', 'until nc -z {{ include "maestro.fullname" . }}-mcp-gateway {{ .Values.mcpGateway.port }}; do echo waiting for mcp-gateway; sleep 2; done']
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        {{- end }}
       {{- end }}
       containers:
       - name: maestro

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -18,9 +18,10 @@ maestro:
   port: 4200
   resources:
     requests:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 1
+      memory: 512Mi
     limits:
+      cpu: 1
       memory: 512Mi
   labels: {}
   annotations: {}
@@ -71,10 +72,11 @@ mcpGateway:
   apiKey: ""
   resources:
     requests:
-      cpu: 500m
-      memory: 128Mi
+      cpu: 1
+      memory: 512Mi
     limits:
-      memory: 256Mi
+      cpu: 1
+      memory: 512Mi
   labels: {}
   annotations: {}
   nodeSelector: {}
@@ -130,6 +132,20 @@ waitContainer:
     tag: "1.36"
     digest: "sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
     pullPolicy: IfNotPresent
+
+# Bundled Dex OIDC provider. Most fields are kept out of this file on purpose
+# so that `--set dex.enabled=true` is enough to turn it on — defaults live in
+# templates/_helpers.tpl (maestro.dexConfig) and inline `dig` in the dex
+# templates. `resources` is surfaced here so operators can tune CPU/memory
+# without chasing template internals.
+dex:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 # Global settings
 global:


### PR DESCRIPTION
## Summary
- Every maestro workload container (maestro, mcp-gateway, dex) and the `wait-for-mcp-gateway` init container now ship with both CPU and memory requests AND limits set 1:1 (limit = request).
- Adds a `dex.resources` section to `values.yaml` so operators can tune dex CPU/memory without chasing inline template defaults.
- Bumps chart version `0.5.16 → 0.5.17`. `appVersion` unchanged.

### Values
- maestro: `1 CPU / 512Mi`
- mcp-gateway: `1 CPU / 512Mi`
- dex: `200m / 128Mi`
- wait-for-mcp-gateway init: `50m / 32Mi`, hardcoded and gated by `global.resources.enabled`

### Scheduling impact
maestro and mcp-gateway previously requested `500m / 128-256Mi`; they now request `1 CPU / 512Mi`. Existing deployments may need nodes with more headroom to place the pods.

## Test plan
- [x] `helm lint maestro` — clean
- [x] `helm template` renders symmetric `requests:`/`limits:` on all four containers
- [x] `helm template --set global.resources.enabled=false` still suppresses every `resources:` block
- [x] `helm unittest maestro` — 20/20 pass