### PR TITLE
maestro: chart 0.5.27 — fix nginx temp paths on read-only rootfs

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.26"
+version: "0.5.27"
 appVersion: "v1.7.16"
 keywords:
   - maestro

--- a/maestro/templates/maestro-tls-config.yaml
+++ b/maestro/templates/maestro-tls-config.yaml
@@ -18,6 +18,15 @@ data:
       ssl_protocols       TLSv1.2 TLSv1.3;
       client_max_body_size 50m;
 
+      # nginx ignores TMPDIR; its default temp paths (e.g. /tmp/proxy_temp)
+      # sit on the read-only root FS. Redirect every temp path under the
+      # writable /tmp/nginx subPath of the shared `tmp` emptyDir.
+      client_body_temp_path /tmp/nginx/client_body;
+      proxy_temp_path       /tmp/nginx/proxy;
+      fastcgi_temp_path     /tmp/nginx/fastcgi;
+      uwsgi_temp_path       /tmp/nginx/uwsgi;
+      scgi_temp_path        /tmp/nginx/scgi;
+
       location / {
         proxy_pass http://127.0.0.1:{{ .Values.maestro.port }};
         proxy_http_version 1.1;

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -57,6 +57,32 @@ tests:
             targetPort: https
             name: https
 
+  - it: nginx config redirects all temp paths under /tmp/nginx
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+    asserts:
+      - template: maestro-tls-config.yaml
+        matchRegex:
+          path: data["default.conf"]
+          pattern: "client_body_temp_path /tmp/nginx/client_body;"
+      - template: maestro-tls-config.yaml
+        matchRegex:
+          path: data["default.conf"]
+          pattern: "proxy_temp_path       /tmp/nginx/proxy;"
+      - template: maestro-tls-config.yaml
+        matchRegex:
+          path: data["default.conf"]
+          pattern: "fastcgi_temp_path     /tmp/nginx/fastcgi;"
+      - template: maestro-tls-config.yaml
+        matchRegex:
+          path: data["default.conf"]
+          pattern: "uwsgi_temp_path       /tmp/nginx/uwsgi;"
+      - template: maestro-tls-config.yaml
+        matchRegex:
+          path: data["default.conf"]
+          pattern: "scgi_temp_path        /tmp/nginx/scgi;"
+
   - it: tls-proxy uses overridable image
     set:
       maestro.baseUrl: https://m.example.com


### PR DESCRIPTION
## Summary
- tls-proxy sidecar (nginx-unprivileged) crashed on first proxied request because nginx's default `proxy_temp_path` (`/tmp/proxy_temp`) sits on the read-only root FS.
- nginx ignores `TMPDIR` — only its `*_temp_path` directives can move these.
- Redirect all five temp paths (`client_body`, `proxy`, `fastcgi`, `uwsgi`, `scgi`) under `/tmp/nginx`, already a writable subPath of the shared `tmp` emptyDir.

## Test plan
- [x] `helm lint maestro`
- [x] `helm unittest maestro` (46 passing, includes new assertion that all five `*_temp_path` directives render)
- [ ] Deploy `maestro.tls.enabled=true` and confirm tls-proxy stays up under traffic