### PR TITLE
maestro: chart 0.5.28 — writable /etc/nginx/conf.d for tls-proxy

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.27"
+version: "0.5.28"
 appVersion: "v1.7.16"
 keywords:
   - maestro

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -116,6 +116,36 @@ spec:
             memory: 64Mi
         {{- end }}
       {{- end }}
+      {{- if dig "tls" "enabled" false .Values.maestro }}
+      # /etc/nginx/conf.d sits on the read-only rootfs. The
+      # nginx-unprivileged entrypoint (10-listen-on-ipv6-by-default.sh)
+      # tries to touch default.conf at startup and fails. Stage the
+      # rendered server block from the configmap into a writable
+      # emptyDir so the entrypoint scripts and nginx itself have a
+      # writable conf.d.
+      - name: nginx-conf-init
+        image: "{{ .Values.maestro.tls.image.repository }}:{{ .Values.maestro.tls.image.tag }}"
+        imagePullPolicy: {{ .Values.maestro.tls.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - cp /src/default.conf /dst/default.conf
+        volumeMounts:
+          - name: tls-config
+            mountPath: /src
+            readOnly: true
+          - name: nginx-conf
+            mountPath: /dst
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 50m
+            memory: 64Mi
+        {{- end }}
+      {{- end }}
       containers:
       - name: maestro
         {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
@@ -207,9 +237,11 @@ spec:
           - name: tls
             mountPath: /etc/nginx/tls
             readOnly: true
-          - name: tls-config
+          # nginx-conf is populated by the nginx-conf-init init container
+          # from the tls-config configmap. emptyDir (vs. configmap mount)
+          # keeps /etc/nginx/conf.d writable for the entrypoint scripts.
+          - name: nginx-conf
             mountPath: /etc/nginx/conf.d
-            readOnly: true
           # nginx-unprivileged needs writable scratch space under
           # /tmp + /var/cache/nginx for its worker temp files. Reuse
           # the maestro pod's existing `tmp` emptyDir.
@@ -247,6 +279,8 @@ spec:
       - name: tls-config
         configMap:
           name: {{ include "maestro.fullname" . }}-maestro-tls
+      - name: nginx-conf
+        emptyDir: {}
       {{- end }}
       {{- with .Values.maestro.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -57,6 +57,38 @@ tests:
             targetPort: https
             name: https
 
+  - it: stages nginx conf into a writable emptyDir via init container
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+    asserts:
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: nginx-conf-init
+          any: true
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-conf
+            emptyDir: {}
+      - template: maestro-deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[?(@.name=="tls-proxy")].volumeMounts
+          content:
+            name: tls-config
+            mountPath: /etc/nginx/conf.d
+            readOnly: true
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[?(@.name=="tls-proxy")].volumeMounts
+          content:
+            name: nginx-conf
+            mountPath: /etc/nginx/conf.d
+          any: true
+
   - it: nginx config redirects all temp paths under /tmp/nginx
     set:
       maestro.baseUrl: https://m.example.com


### PR DESCRIPTION
## Summary
- Follow-up to #39. After fixing the nginx temp paths, the tls-proxy still hit a read-only `/etc/nginx/conf.d` because the configmap volume mount makes that directory read-only.
- nginx-unprivileged's `10-listen-on-ipv6-by-default.sh` startup hook tries to touch `default.conf` and fails on read-only mounts.
- New `nginx-conf-init` init container copies the rendered server block from the `tls-config` configmap into a fresh `nginx-conf` emptyDir, which tls-proxy mounts at `/etc/nginx/conf.d`. Configmap stays the source of truth; conf.d is now fully writable.

## Test plan
- [x] `helm lint maestro`
- [x] `helm unittest maestro` (47 passing, includes new assertion that the init container exists, the emptyDir is added, and tls-proxy no longer mounts the configmap at `/etc/nginx/conf.d`)
- [ ] Deploy `maestro.tls.enabled=true` and confirm tls-proxy starts cleanly and serves traffic