### PR TITLE
maestro: chart 0.7.0, require a license

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.6.14"
+version: "0.7.0"
 appVersion: "v1.17.1"
 keywords:
   - maestro

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -156,6 +156,52 @@ Return the secret name for the Cardinal API key.
 {{- end }}
 
 {{/*
+Validate license configuration. Called from license-validation.yaml to fail early.
+*/}}
+{{- define "maestro.validateLicense" -}}
+{{- if .Values.license.create }}
+{{- if not .Values.license.data }}
+{{- fail "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName." }}
+{{- end }}
+{{- else }}
+{{- if not .Values.license.secretName }}
+{{- fail "license.secretName is required when license.create is false. Provide the name of an existing Kubernetes secret containing the license." }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the license. If create is true, prefix with release name.
+*/}}
+{{- define "maestro.licenseSecretName" -}}
+{{- if .Values.license.create }}
+{{- printf "%s-%s" (include "maestro.fullname" .) .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+License volume mount. Always emitted — license is required.
+Usage: {{ include "maestro.licenseVolumeMount" . }}
+*/}}
+{{- define "maestro.licenseVolumeMount" -}}
+- name: license
+  mountPath: /app/license
+  readOnly: true
+{{- end }}
+
+{{/*
+License volume. Always emitted — license is required.
+Usage: {{ include "maestro.licenseVolume" . }}
+*/}}
+{{- define "maestro.licenseVolume" -}}
+- name: license
+  secret:
+    secretName: {{ include "maestro.licenseSecretName" . }}
+{{- end }}
+
+{{/*
 OTLP env vars pointing at CardinalHQ's hosted intake. Emits nothing when
 global.cardinal.apiKey is empty, so existing installs without telemetry
 configuration are unaffected (and chart-test env-index assertions stay

--- a/maestro/templates/license-secret.yaml
+++ b/maestro/templates/license-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.license.create .Values.license.data -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "maestro.licenseSecretName" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  license.json: {{ .Values.license.data | b64enc | quote }}
+{{- end }}

--- a/maestro/templates/license-validation.yaml
+++ b/maestro/templates/license-validation.yaml
@@ -1,0 +1,5 @@
+{{/*
+License validation — ensures a valid license configuration is provided.
+This template renders nothing but fails early if the license is misconfigured.
+*/}}
+{{- include "maestro.validateLicense" . -}}

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -193,6 +193,7 @@ spec:
         - name: data
           mountPath: {{ .Values.maestro.persistence.mountPath | default "/var/lib/maestro" | quote }}
         {{- end }}
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
         {{- with .Values.maestro.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -243,6 +244,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "maestro.fullname" . }}-data
       {{- end }}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
       {{- if dig "tls" "enabled" false .Values.maestro }}
       - name: tls
         {{- $tlsSecret := include "maestro.tlsResolvedSecretName" . }}

--- a/maestro/templates/mcp-gateway-deployment.yaml
+++ b/maestro/templates/mcp-gateway-deployment.yaml
@@ -55,6 +55,10 @@ spec:
         resources:
           {{- toYaml .Values.mcpGateway.resources | nindent 10 }}
         {{- end }}
+        volumeMounts:
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
       {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector .Values.mcpGateway.nodeSelector) | nindent 6 }}
       {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  .Values.mcpGateway.tolerations)  | nindent 6 }}
       {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.mcpGateway.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "maestro.licenseVolume" . | nindent 6 }}

--- a/maestro/tests/license_test.yaml
+++ b/maestro/tests/license_test.yaml
@@ -1,0 +1,133 @@
+suite: test license configuration
+set:
+  database.host: db.example.com
+templates:
+  - license-secret.yaml
+  - license-validation.yaml
+  - maestro-deployment.yaml
+  - mcp-gateway-deployment.yaml
+tests:
+  # Secret creation tests
+  - it: creates the license secret when create is true and data is provided
+    set:
+      license.create: true
+      license.data: "license-content"
+    templates:
+      - license-secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-maestro-maestro-license
+      - equal:
+          path: data["license.json"]
+          value: bGljZW5zZS1jb250ZW50
+
+  - it: fails when create is true but data is empty
+    set:
+      license.create: true
+      license.data: ""
+    templates:
+      - license-validation.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName."
+
+  - it: fails with default values (create true, no data)
+    templates:
+      - license-validation.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName."
+
+  - it: does not create license secret when create is false
+    set:
+      license.create: false
+      license.secretName: "my-external-license"
+    templates:
+      - license-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when create is false and secretName is empty
+    set:
+      license.create: false
+      license.secretName: ""
+    templates:
+      - license-validation.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "license.secretName is required when license.create is false. Provide the name of an existing Kubernetes secret containing the license."
+
+  # Volume mount tests — maestro container
+  - it: mounts the license volume into the maestro container
+    set:
+      license.data: "license-content"
+    templates:
+      - maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: license
+            mountPath: /app/license
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: RELEASE-NAME-maestro-maestro-license
+
+  # Volume mount tests — mcp-gateway container
+  - it: mounts the license volume into the mcp-gateway container
+    set:
+      license.data: "license-content"
+    templates:
+      - mcp-gateway-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: license
+            mountPath: /app/license
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: RELEASE-NAME-maestro-maestro-license
+
+  # BYOS — exact secret name when create is false
+  - it: uses the exact secret name when create is false (BYOS)
+    set:
+      license.create: false
+      license.secretName: "my-external-license"
+    templates:
+      - maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: my-external-license
+
+  # Prefixed secret name when create is true
+  - it: prefixes the secret name when create is true
+    set:
+      license.create: true
+      license.secretName: "custom-license"
+      license.data: "license-content"
+    templates:
+      - mcp-gateway-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: RELEASE-NAME-maestro-custom-license

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -179,6 +179,21 @@ mcpGateway:
   affinity: {}
   env: []
 
+# License configuration
+# A valid license is required for Maestro to operate.
+# The license secret is mounted to /app/license in the maestro and
+# mcp-gateway containers.
+license:
+  # Whether to create the license secret from the data below.
+  # Set to false to use an existing secret (BYOS).
+  create: true
+  # Name of the Kubernetes secret containing the license.
+  # Used whether create is true or false.
+  secretName: "maestro-license"
+  # Raw license.json content (only used when create: true).
+  # The content will be stored under the key "license.json" in the secret.
+  data: ""
+
 # Database configuration
 # Required.
 database:


### PR DESCRIPTION
## Summary
- Add a license requirement to the maestro chart, using the same mechanism as lakerunner
- New top-level \`license\` block in \`values.yaml\` (\`create\`, \`secretName\`, \`data\`)
- Helpers added: \`maestro.validateLicense\`, \`maestro.licenseSecretName\`, \`maestro.licenseVolume\`, \`maestro.licenseVolumeMount\`
- New \`templates/license-secret.yaml\` (renders only when \`create=true\` and \`data\` is non-empty) and \`templates/license-validation.yaml\` (fails fast with a clear message when misconfigured)
- License secret mounted at \`/app/license\` in both maestro and mcp-gateway pods (Dex is upstream and is intentionally not mounted)
- Chart bumped to \`0.7.0\` (minor: breaking change for existing installs)

## Breaking change
Existing maestro installs will fail \`helm upgrade\` until one of:
- \`--set-file license.data=license.json\` (chart creates the secret), or
- \`--set license.create=false --set license.secretName=<existing-secret>\` (BYOS)

This matches the behavior already in place for lakerunner.

## Test plan
- [x] \`helm lint maestro\`
- [x] \`helm unittest maestro\` — 57/57 pass, including 9 new license cases (secret creation, fail-when-misconfigured, BYOS, prefixed names, volume + mount on both deployments)
- [x] \`helm template\` rendering verified: validation fails with a clear message when license is unset; passes and produces a Secret + mounts when \`license.data\` is provided