### PR TITLE
lakerunner: chart 3.7.4, per-component trace sampling override

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.7.3"
+version: "3.7.4"
 appVersion: "v1.19.3"
 keywords:
   - lakerunner

--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -183,19 +183,37 @@ Empty override values fall back to the global config.
 {{- end }}
 
 {{/*
-Generate OpenTelemetry trace sampling env vars from global.monitoring.traces config.
-Usage: {{ include "lakerunner.tracesEnv" . }}
+Generate OpenTelemetry trace sampling env vars.
+Reads global.monitoring.traces, then merges in per-component <comp>.monitoring.traces
+(component values win for any keys they define).
+Takes one or two args:
+  0: the root chart context
+  1: (optional) the component's values block (may set .monitoring.traces.{sampler,arg})
+Usage:
+  {{ include "lakerunner.tracesEnv" (list . .Values.queryApi) }}
+  {{ include "lakerunner.tracesEnv" (list .) }}
 */}}
 {{- define "lakerunner.tracesEnv" -}}
-{{- if .Values.global.monitoring }}
-{{- if .Values.global.monitoring.traces }}
-{{- with .Values.global.monitoring.traces }}
+{{- $root := index . 0 -}}
+{{- $comp := dict -}}
+{{- if gt (len .) 1 -}}
+{{- $compArg := index . 1 -}}
+{{- if $compArg -}}{{- $comp = $compArg -}}{{- end -}}
+{{- end -}}
+{{- $traces := dict -}}
+{{- if and $root.Values.global.monitoring $root.Values.global.monitoring.traces -}}
+{{- $traces = deepCopy $root.Values.global.monitoring.traces -}}
+{{- end -}}
+{{- if and $comp.monitoring $comp.monitoring.traces -}}
+{{- $traces = merge (deepCopy $comp.monitoring.traces) $traces -}}
+{{- end -}}
+{{- if $traces.sampler }}
 - name: OTEL_TRACES_SAMPLER
-  value: {{ .sampler | quote }}
+  value: {{ $traces.sampler | quote }}
+{{- end }}
+{{- if hasKey $traces "arg" }}
 - name: OTEL_TRACES_SAMPLER_ARG
-  value: {{ .arg | quote }}
-{{- end }}
-{{- end }}
+  value: {{ $traces.arg | quote }}
 {{- end }}
 {{- end -}}
 
@@ -212,7 +230,7 @@ Usage:
 {{- $comp := index . 1 -}}
 {{- include "lakerunner.setupEnv" $root | nindent 2 -}}
 {{- include "lakerunner.goRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
-{{- include "lakerunner.tracesEnv" $root | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
 {{- with $root.Values.global.env -}}
 {{ toYaml . | nindent 2 -}}
 {{- end -}}
@@ -234,7 +252,7 @@ Usage:
 {{- $comp := index . 1 -}}
 {{- include "lakerunner.commonEnv" $root | nindent 2 -}}
 {{- include "lakerunner.goRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
-{{- include "lakerunner.tracesEnv" $root | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
 {{- with $root.Values.global.env -}}
 {{ toYaml . | nindent 2 -}}
 {{- end -}}
@@ -257,7 +275,7 @@ Usage:
 {{- $comp := index . 1 -}}
 {{- include "lakerunner.commonEnv" $root | nindent 2 -}}
 {{- include "lakerunner.duckdbRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
-{{- include "lakerunner.tracesEnv" $root | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
 {{- with $root.Values.global.env -}}
 {{ toYaml . | nindent 2 -}}
 {{- end -}}
@@ -1041,7 +1059,7 @@ Usage:
 {{- $comp := index . 1 -}}
 {{- include "lakerunner.commonEnv" $root | nindent 2 -}}
 {{- include "lakerunner.queryWorkerRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
-{{- include "lakerunner.tracesEnv" $root | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
 {{- with $root.Values.global.env -}}
 {{ toYaml . | nindent 2 -}}
 {{- end -}}

--- a/lakerunner/tests/trace-sampling_test.yaml
+++ b/lakerunner/tests/trace-sampling_test.yaml
@@ -1,0 +1,95 @@
+suite: test OpenTelemetry trace sampling configuration
+values:
+  - ../values.yaml
+set:
+  cloudProvider.aws.region: us-west-2
+  license.data: '{"key":"test"}'
+templates:
+  - query-api-deployment.yaml
+  - query-worker-deployment.yaml
+  - process-logs-deployment.yaml
+tests:
+  - it: applies global trace sampling defaults to all components
+    asserts:
+      - template: query-api-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.01"
+      - template: query-worker-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.01"
+      - template: process-logs-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.01"
+
+  - it: per-component override wins over global for query-api only
+    set:
+      queryApi.monitoring.traces.arg: "1.0"
+    asserts:
+      - template: query-api-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "1.0"
+      - template: query-worker-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.01"
+      - template: process-logs-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.01"
+
+  - it: per-component override applies to query-worker independently
+    set:
+      queryWorker.monitoring.traces.arg: "0.5"
+      queryWorker.monitoring.traces.sampler: "traceidratio"
+    asserts:
+      - template: query-worker-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER
+            value: "traceidratio"
+      - template: query-worker-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.5"
+      - template: query-api-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER
+            value: "parentbased_traceidratio"
+
+  - it: component override of only arg keeps global sampler
+    set:
+      queryApi.monitoring.traces.arg: "0.25"
+    asserts:
+      - template: query-api-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER
+            value: "parentbased_traceidratio"
+      - template: query-api-deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "0.25"

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -759,6 +759,13 @@ queryApi:
   tolerations: []
   affinity: {}
   env: []
+  # Per-component override of global.monitoring.traces. Any keys set here
+  # win over the global values; unset keys fall back to the global config.
+  # Example:
+  #   monitoring:
+  #     traces:
+  #       arg: "1.0"   # 100% sampling for query-api only
+  monitoring: {}
 
 # Query Worker configuration
 queryWorker:
@@ -789,6 +796,13 @@ queryWorker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Per-component override of global.monitoring.traces. Any keys set here
+  # win over the global values; unset keys fall back to the global config.
+  # Example:
+  #   monitoring:
+  #     traces:
+  #       arg: "0.5"   # 50% sampling for query-worker only
+  monitoring: {}
 
 # Grafana configuration
 grafana:


### PR DESCRIPTION
## Summary
- Add optional `<component>.monitoring.traces.{sampler,arg}` override that wins over `global.monitoring.traces` for that component only
- Merge semantics: a partial override (e.g. `arg` only) keeps the global `sampler`
- Documented the knob on `queryApi` and `queryWorker` in `values.yaml`; available to every component that goes through `injectEnv*` helpers
- Bumps chart to 3.7.4

## Test plan
- [x] `helm lint lakerunner`
- [x] `helm unittest lakerunner` (290 tests pass, including 4 new trace-sampling cases)
- [x] `helm template` rendering verified: query-api/query-worker emit overridden `OTEL_TRACES_SAMPLER_ARG` while every other component keeps the global default