### PR TITLE
maestro: chart 0.7.2, appVersion v1.18.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.1"
-appVersion: "v1.17.2"
+version: "0.7.2"
+appVersion: "v1.18.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
## Summary

Bump maestro Helm chart to track release `maestro/v1.18.0`.

- `appVersion: v1.17.2 → v1.18.0`
- `version: 0.7.1 → 0.7.2`

## What ships in v1.18.0

- conductor#539 — license-driven OTel config for maestro and mcp-gateway
- conductor#540 — Java/Kotlin (JVM) cluster adapter for KG harvester

## Test plan

- [ ] PR merged
- [ ] Chart published to `oci://public.ecr.aws/cardinalhq.io` after merge
- [ ] kubernetes-clusters values bumped to deploy v1.18.0