### PR TITLE
lakerunner: bump appVersion to v1.19.2, chart 3.7.1

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.7.0"
-appVersion: "v1.19.0"
+version: "3.7.1"
+appVersion: "v1.19.2"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
## Summary

- Bumps `appVersion` to `v1.19.2` and chart `version` to `3.7.1` for the `lakerunner` chart.
- v1.19.2 removes the KEDA external scaler and worklane depth monitor (cardinalhq/lakerunner#663). The in-process PI autoscaler still scales worker-process-{logs,metrics,traces}; the `lakerunner.worklane.depth` metric is now emitted from `internal/scaling/`.

## Test plan

- [ ] `helm lint charts/lakerunner` passes
- [ ] `helm template` renders without referencing removed externalscaler resources