### PR TITLE
lakerunner: chart 3.7.3, appVersion v1.19.3

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.7.2"
-appVersion: "v1.19.2"
+version: "3.7.3"
+appVersion: "v1.19.3"
 keywords:
   - lakerunner
   - logs

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -540,7 +540,7 @@ monitoring:
 
 # Perch operator — version control and collector management
 perch:
-  enabled: false
+  enabled: true
   # Cluster identifier (auto-derived from kube-system UID if empty)
   clusterId: ""
   maestro:
@@ -919,4 +919,3 @@ collector:
   # These will be merged with the default annotations
   # Optional.
   annotations: {}
-


### PR DESCRIPTION
## Summary
- Bump lakerunner chart to 3.7.3, appVersion v1.19.3
- Enable perch operator by default

## Test plan
- [x] helm lint