### PR TITLE
maestro: chart 0.6.2, appVersion v1.14.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.6.1"
-appVersion: "v1.13.9"
+version: "0.6.2"
+appVersion: "v1.14.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump maestro chart to 0.6.2 with appVersion v1.14.0 (releases conductor#488 + #489).