### PR TITLE
maestro: chart 0.5.33, appVersion v1.12.3

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.5.32"
-appVersion: "v1.11.2"
+version: "0.5.33"
+appVersion: "v1.12.3"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
## Summary

- Bumps maestro chart `version` to **0.5.33** and `appVersion` to **v1.12.3**.
- Pulls in per-integration ServiceNow egress proxy support from [cardinalhq/conductor#459](https://github.com/cardinalhq/conductor/pull/459).
- **No template changes.** The new feature is purely additive at the application layer (three optional JSONB fields on `maestro_integrations`) — no new env vars, secrets, ports, volumes, or operator-facing config to wire up here.

## What's in v1.12.3 (vs. current pin v1.11.2)

This bump skips 9 patch versions. The headline change for this release is the ServiceNow egress proxy support; intermediate patches between v1.11.3 and v1.12.1 are also picked up (see conductor release notes / tag history).

## Test plan

- [x] `Chart.yaml` parses
- [ ] Helm template renders without diffs other than the appVersion label
- [ ] OCI publish succeeds on tag push (per repo workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)