### PR TITLE
maestro: chart 0.5.29 — drop ROFS for the maestro pod when TLS is on

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.28"
+version: "0.5.29"
 appVersion: "v1.7.16"
 keywords:
   - maestro

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -44,6 +44,22 @@ spec:
       {{- end }}
       {{- include "maestro.podSecurityContext" (dict "root" . "override" $podSec) | nindent 6 }}
       {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      {{- /*
+        With the in-pod TLS sidecar, several paths nginx-unprivileged needs
+        to touch (/tmp/proxy_temp, /etc/nginx/conf.d/default.conf via the
+        ipv6 listen entrypoint hook, /var/cache/nginx) sit on the read-only
+        rootfs. Rather than chase each one with init containers and subPath
+        mounts, drop readOnlyRootFilesystem for the whole pod when TLS is
+        enabled. Operators who need ROFS=true can still set it explicitly
+        in maestro.containerSecurityContext.
+      */}}
+      {{- $containerSec := .Values.maestro.containerSecurityContext | default dict -}}
+      {{- if and (dig "tls" "enabled" false .Values.maestro) (not (hasKey $containerSec "readOnlyRootFilesystem")) -}}
+        {{- $merged := dict -}}
+        {{- range $k, $v := $containerSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
+        {{- $_ := set $merged "readOnlyRootFilesystem" false -}}
+        {{- $containerSec = $merged -}}
+      {{- end }}
       initContainers:
       # Reuses the unified maestro image so we don't need a separate
       # busybox/netcat dependency. The entrypoint exposes a `wait-for-tcp`
@@ -51,7 +67,7 @@ spec:
       - name: wait-for-mcp-gateway
         image: {{ include "maestro.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
         args:
           - wait-for-tcp
           - {{ include "maestro.fullname" . }}-mcp-gateway
@@ -72,7 +88,7 @@ spec:
       - name: tls-init
         image: "{{ .Values.maestro.tls.cert.image.repository }}:{{ .Values.maestro.tls.cert.image.tag }}"
         imagePullPolicy: {{ .Values.maestro.tls.cert.image.pullPolicy }}
-        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -116,39 +132,9 @@ spec:
             memory: 64Mi
         {{- end }}
       {{- end }}
-      {{- if dig "tls" "enabled" false .Values.maestro }}
-      # /etc/nginx/conf.d sits on the read-only rootfs. The
-      # nginx-unprivileged entrypoint (10-listen-on-ipv6-by-default.sh)
-      # tries to touch default.conf at startup and fails. Stage the
-      # rendered server block from the configmap into a writable
-      # emptyDir so the entrypoint scripts and nginx itself have a
-      # writable conf.d.
-      - name: nginx-conf-init
-        image: "{{ .Values.maestro.tls.image.repository }}:{{ .Values.maestro.tls.image.tag }}"
-        imagePullPolicy: {{ .Values.maestro.tls.image.pullPolicy }}
-        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - cp /src/default.conf /dst/default.conf
-        volumeMounts:
-          - name: tls-config
-            mountPath: /src
-            readOnly: true
-          - name: nginx-conf
-            mountPath: /dst
-        {{- if .Values.global.resources.enabled }}
-        resources:
-          requests:
-            cpu: 50m
-            memory: 32Mi
-          limits:
-            cpu: 50m
-            memory: 64Mi
-        {{- end }}
-      {{- end }}
       containers:
       - name: maestro
-        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
         image: {{ include "maestro.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
@@ -217,7 +203,7 @@ spec:
       - name: tls-proxy
         image: "{{ .Values.maestro.tls.image.repository }}:{{ .Values.maestro.tls.image.tag }}"
         imagePullPolicy: {{ .Values.maestro.tls.image.pullPolicy }}
-        {{- include "maestro.containerSecurityContext" (dict "root" . "override" .Values.maestro.containerSecurityContext) | nindent 8 }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
         ports:
           - containerPort: {{ .Values.maestro.tls.port }}
             name: https
@@ -237,20 +223,9 @@ spec:
           - name: tls
             mountPath: /etc/nginx/tls
             readOnly: true
-          # nginx-conf is populated by the nginx-conf-init init container
-          # from the tls-config configmap. emptyDir (vs. configmap mount)
-          # keeps /etc/nginx/conf.d writable for the entrypoint scripts.
-          - name: nginx-conf
+          - name: tls-config
             mountPath: /etc/nginx/conf.d
-          # nginx-unprivileged needs writable scratch space under
-          # /tmp + /var/cache/nginx for its worker temp files. Reuse
-          # the maestro pod's existing `tmp` emptyDir.
-          - name: tmp
-            mountPath: /var/cache/nginx
-            subPath: nginx-cache
-          - name: tmp
-            mountPath: /tmp/nginx
-            subPath: nginx-tmp
+            readOnly: true
         {{- if .Values.global.resources.enabled }}
         resources:
           {{- toYaml .Values.maestro.tls.resources | nindent 10 }}
@@ -279,8 +254,6 @@ spec:
       - name: tls-config
         configMap:
           name: {{ include "maestro.fullname" . }}-maestro-tls
-      - name: nginx-conf
-        emptyDir: {}
       {{- end }}
       {{- with .Values.maestro.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/maestro/templates/maestro-tls-config.yaml
+++ b/maestro/templates/maestro-tls-config.yaml
@@ -18,15 +18,6 @@ data:
       ssl_protocols       TLSv1.2 TLSv1.3;
       client_max_body_size 50m;
 
-      # nginx ignores TMPDIR; its default temp paths (e.g. /tmp/proxy_temp)
-      # sit on the read-only root FS. Redirect every temp path under the
-      # writable /tmp/nginx subPath of the shared `tmp` emptyDir.
-      client_body_temp_path /tmp/nginx/client_body;
-      proxy_temp_path       /tmp/nginx/proxy;
-      fastcgi_temp_path     /tmp/nginx/fastcgi;
-      uwsgi_temp_path       /tmp/nginx/uwsgi;
-      scgi_temp_path        /tmp/nginx/scgi;
-
       location / {
         proxy_pass http://127.0.0.1:{{ .Values.maestro.port }};
         proxy_http_version 1.1;

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -57,63 +57,44 @@ tests:
             targetPort: https
             name: https
 
-  - it: stages nginx conf into a writable emptyDir via init container
+  - it: drops readOnlyRootFilesystem on every container when tls is enabled
     set:
       maestro.baseUrl: https://m.example.com
       maestro.tls.enabled: true
     asserts:
       - template: maestro-deployment.yaml
-        contains:
-          path: spec.template.spec.initContainers
-          content:
-            name: nginx-conf-init
-          any: true
+        equal:
+          path: spec.template.spec.containers[?(@.name=="maestro")].securityContext.readOnlyRootFilesystem
+          value: false
       - template: maestro-deployment.yaml
-        contains:
-          path: spec.template.spec.volumes
-          content:
-            name: nginx-conf
-            emptyDir: {}
+        equal:
+          path: spec.template.spec.containers[?(@.name=="tls-proxy")].securityContext.readOnlyRootFilesystem
+          value: false
       - template: maestro-deployment.yaml
-        notContains:
-          path: spec.template.spec.containers[?(@.name=="tls-proxy")].volumeMounts
-          content:
-            name: tls-config
-            mountPath: /etc/nginx/conf.d
-            readOnly: true
-      - template: maestro-deployment.yaml
-        contains:
-          path: spec.template.spec.containers[?(@.name=="tls-proxy")].volumeMounts
-          content:
-            name: nginx-conf
-            mountPath: /etc/nginx/conf.d
-          any: true
+        equal:
+          path: spec.template.spec.initContainers[?(@.name=="tls-init")].securityContext.readOnlyRootFilesystem
+          value: false
 
-  - it: nginx config redirects all temp paths under /tmp/nginx
+  - it: keeps readOnlyRootFilesystem on the maestro container when tls is disabled
+    set:
+      maestro.baseUrl: https://m.example.com
+    asserts:
+      - template: maestro-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[?(@.name=="maestro")].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: respects an explicit readOnlyRootFilesystem override even when tls is enabled
     set:
       maestro.baseUrl: https://m.example.com
       maestro.tls.enabled: true
+      maestro.containerSecurityContext:
+        readOnlyRootFilesystem: true
     asserts:
-      - template: maestro-tls-config.yaml
-        matchRegex:
-          path: data["default.conf"]
-          pattern: "client_body_temp_path /tmp/nginx/client_body;"
-      - template: maestro-tls-config.yaml
-        matchRegex:
-          path: data["default.conf"]
-          pattern: "proxy_temp_path       /tmp/nginx/proxy;"
-      - template: maestro-tls-config.yaml
-        matchRegex:
-          path: data["default.conf"]
-          pattern: "fastcgi_temp_path     /tmp/nginx/fastcgi;"
-      - template: maestro-tls-config.yaml
-        matchRegex:
-          path: data["default.conf"]
-          pattern: "uwsgi_temp_path       /tmp/nginx/uwsgi;"
-      - template: maestro-tls-config.yaml
-        matchRegex:
-          path: data["default.conf"]
-          pattern: "scgi_temp_path        /tmp/nginx/scgi;"
+      - template: maestro-deployment.yaml
+        equal:
+          path: spec.template.spec.containers[?(@.name=="tls-proxy")].securityContext.readOnlyRootFilesystem
+          value: true
 
   - it: tls-proxy uses overridable image
     set:


### PR DESCRIPTION
## Summary
- The nginx-unprivileged sidecar wants writable `/tmp`, `/var/cache/nginx`, and `/etc/nginx/conf.d`. PRs #39 and #40 chased each one with subPath mounts, init containers, and nginx config overrides — too much surface area for a workaround.
- Simpler: when `maestro.tls.enabled=true`, override `readOnlyRootFilesystem` to `false` for every container in the maestro pod, and revert both prior workarounds. Operators who really want ROFS under TLS can still set it explicitly in `maestro.containerSecurityContext`.

## Changes
- Compute an effective container security context once at the top of the deployment template; flip ROFS to false unless the user explicitly set it.
- Drop the `nginx-conf-init` init container and `nginx-conf` emptyDir; tls-config configmap mounts directly at `/etc/nginx/conf.d` again.
- Drop the `/tmp/nginx` + `/var/cache/nginx` subPath mounts on tls-proxy and the `*_temp_path` nginx directives in the configmap.

## Test plan
- [x] `helm lint maestro`
- [x] `helm unittest maestro` (48 passing, includes asserts that ROFS is `false` on maestro/tls-proxy/tls-init when tls is on, stays `true` on maestro when tls is off, and that an explicit override wins)
- [ ] Deploy `maestro.tls.enabled=true` and confirm tls-proxy starts cleanly and serves traffic