### PR TITLE
maestro: chart 0.7.1, appVersion v1.17.2

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.0"
-appVersion: "v1.17.1"
+version: "0.7.1"
+appVersion: "v1.17.2"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump maestro chart appVersion to v1.17.2 (Logs explore page-load perf fixes + metrics work).

No template / values surface changes — chart bump is for appVersion tracking only.