### PR TITLE
maestro: chart 0.5.25 — optional in-pod TLS sidecar

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.24"
+version: "0.5.25"
 appVersion: "v1.7.16"
 keywords:
   - maestro

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -92,3 +92,33 @@ When `dex.enabled: true` (chart 0.5.24+ with maestro v1.7.16+), the chart wires 
 Ingress-based installs are unaffected: the Ingress's `/dex` path rule path-matches first and routes directly to the Dex Service, so the in-pod proxy is never exercised in that flow.
 
 Set `dex.proxyEnabled: false` to opt out (env vars are not emitted; the maestro pod returns 404 for `/<pathPrefix>/*` and an Ingress is required for the OIDC flow to work).
+
+#### HTTPS at the maestro Service (chart 0.5.25+)
+
+When the consumer requires HTTPS but no Ingress controller is doing TLS termination — for example a POC bastion port-forward that the customer's policy mandates be served over TLS — set `maestro.tls.enabled: true`. The chart adds an nginx-unprivileged sidecar in the maestro pod that listens on `maestro.tls.port` (default `4443`) and proxies to the maestro container on localhost. The maestro Service exposes the new HTTPS port alongside the existing HTTP one.
+
+```yaml
+maestro:
+  baseUrl: https://1-2-3-4.nip.io:8443
+  tls:
+    enabled: true
+    # cert.autoGenerate: true (default) — self-signed cert generated at pod
+    # start with SAN = host of maestro.baseUrl + cert.sans extras.
+    cert:
+      sans: []
+    # OR: bring your own (cert-manager, manual Secret, etc.)
+    # secretName: my-tls
+ingress:
+  enabled: false
+dex:
+  enabled: true
+  staticUsers: [...]
+```
+
+```sh
+kubectl port-forward --address 0.0.0.0 svc/<release>-maestro 8443:4443
+```
+
+The chart fails template rendering when `tls.enabled: true` and the resolved base URL isn't `https://`, so OIDC URLs always match the served scheme. Auto-generated certs regenerate on every pod restart (browser re-prompts for trust); use `tls.secretName` for stable certs.
+
+All sidecar/init images are overridable: `maestro.tls.image.{repository,tag,pullPolicy}` for the nginx sidecar, `maestro.tls.cert.image.{repository,tag,pullPolicy}` for the openssl cert-init. `dex.image.{repository,tag,pullPolicy}` overrides the bundled Dex image (defaults in `templates/_helpers.tpl`).

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -269,6 +269,42 @@ before composition, so common operator typos like
 {{- end -}}
 
 {{/*
+Hostname-only view of maestro.baseUrl, with scheme and port stripped.
+Used by the TLS sidecar's cert-init container to put the right CN/SAN
+on its self-signed certificate.
+*/}}
+{{- define "maestro.baseUrlHost" -}}
+{{- $base := include "maestro.baseUrl" . -}}
+{{- $hostport := $base | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- regexReplaceAll ":[0-9]+$" $hostport "" -}}
+{{- end -}}
+
+{{/*
+Validate maestro.tls inputs:
+  * tls.enabled=true requires the resolved baseUrl to use https://, so the
+    OIDC issuer URL the SPA hands to the browser matches the scheme the
+    maestro Service actually serves.
+  * Exactly one of cert.autoGenerate=true OR secretName must be set.
+*/}}
+{{- define "maestro.tlsValidate" -}}
+{{- $tls := dig "tls" dict (.Values.maestro | default dict) -}}
+{{- if dig "enabled" false $tls -}}
+  {{- $base := include "maestro.baseUrlOrFail" . -}}
+  {{- if not (hasPrefix "https://" $base) -}}
+    {{- fail (printf "maestro.tls.enabled=true requires maestro.baseUrl to use https:// (got %q). Either set maestro.baseUrl to an https URL or set ingress.tls so the chart derives one." $base) -}}
+  {{- end -}}
+  {{- $autogen := dig "cert" "autoGenerate" true $tls -}}
+  {{- $secret := dig "secretName" "" $tls -}}
+  {{- if and $autogen $secret -}}
+    {{- fail "maestro.tls: set exactly one of cert.autoGenerate=true OR secretName, not both" -}}
+  {{- end -}}
+  {{- if and (not $autogen) (not $secret) -}}
+    {{- fail "maestro.tls.enabled=true requires either cert.autoGenerate=true (default) or a non-empty secretName" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Same as maestro.baseUrl but fails template rendering when the result is
 empty. Use everywhere a dex-related URL is composed so a missing base
 URL produces an explicit install-time error rather than a silent `/`

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -65,6 +65,57 @@ spec:
             cpu: 50m
             memory: 64Mi
         {{- end }}
+      {{- if and (dig "tls" "enabled" false .Values.maestro) (dig "tls" "cert" "autoGenerate" true .Values.maestro) (not (dig "tls" "secretName" "" .Values.maestro)) }}
+      # Generates a self-signed cert into the shared `tls` emptyDir at pod
+      # start. Cert regenerates each pod restart — fine for POC, swap to
+      # maestro.tls.secretName for stable certs.
+      - name: tls-init
+        image: "{{ .Values.maestro.tls.cert.image.repository }}:{{ .Values.maestro.tls.cert.image.tag }}"
+        imagePullPolicy: {{ .Values.maestro.tls.cert.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            HOST="${TLS_HOST}"
+            EXTRA_SANS="${TLS_EXTRA_SANS}"
+            SAN="DNS:${HOST}"
+            if [ -n "${EXTRA_SANS}" ]; then SAN="${SAN},${EXTRA_SANS}"; fi
+            cat >/tmp/openssl.cnf <<EOF
+            [req]
+            distinguished_name=req
+            prompt=no
+            req_extensions=v3
+            [req_distinguished_name]
+            CN=${HOST}
+            [v3]
+            subjectAltName=${SAN}
+            basicConstraints=CA:FALSE
+            keyUsage=digitalSignature,keyEncipherment
+            extendedKeyUsage=serverAuth
+            EOF
+            openssl req -x509 -newkey rsa:2048 -nodes \
+              -keyout /tls/tls.key -out /tls/tls.crt \
+              -days 365 -extensions v3 -config /tmp/openssl.cnf
+            chmod 0644 /tls/tls.key /tls/tls.crt
+        env:
+          - name: TLS_HOST
+            value: {{ include "maestro.baseUrlHost" . | quote }}
+          - name: TLS_EXTRA_SANS
+            value: {{ join "," (default list .Values.maestro.tls.cert.sans) | quote }}
+        volumeMounts:
+          - name: tls
+            mountPath: /tls
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 64Mi
+        {{- end }}
+      {{- end }}
       containers:
       - name: maestro
         {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
@@ -128,6 +179,51 @@ spec:
         {{- with .Values.maestro.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if dig "tls" "enabled" false .Values.maestro }}
+      # TLS-terminating sidecar. Listens on tls.port, proxies plaintext
+      # to the maestro container on localhost. Mounts the cert from the
+      # tls volume (populated by tls-init when autoGenerate=true, or from
+      # maestro.tls.secretName).
+      - name: tls-proxy
+        image: "{{ .Values.maestro.tls.image.repository }}:{{ .Values.maestro.tls.image.tag }}"
+        imagePullPolicy: {{ .Values.maestro.tls.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        ports:
+          - containerPort: {{ .Values.maestro.tls.port }}
+            name: https
+        readinessProbe:
+          tcpSocket:
+            port: https
+          periodSeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          tcpSocket:
+            port: https
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+          - name: tls
+            mountPath: /etc/nginx/tls
+            readOnly: true
+          - name: tls-config
+            mountPath: /etc/nginx/conf.d
+            readOnly: true
+          # nginx-unprivileged needs writable scratch space under
+          # /tmp + /var/cache/nginx for its worker temp files. Reuse
+          # the maestro pod's existing `tmp` emptyDir.
+          - name: tmp
+            mountPath: /var/cache/nginx
+            subPath: nginx-cache
+          - name: tmp
+            mountPath: /tmp/nginx
+            subPath: nginx-tmp
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.maestro.tls.resources | nindent 10 }}
+        {{- end }}
+      {{- end }}
       {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector .Values.maestro.nodeSelector) | nindent 6 }}
       {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  .Values.maestro.tolerations)  | nindent 6 }}
       {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.maestro.affinity)     | nindent 6 }}
@@ -138,6 +234,18 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "maestro.fullname" . }}-data
+      {{- end }}
+      {{- if dig "tls" "enabled" false .Values.maestro }}
+      - name: tls
+        {{- if dig "tls" "secretName" "" .Values.maestro }}
+        secret:
+          secretName: {{ .Values.maestro.tls.secretName }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: tls-config
+        configMap:
+          name: {{ include "maestro.fullname" . }}-maestro-tls
       {{- end }}
       {{- with .Values.maestro.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/maestro/templates/maestro-service.yaml
+++ b/maestro/templates/maestro-service.yaml
@@ -13,6 +13,11 @@ spec:
     - port: {{ .Values.maestro.port }}
       targetPort: http
       name: http
+    {{- if dig "tls" "enabled" false (.Values.maestro | default dict) }}
+    - port: {{ .Values.maestro.tls.port }}
+      targetPort: https
+      name: https
+    {{- end }}
   selector:
     {{- include "maestro.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: maestro

--- a/maestro/templates/maestro-tls-config.yaml
+++ b/maestro/templates/maestro-tls-config.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.maestro.enabled (dig "tls" "enabled" false (.Values.maestro | default dict)) -}}
+{{- include "maestro.tlsValidate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro-tls
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  default.conf: |
+    server {
+      listen {{ .Values.maestro.tls.port }} ssl;
+      http2 on;
+      ssl_certificate     /etc/nginx/tls/tls.crt;
+      ssl_certificate_key /etc/nginx/tls/tls.key;
+      ssl_protocols       TLSv1.2 TLSv1.3;
+      client_max_body_size 50m;
+
+      location / {
+        proxy_pass http://127.0.0.1:{{ .Values.maestro.port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        # OIDC redirect, SSE, and proxied Dex form posts must stream.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout  300s;
+        proxy_send_timeout  300s;
+      }
+    }
+{{- end }}

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -1,0 +1,162 @@
+suite: in-pod TLS sidecar
+templates:
+  - maestro-deployment.yaml
+  - maestro-service.yaml
+  - maestro-tls-config.yaml
+tests:
+  - it: emits no TLS resources when disabled
+    set:
+      maestro.baseUrl: https://m.example.com
+    asserts:
+      - template: maestro-tls-config.yaml
+        hasDocuments: { count: 0 }
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.containers
+          content:
+            name: tls-proxy
+          any: true
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+          any: true
+      - template: maestro-service.yaml
+        notContains:
+          path: spec.ports
+          content:
+            name: https
+          any: true
+
+  - it: with autoGenerate, adds tls-init + tls-proxy + service https port
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+    asserts:
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+          any: true
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.containers
+          content:
+            name: tls-proxy
+          any: true
+      - template: maestro-service.yaml
+        contains:
+          path: spec.ports
+          content:
+            port: 4443
+            targetPort: https
+            name: https
+
+  - it: tls-proxy uses overridable image
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.image.repository: registry.example.com/nginx
+      maestro.tls.image.tag: 1.27-custom
+    asserts:
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.containers
+          content:
+            name: tls-proxy
+            image: registry.example.com/nginx:1.27-custom
+          any: true
+
+  - it: tls-init uses overridable openssl image and skips when secretName set
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+      maestro.tls.secretName: my-tls
+    asserts:
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+          any: true
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: my-tls
+
+  - it: rejects http baseUrl when tls.enabled
+    set:
+      maestro.baseUrl: http://m.example.com
+      maestro.tls.enabled: true
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls.enabled=true requires maestro.baseUrl to use https:// (got \"http://m.example.com\"). Either set maestro.baseUrl to an https URL or set ingress.tls so the chart derives one."
+
+  - it: rejects both autoGenerate and secretName
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: true
+      maestro.tls.secretName: my-tls
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls: set exactly one of cert.autoGenerate=true OR secretName, not both"
+
+  - it: rejects neither autoGenerate nor secretName
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls.enabled=true requires either cert.autoGenerate=true (default) or a non-empty secretName"
+
+  - it: cert-init uses overridable openssl image
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.image.repository: registry.example.com/openssl
+      maestro.tls.cert.image.tag: "3.3"
+    asserts:
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+            image: registry.example.com/openssl:3.3
+          any: true
+
+  - it: cert-init injects host derived from baseUrl into env
+    set:
+      maestro.baseUrl: https://m.example.com:8443
+      maestro.tls.enabled: true
+      maestro.tls.cert.sans:
+        - bastion.example.com
+        - 1-2-3-4.nip.io
+    asserts:
+      # tls-init is initContainers[1] (wait-for-mcp-gateway is [0]).
+      - template: maestro-deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[1].name
+          value: tls-init
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: TLS_HOST
+            value: m.example.com
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: TLS_EXTRA_SANS
+            value: bastion.example.com,1-2-3-4.nip.io

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -63,6 +63,60 @@ maestro:
   extraVolumes: []       # additional volumes
   extraVolumeMounts: []  # additional volume mounts
 
+  # Optional in-pod TLS termination. When enabled, the chart adds an
+  # nginx-unprivileged sidecar that listens on `tls.port` with a
+  # certificate from one of two sources, and the maestro Service exposes
+  # both the HTTP port (still cluster-internal) and the new HTTPS port.
+  # Use this when the consumer requires HTTPS but no Ingress controller
+  # is doing TLS termination — for example a POC bastion port-forward
+  # against the maestro Service. The maestro container itself keeps
+  # speaking plain HTTP on localhost; the sidecar terminates TLS and
+  # proxies to it.
+  #
+  # The chart fails template rendering when tls.enabled=true unless
+  # `maestro.baseUrl` (or the derived ingress.host+ingress.tls combo)
+  # uses https://, so the OIDC URLs the SPA hands to the browser match
+  # the actual scheme served.
+  tls:
+    enabled: false
+    # Container port the sidecar listens on. The maestro Service exposes
+    # this as `https`. Operators typically port-forward this port.
+    port: 4443
+    # Sidecar image. Overridable for air-gapped registries.
+    image:
+      repository: nginxinc/nginx-unprivileged
+      tag: "1.27-alpine"
+      pullPolicy: IfNotPresent
+    # Additional resources for the sidecar.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    # Certificate source — pick exactly one path. The chart fails
+    # rendering if both `cert.autoGenerate` and `secretName` are set.
+    cert:
+      # When true and `secretName` is empty, an init container generates
+      # a self-signed cert into an emptyDir at pod start. The cert
+      # regenerates on every pod restart, so browsers re-prompt for
+      # trust each time — fine for POC, swap to `secretName` for stable
+      # operation.
+      autoGenerate: true
+      # Extra Subject Alternative Names beyond the host extracted from
+      # `maestro.baseUrl`. Use this to add bastion hostnames or IPs.
+      sans: []
+      # Image used by the cert-init container. openssl CLI is the only
+      # requirement.
+      image:
+        repository: cgr.dev/chainguard/openssl
+        tag: latest
+        pullPolicy: IfNotPresent
+    # Reference an existing kubernetes.io/tls Secret instead of
+    # generating one. Mutually exclusive with cert.autoGenerate=true.
+    # secretName: ""
+
   # Persistent storage for ephemeral working data: orchestra artifact
   # payloads (per-run subdirs) and ontology git checkouts. Off by default
   # — when enabled, mounts a PVC at `mountPath` and sets the env vars
@@ -149,6 +203,14 @@ serviceAccount:
 # templates. `resources` is surfaced here so operators can tune CPU/memory
 # without chasing template internals.
 dex:
+  # Dex container image. Defaults are also defined in templates/_helpers.tpl
+  # (maestro.dexConfig) so `--set dex.enabled=true` keeps working with
+  # zero extra fields. Surfaced here so air-gapped/private-registry
+  # installs can override without chasing template internals.
+  # image:
+  #   repository: ghcr.io/dexidp/dex
+  #   tag: v2.41.1
+  #   pullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
## Summary

Adds an opt-in nginx-unprivileged sidecar to the maestro pod that
terminates TLS on port 4443 and proxies plaintext to the maestro
container on localhost. The maestro Service exposes both the existing
HTTP port and the new HTTPS port. Designed for installs that require
HTTPS but have no Ingress controller doing TLS termination — POC
bastion port-forwards in particular.

```yaml
maestro:
  baseUrl: https://1-2-3-4.nip.io:8443
  tls:
    enabled: true
ingress:
  enabled: false
dex:
  enabled: true
  staticUsers: [...]
```

```sh
kubectl port-forward --address 0.0.0.0 svc/<release>-maestro 8443:4443
```

## Cert source

Either:
- `cert.autoGenerate: true` (default) — init container generates a
  self-signed cert at pod start with SAN = host of `maestro.baseUrl`
  plus any `cert.sans` extras. Regenerates on every pod restart, so
  browsers re-prompt for trust each time. Fine for POC.
- `secretName: <my-tls>` — bring your own cert (cert-manager, manual,
  whatever).

The chart fails rendering when `tls.enabled` and the resolved baseUrl
isn't `https://`, so OIDC URLs always match the served scheme.

## Image overridability

All sidecar/init images are overridable for air-gapped registries:

- `maestro.tls.image.{repository,tag,pullPolicy}` — nginx sidecar
  (defaults to `nginxinc/nginx-unprivileged:1.27-alpine`)
- `maestro.tls.cert.image.{repository,tag,pullPolicy}` — openssl
  cert-init (defaults to `cgr.dev/chainguard/openssl:latest`)

Also surfaces the previously-undocumented `dex.image.{repository,tag,pullPolicy}`
overrides in `values.yaml` so air-gapped installs can swap the Dex
image without chasing the helpers.tpl defaults.

## Tests

8 new helm-unittest cases in `tests/tls_test.yaml`:
- disabled is a no-op (no init, no sidecar, no service port)
- autoGenerate emits init + sidecar + https service port
- image overrides land in the rendered manifests
- secretName path skips the init container, mounts secret as `tls`
- validation rejects http baseUrl
- validation rejects both autoGenerate + secretName
- validation rejects neither autoGenerate nor secretName
- SAN env vars derive correctly from baseUrl + cert.sans

40/40 unit tests pass: `make test`.

## Test plan

- [x] `make test` (lint + template render + unittest, 40 cases)
- [ ] Deploy with `tls.enabled: true` against a live cluster, port-
      forward, verify HTTPS + Dex login round-trip

## Companion changes

None. Chart-only; no maestro/conductor code change. Sidecar is opt-in,
existing installs keep their HTTP-only Service ports.