### PR TITLE
maestro: chart 0.5.26 — inline TLS cert + IP-cert helper

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.25"
+version: "0.5.26"
 appVersion: "v1.7.16"
 keywords:
   - maestro

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -97,16 +97,32 @@ Set `dex.proxyEnabled: false` to opt out (env vars are not emitted; the maestro 
 
 When the consumer requires HTTPS but no Ingress controller is doing TLS termination — for example a POC bastion port-forward that the customer's policy mandates be served over TLS — set `maestro.tls.enabled: true`. The chart adds an nginx-unprivileged sidecar in the maestro pod that listens on `maestro.tls.port` (default `4443`) and proxies to the maestro container on localhost. The maestro Service exposes the new HTTPS port alongside the existing HTTP one.
 
+Pick exactly one of three certificate sources:
+
 ```yaml
 maestro:
   baseUrl: https://1-2-3-4.nip.io:8443
   tls:
     enabled: true
-    # cert.autoGenerate: true (default) — self-signed cert generated at pod
-    # start with SAN = host of maestro.baseUrl + cert.sans extras.
     cert:
+      # 1. autoGenerate (default) — self-signed cert generated at pod start
+      # with SAN = host of maestro.baseUrl + cert.sans extras. Cert
+      # regenerates on every pod restart, so browsers re-prompt for trust.
+      autoGenerate: true
       sans: []
-    # OR: bring your own (cert-manager, manual Secret, etc.)
+
+      # 2. Inline PEM cert + key. The chart creates a kubernetes.io/tls
+      # Secret named "<release>-maestro-tls-cert" and the sidecar mounts
+      # it. Set `autoGenerate: false` when using this path.
+      # crt: |
+      #   -----BEGIN CERTIFICATE-----
+      #   ...
+      # key: |
+      #   -----BEGIN PRIVATE KEY-----
+      #   ...
+
+    # 3. Reference an existing kubernetes.io/tls Secret (cert-manager,
+    # manual creation, etc.). Set cert.autoGenerate: false when using it.
     # secretName: my-tls
 ingress:
   enabled: false
@@ -119,6 +135,27 @@ dex:
 kubectl port-forward --address 0.0.0.0 svc/<release>-maestro 8443:4443
 ```
 
-The chart fails template rendering when `tls.enabled: true` and the resolved base URL isn't `https://`, so OIDC URLs always match the served scheme. Auto-generated certs regenerate on every pod restart (browser re-prompts for trust); use `tls.secretName` for stable certs.
+For an IP-only POC bastion (no DNS), generate a matching self-signed cert
+with the bundled helper and feed the files in via `helm --set-file`:
+
+```sh
+maestro/scripts/gen-tls-cert.sh 1.2.3.4 --out-dir /tmp/maestro-tls
+helm upgrade --install <release> oci://public.ecr.aws/cardinalhq.io/maestro \
+  --values values-local.yaml \
+  --set maestro.tls.enabled=true \
+  --set maestro.tls.cert.autoGenerate=false \
+  --set-file maestro.tls.cert.crt=/tmp/maestro-tls/tls.crt \
+  --set-file maestro.tls.cert.key=/tmp/maestro-tls/tls.key
+```
+
+The script validates the dotted-quad format, emits `tls.crt`/`tls.key`
+with `IP:1.2.3.4` as the SAN, and prints the matching helm command on
+stdout. Use `--extra-san DNS:bastion.local` (repeatable) to add more
+SANs when the same install is reachable through multiple hostnames.
+
+The chart fails template rendering when `tls.enabled: true` and the
+resolved base URL isn't `https://`, so OIDC URLs always match the served
+scheme. It also fails when more than one cert source is configured, or
+when only one of `cert.crt`/`cert.key` is set.
 
 All sidecar/init images are overridable: `maestro.tls.image.{repository,tag,pullPolicy}` for the nginx sidecar, `maestro.tls.cert.image.{repository,tag,pullPolicy}` for the openssl cert-init. `dex.image.{repository,tag,pullPolicy}` overrides the bundled Dex image (defaults in `templates/_helpers.tpl`).

--- a/maestro/scripts/gen-tls-cert.sh
+++ b/maestro/scripts/gen-tls-cert.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Generate a self-signed TLS cert + key suitable for feeding into the
+# maestro chart's inline TLS path:
+#
+#   maestro.tls.cert.autoGenerate=false
+#   maestro.tls.cert.crt=<contents of tls.crt>
+#   maestro.tls.cert.key=<contents of tls.key>
+#
+# The cert covers a single IPv4 address (1.2.3.4 dotted-quad) as a
+# Subject Alternative Name. Use this for IP-only POC bastion deployments
+# where DNS isn't an option. Browsers will still warn (it's self-signed),
+# but the cert chain validates against the IP rather than failing on a
+# CN/SAN mismatch.
+#
+# Usage:
+#   scripts/gen-tls-cert.sh <ipv4> [--out-dir <dir>] [--days <n>] [--extra-san <san>...]
+#
+# Examples:
+#   scripts/gen-tls-cert.sh 1.2.3.4
+#   scripts/gen-tls-cert.sh 10.0.42.7 --out-dir /tmp/maestro-tls --days 730
+#   scripts/gen-tls-cert.sh 1.2.3.4 --extra-san DNS:bastion.local --extra-san IP:10.0.0.1
+#
+# Outputs <out-dir>/tls.crt and <out-dir>/tls.key (defaults to ./).
+# Prints a copy-pasteable `helm install --set-file ...` snippet on stdout.
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+IP=""
+OUT_DIR="."
+DAYS=365
+EXTRA_SANS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage 0
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --days)
+      DAYS="$2"
+      shift 2
+      ;;
+    --extra-san)
+      EXTRA_SANS+=("$2")
+      shift 2
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage 1 >&2
+      ;;
+    *)
+      if [[ -n "$IP" ]]; then
+        echo "error: only one IPv4 argument is supported (got '$IP' and '$1')" >&2
+        exit 1
+      fi
+      IP="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$IP" ]]; then
+  echo "error: missing required IPv4 address argument" >&2
+  usage 1 >&2
+fi
+
+# Strict 1.2.3.4 dotted-quad with 0-255 in each octet. Anything else
+# (DNS names, CIDR notation, IPv6) is rejected so the operator gets a
+# clear error rather than a cert with a useless SAN.
+if ! [[ "$IP" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "error: '$IP' is not a 1.2.3.4 dotted-quad IPv4 address" >&2
+  exit 1
+fi
+for octet in "${BASH_REMATCH[@]:1}"; do
+  if (( octet > 255 )); then
+    echo "error: '$IP' has an octet > 255" >&2
+    exit 1
+  fi
+done
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "error: openssl not found in PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+CRT="$OUT_DIR/tls.crt"
+KEY="$OUT_DIR/tls.key"
+CFG="$(mktemp -t gen-tls-cert.XXXXXX.cnf)"
+trap 'rm -f "$CFG"' EXIT
+
+SAN="IP:${IP}"
+for s in "${EXTRA_SANS[@]:-}"; do
+  [[ -z "$s" ]] && continue
+  SAN="${SAN},${s}"
+done
+
+cat >"$CFG" <<EOF
+[req]
+distinguished_name=req_distinguished_name
+prompt=no
+req_extensions=v3
+[req_distinguished_name]
+CN=${IP}
+[v3]
+subjectAltName=${SAN}
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+EOF
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$KEY" -out "$CRT" \
+  -days "$DAYS" -extensions v3 -config "$CFG" >/dev/null 2>&1
+
+chmod 0600 "$KEY"
+chmod 0644 "$CRT"
+
+cat <<EOF
+Wrote:
+  cert: $CRT
+  key:  $KEY
+SAN:    ${SAN}
+Expiry: $(openssl x509 -in "$CRT" -noout -enddate | sed 's/^notAfter=//')
+
+Feed into the maestro chart with:
+  helm upgrade --install <release> oci://public.ecr.aws/cardinalhq.io/maestro \\
+    --values values-local.yaml \\
+    --set maestro.tls.enabled=true \\
+    --set maestro.tls.cert.autoGenerate=false \\
+    --set-file maestro.tls.cert.crt=$CRT \\
+    --set-file maestro.tls.cert.key=$KEY
+EOF

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -284,7 +284,10 @@ Validate maestro.tls inputs:
   * tls.enabled=true requires the resolved baseUrl to use https://, so the
     OIDC issuer URL the SPA hands to the browser matches the scheme the
     maestro Service actually serves.
-  * Exactly one of cert.autoGenerate=true OR secretName must be set.
+  * Exactly one of three cert sources must be configured:
+      - cert.autoGenerate=true (default, in-pod self-signed)
+      - secretName (existing kubernetes.io/tls Secret)
+      - cert.crt + cert.key (inline PEM, chart creates the Secret)
 */}}
 {{- define "maestro.tlsValidate" -}}
 {{- $tls := dig "tls" dict (.Values.maestro | default dict) -}}
@@ -295,12 +298,42 @@ Validate maestro.tls inputs:
   {{- end -}}
   {{- $autogen := dig "cert" "autoGenerate" true $tls -}}
   {{- $secret := dig "secretName" "" $tls -}}
-  {{- if and $autogen $secret -}}
-    {{- fail "maestro.tls: set exactly one of cert.autoGenerate=true OR secretName, not both" -}}
+  {{- $crt := dig "cert" "crt" "" $tls -}}
+  {{- $key := dig "cert" "key" "" $tls -}}
+  {{- if or (and $crt (not $key)) (and $key (not $crt)) -}}
+    {{- fail "maestro.tls.cert: set both cert.crt and cert.key, or neither" -}}
   {{- end -}}
-  {{- if and (not $autogen) (not $secret) -}}
-    {{- fail "maestro.tls.enabled=true requires either cert.autoGenerate=true (default) or a non-empty secretName" -}}
+  {{- $inline := and $crt $key -}}
+  {{- $count := 0 -}}
+  {{- if $autogen -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if $secret -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if $inline -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if gt $count 1 -}}
+    {{- fail "maestro.tls: set exactly one cert source — cert.autoGenerate=true, secretName, or cert.crt+cert.key (set cert.autoGenerate=false when using one of the BYO paths)" -}}
   {{- end -}}
+  {{- if eq $count 0 -}}
+    {{- fail "maestro.tls.enabled=true requires one cert source: cert.autoGenerate=true (default), a non-empty secretName, or cert.crt+cert.key" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the Secret name the TLS sidecar mounts. Returns:
+  * .Values.maestro.tls.secretName when a user-provided Secret is referenced.
+  * "<fullname>-maestro-tls-cert" when inline cert.crt+cert.key are set
+    (the chart creates that Secret via templates/maestro-tls-secret.yaml).
+  * empty string when autoGenerate is in effect (the volume is an emptyDir
+    populated by the tls-init container).
+*/}}
+{{- define "maestro.tlsResolvedSecretName" -}}
+{{- $tls := dig "tls" dict (.Values.maestro | default dict) -}}
+{{- $secret := dig "secretName" "" $tls -}}
+{{- $crt := dig "cert" "crt" "" $tls -}}
+{{- $key := dig "cert" "key" "" $tls -}}
+{{- if $secret -}}
+{{- $secret -}}
+{{- else if and $crt $key -}}
+{{- printf "%s-maestro-tls-cert" (include "maestro.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -237,9 +237,10 @@ spec:
       {{- end }}
       {{- if dig "tls" "enabled" false .Values.maestro }}
       - name: tls
-        {{- if dig "tls" "secretName" "" .Values.maestro }}
+        {{- $tlsSecret := include "maestro.tlsResolvedSecretName" . }}
+        {{- if $tlsSecret }}
         secret:
-          secretName: {{ .Values.maestro.tls.secretName }}
+          secretName: {{ $tlsSecret }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/maestro/templates/maestro-tls-secret.yaml
+++ b/maestro/templates/maestro-tls-secret.yaml
@@ -1,0 +1,24 @@
+{{- /*
+  Validation lives in maestro-tls-config.yaml so the chart raises a single
+  error from a deterministic template. This file only renders when both
+  inline cert fields are set; bad combinations (e.g. inline + autoGenerate)
+  fail rendering elsewhere before this Secret matters.
+*/}}
+{{- if and .Values.maestro.enabled (dig "tls" "enabled" false (.Values.maestro | default dict)) -}}
+{{- $crt := dig "tls" "cert" "crt" "" (.Values.maestro | default dict) -}}
+{{- $key := dig "tls" "cert" "key" "" (.Values.maestro | default dict) -}}
+{{- if and $crt $key -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro-tls-cert
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  tls.crt: {{ $crt | b64enc | quote }}
+  tls.key: {{ $key | b64enc | quote }}
+{{- end -}}
+{{- end }}

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -3,12 +3,15 @@ templates:
   - maestro-deployment.yaml
   - maestro-service.yaml
   - maestro-tls-config.yaml
+  - maestro-tls-secret.yaml
 tests:
   - it: emits no TLS resources when disabled
     set:
       maestro.baseUrl: https://m.example.com
     asserts:
       - template: maestro-tls-config.yaml
+        hasDocuments: { count: 0 }
+      - template: maestro-tls-secret.yaml
         hasDocuments: { count: 0 }
       - template: maestro-deployment.yaml
         notContains:
@@ -108,9 +111,9 @@ tests:
     template: maestro-tls-config.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "maestro.tls: set exactly one of cert.autoGenerate=true OR secretName, not both"
+          errorMessage: "maestro.tls: set exactly one cert source — cert.autoGenerate=true, secretName, or cert.crt+cert.key (set cert.autoGenerate=false when using one of the BYO paths)"
 
-  - it: rejects neither autoGenerate nor secretName
+  - it: rejects no cert source
     set:
       maestro.baseUrl: https://m.example.com
       maestro.tls.enabled: true
@@ -118,7 +121,100 @@ tests:
     template: maestro-tls-config.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "maestro.tls.enabled=true requires either cert.autoGenerate=true (default) or a non-empty secretName"
+          errorMessage: "maestro.tls.enabled=true requires one cert source: cert.autoGenerate=true (default), a non-empty secretName, or cert.crt+cert.key"
+
+  - it: rejects autoGenerate combined with inline cert
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: true
+      maestro.tls.cert.crt: "PEM CERT"
+      maestro.tls.cert.key: "PEM KEY"
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls: set exactly one cert source — cert.autoGenerate=true, secretName, or cert.crt+cert.key (set cert.autoGenerate=false when using one of the BYO paths)"
+
+  - it: rejects secretName combined with inline cert
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+      maestro.tls.secretName: my-tls
+      maestro.tls.cert.crt: "PEM CERT"
+      maestro.tls.cert.key: "PEM KEY"
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls: set exactly one cert source — cert.autoGenerate=true, secretName, or cert.crt+cert.key (set cert.autoGenerate=false when using one of the BYO paths)"
+
+  - it: rejects inline cert with only crt
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+      maestro.tls.cert.crt: "PEM CERT"
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls.cert: set both cert.crt and cert.key, or neither"
+
+  - it: rejects inline cert with only key
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+      maestro.tls.cert.key: "PEM KEY"
+    template: maestro-tls-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "maestro.tls.cert: set both cert.crt and cert.key, or neither"
+
+  - it: with inline cert, renders Secret and mounts it without tls-init
+    set:
+      maestro.baseUrl: https://1-2-3-4.nip.io:8443
+      maestro.tls.enabled: true
+      maestro.tls.cert.autoGenerate: false
+      maestro.tls.cert.crt: "PEM CERT"
+      maestro.tls.cert.key: "PEM KEY"
+    release:
+      name: r
+    asserts:
+      - template: maestro-tls-secret.yaml
+        hasDocuments: { count: 1 }
+      - template: maestro-tls-secret.yaml
+        equal:
+          path: kind
+          value: Secret
+      - template: maestro-tls-secret.yaml
+        equal:
+          path: type
+          value: kubernetes.io/tls
+      - template: maestro-tls-secret.yaml
+        equal:
+          path: metadata.name
+          value: r-maestro-maestro-tls-cert
+      - template: maestro-tls-secret.yaml
+        equal:
+          path: data["tls.crt"]
+          value: UEVNIENFUlQ=     # base64("PEM CERT")
+      - template: maestro-tls-secret.yaml
+        equal:
+          path: data["tls.key"]
+          value: UEVNIEtFWQ==     # base64("PEM KEY")
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+          any: true
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: r-maestro-maestro-tls-cert
 
   - it: cert-init uses overridable openssl image
     set:

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -95,17 +95,20 @@ maestro:
       limits:
         cpu: 200m
         memory: 128Mi
-    # Certificate source — pick exactly one path. The chart fails
-    # rendering if both `cert.autoGenerate` and `secretName` are set.
+    # Certificate source — pick exactly one of three paths. The chart
+    # fails rendering if more than one is configured, or if none is.
+    #   1. cert.autoGenerate=true (default) — in-pod self-signed
+    #   2. secretName — reference an existing kubernetes.io/tls Secret
+    #   3. cert.crt + cert.key — inline PEM, chart creates the Secret
     cert:
-      # When true and `secretName` is empty, an init container generates
-      # a self-signed cert into an emptyDir at pod start. The cert
-      # regenerates on every pod restart, so browsers re-prompt for
-      # trust each time — fine for POC, swap to `secretName` for stable
-      # operation.
+      # When true and both `secretName` and `cert.crt`/`cert.key` are
+      # empty, an init container generates a self-signed cert into an
+      # emptyDir at pod start. The cert regenerates on every pod
+      # restart, so browsers re-prompt for trust each time — fine for
+      # POC, swap to one of the two BYO paths below for stable certs.
       autoGenerate: true
       # Extra Subject Alternative Names beyond the host extracted from
-      # `maestro.baseUrl`. Use this to add bastion hostnames or IPs.
+      # `maestro.baseUrl`. Used only by the autoGenerate path.
       sans: []
       # Image used by the cert-init container. openssl CLI is the only
       # requirement.
@@ -113,8 +116,24 @@ maestro:
         repository: cgr.dev/chainguard/openssl
         tag: latest
         pullPolicy: IfNotPresent
+      # Inline-provided PEM certificate and private key. When both are
+      # non-empty, the chart creates a kubernetes.io/tls Secret named
+      # "<release>-maestro-tls-cert" and the sidecar mounts it. Mutually
+      # exclusive with autoGenerate=true and secretName. Set
+      # `cert.autoGenerate: false` when using this path.
+      #
+      # Generate a matching pair for an IP-only deployment with the
+      # bundled scripts/gen-tls-cert.sh helper, then feed the files
+      # in via `helm --set-file`:
+      #   helm install ... \
+      #     --set maestro.tls.cert.autoGenerate=false \
+      #     --set-file maestro.tls.cert.crt=tls.crt \
+      #     --set-file maestro.tls.cert.key=tls.key
+      crt: ""
+      key: ""
     # Reference an existing kubernetes.io/tls Secret instead of
-    # generating one. Mutually exclusive with cert.autoGenerate=true.
+    # generating one or providing inline PEM. Mutually exclusive with
+    # cert.autoGenerate=true and cert.crt/cert.key.
     # secretName: ""
 
   # Persistent storage for ephemeral working data: orchestra artifact


### PR DESCRIPTION
## Summary

- Adds a third certificate source for the in-pod TLS sidecar: inline PEM via `maestro.tls.cert.crt` + `cert.key`. The chart renders a `kubernetes.io/tls` Secret named `<release>-maestro-tls-cert` and the sidecar mounts it. Joins the existing `cert.autoGenerate` (in-pod self-signed) and `secretName` (BYO Secret) paths.
- Validation tightened to enforce exactly one of {`autoGenerate`, `secretName`, inline crt+key}; rejects half-set inline pairs.
- New `maestro/scripts/gen-tls-cert.sh` generates a self-signed cert + key with an `IP:1.2.3.4` SAN for IP-only POC bastions, validates dotted-quad strictly, supports `--extra-san`, and prints the matching `helm --set-file` snippet on stdout.
- Chart 0.5.25 → 0.5.26.

## Test plan

- [x] `helm unittest maestro` — 45 passed (was 40, +5 inline-cert tests including all rejection paths)
- [x] `helm lint maestro` — clean
- [x] End-to-end render with `--set-file` from script-generated cert: Secret materializes, deployment volume references it, no `tls-init` initContainer
- [x] Script smoke-tested: cert SAN matches IP, rejects DNS / IPv6 / >255 octets / missing args