### PR TITLE
maestro: drop mcpGateway.enabled toggle (0.5.18)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.17"
+version: "0.5.18"
 appVersion: "v1.7.7"
 keywords:
   - maestro

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -23,7 +23,6 @@ spec:
       serviceAccountName: {{ include "maestro.serviceAccountName" . }}
       {{- include "maestro.podSecurityContext" (dict "root" . "override" .Values.maestro.podSecurityContext) | nindent 6 }}
       {{- include "maestro.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.mcpGateway.enabled }}
       initContainers:
       - name: wait-for-mcp-gateway
         image: {{ include "maestro.waitContainerImage" . }}
@@ -39,7 +38,6 @@ spec:
             cpu: 50m
             memory: 32Mi
         {{- end }}
-      {{- end }}
       containers:
       - name: maestro
         {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}

--- a/maestro/templates/mcp-gateway-deployment.yaml
+++ b/maestro/templates/mcp-gateway-deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.mcpGateway.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,4 +57,3 @@ spec:
       {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector .Values.mcpGateway.nodeSelector) | nindent 6 }}
       {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  .Values.mcpGateway.tolerations)  | nindent 6 }}
       {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.mcpGateway.affinity)     | nindent 6 }}
-{{- end }}

--- a/maestro/templates/mcp-gateway-service.yaml
+++ b/maestro/templates/mcp-gateway-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.mcpGateway.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +18,3 @@ spec:
   selector:
     {{- include "maestro.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: mcp-gateway
-{{- end }}

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -63,9 +63,10 @@ maestro:
   extraVolumes: []       # additional volumes
   extraVolumeMounts: []  # additional volume mounts
 
-# MCP Gateway configuration
+# MCP Gateway configuration.
+# mcp-gateway is a required companion to maestro and is always deployed;
+# there is no toggle to disable it.
 mcpGateway:
-  enabled: true
   replicas: 1
   port: 8080
   debugPort: 9090
@@ -122,10 +123,11 @@ serviceAccount:
   annotations: {}
 
 # Wait-for-mcp-gateway init container image (used by the maestro deployment
-# when mcpGateway.enabled is true). Pinned to the busybox:1.36 multi-arch
-# manifest list digest so image pulls are reproducible while still resolving
-# to the correct per-arch variant at pull time. Clear `digest` to use the
-# floating tag, or override any field to point at a mirror.
+# to poll mcp-gateway readiness before starting maestro). Pinned to the
+# busybox:1.36 multi-arch manifest list digest so image pulls are
+# reproducible while still resolving to the correct per-arch variant at
+# pull time. Clear `digest` to use the floating tag, or override any
+# field to point at a mirror.
 waitContainer:
   image:
     repository: busybox


### PR DESCRIPTION
## Summary
- mcp-gateway is a required companion to maestro and must always be deployed. Remove the `mcpGateway.enabled` values knob and the `{{- if .Values.mcpGateway.enabled }}` gates so the templates match reality.
- Files touched: `values.yaml`, `templates/mcp-gateway-deployment.yaml`, `templates/mcp-gateway-service.yaml`, `templates/maestro-deployment.yaml`, `Chart.yaml`.
- Bumps chart version `0.5.17 → 0.5.18`. `appVersion` unchanged.

### Breaking change
Any values file that previously set `mcpGateway.enabled: false` will now silently render mcp-gateway anyway (Helm doesn't error on unknown keys). That was not a supported configuration.

## Test plan
- [x] `helm lint maestro` clean
- [x] `grep -rn "mcpGateway\.enabled" maestro/` returns no matches
- [x] Default `helm template` renders the mcp-gateway Service, Deployment, and the `wait-for-mcp-gateway` init container unconditionally
- [x] `helm unittest maestro` — 20/20 tests pass