### PR TITLE
maestro: chart 0.6.11, appVersion v1.16.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.6.10"
-appVersion: "v1.14.10"
+version: "0.6.11"
+appVersion: "v1.16.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bumps maestro chart to track maestro/v1.16.0 from cardinalhq/conductor.