### PR TITLE
maestro: chart 0.6.6, appVersion v1.14.5

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.6.5"
-appVersion: "v1.14.4"
+version: "0.6.6"
+appVersion: "v1.14.5"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump maestro chart to 0.6.6 with appVersion v1.14.5 (releases conductor#495).