### PR TITLE
maestro: auto-inject Cardinal OTLP telemetry env when global.cardinal.apiKey is set

### DIFF
--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -149,6 +149,34 @@ Database environment variables shared across components.
 {{- end }}
 
 {{/*
+Return the secret name for the Cardinal API key.
+*/}}
+{{- define "maestro.cardinalApiKeySecretName" -}}
+{{- printf "%s-%s" (include "maestro.fullname" .) "cardinal-api-key" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+OTLP env vars pointing at CardinalHQ's hosted intake. Emits nothing when
+global.cardinal.apiKey is empty, so existing installs without telemetry
+configuration are unaffected (and chart-test env-index assertions stay
+stable). Both maestro (tracing.ts) and mcp-gateway (telemetry.go) read
+OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS directly; no
+extra gating env var is needed (lakerunner's ENABLE_OTLP_TELEMETRY is
+lakerunner-specific and unused here).
+*/}}
+{{- define "maestro.cardinalTelemetryEnv" -}}
+{{- if .Values.global.cardinal.apiKey }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ if eq .Values.global.cardinal.env "test" }}"https://customer-intake-otelhttp.us-east-2.aws.test.cardinalhq.net"{{ else }}"https://otelhttp.intake.us-east-2.aws.cardinalhq.io"{{ end }}
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "maestro.cardinalApiKeySecretName" . }}
+      key: CARDINAL_API_HEADER
+{{- end }}
+{{- end }}
+
+{{/*
   Merge two maps (global + local), emit nodeSelector: if non-empty.
   args: [ globalMap, localMap ]
 */}}

--- a/maestro/templates/cardinal-api-key-secret.yaml
+++ b/maestro/templates/cardinal-api-key-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.cardinal.apiKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "maestro.cardinalApiKeySecretName" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+type: Opaque
+data:
+  cardinalhq-api-key: {{ .Values.global.cardinal.apiKey | b64enc }}
+  # Pre-formatted OTLP header string consumed by OTEL_EXPORTER_OTLP_HEADERS.
+  CARDINAL_API_HEADER: {{ printf "x-cardinalhq-api-key=%s" .Values.global.cardinal.apiKey | b64enc }}
+{{- end }}

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -153,6 +153,7 @@ spec:
             value: {{ printf "%s/artifacts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
           {{- end }}
           {{- include "maestro.oidcEnv" . | nindent 10 }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
           {{- with .Values.global.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/maestro/templates/mcp-gateway-deployment.yaml
+++ b/maestro/templates/mcp-gateway-deployment.yaml
@@ -44,6 +44,7 @@ spec:
           - name: MCP_API_KEY
             value: {{ .Values.mcpGateway.apiKey | quote }}
           {{- end }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
           {{- with .Values.global.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -257,6 +257,14 @@ global:
     # Set to false to omit resource specifications entirely from rendered templates
     # Default: true
     enabled: true
+  # CardinalHQ telemetry configuration. When apiKey is set, the chart
+  # auto-injects OTEL_EXPORTER_OTLP_ENDPOINT + OTEL_EXPORTER_OTLP_HEADERS
+  # into both the maestro and mcp-gateway containers, pointing at
+  # CardinalHQ's hosted OTLP intake. Leave empty to disable.
+  cardinal:
+    apiKey: ""
+    # Set to "test" to route at the test intake endpoint instead of prod.
+    env: ""
   imagePullSecrets: []
   # Common environment variables to inject into all containers.
   env: []


### PR DESCRIPTION
## Summary
- Adds `global.cardinal.apiKey` (and `global.cardinal.env` test/prod switch) to the maestro chart, mirroring the lakerunner chart pattern.
- New `cardinal-api-key-secret.yaml` template materializes the raw key + a pre-formatted `CARDINAL_API_HEADER=x-cardinalhq-api-key=<key>`.
- New `maestro.cardinalTelemetryEnv` helper injects `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_EXPORTER_OTLP_HEADERS` into both the maestro and mcp-gateway containers, gated on `apiKey` being non-empty.

Without this, only lakerunner pods emitted to the SaaS OTLP intake — maestro/mcp-gateway were silent unless operators hand-rolled the OTEL env vars into `maestro.env` / `mcpGateway.env`. Both binaries already support OTLP (`packages/maestro/src/tracing.ts`, `packages/mcp-gateway/internal/telemetry/telemetry.go`); this is purely a chart wiring gap.

Skipped lakerunner's `ENABLE_OTLP_TELEMETRY` because neither maestro nor mcp-gateway reads it; the OTLP endpoint env var alone is enough to enable each side.

## Test plan
- [x] `helm unittest .` — 48/48 pass (existing env_test index assertions stay stable because the new helper emits nothing when `apiKey` is empty)
- [x] `helm template foo .` with no apiKey — no secret, no OTEL env vars
- [x] `helm template foo . --set global.cardinal.apiKey=k` — secret rendered, both containers get OTEL env vars pointing at prod intake
- [x] `helm template foo . --set global.cardinal.apiKey=k --set global.cardinal.env=test` — endpoint flips to test intake
- [x] `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)