### PR TITLE
maestro: chart 0.6.5, appVersion v1.14.4

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.6.4"
-appVersion: "v1.14.3"
+version: "0.6.5"
+appVersion: "v1.14.4"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump maestro chart to 0.6.5 with appVersion v1.14.4 (releases conductor#494).