### PR TITLE
lakerunner: chart 3.8.0, perch local-maestro API key

### DIFF
--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.8.0
+
+* **NEW**: Optional `perch.maestro.apiKey.existingSecret` value for self-hosted
+  topologies that need a separate API key for the local maestro
+  - Required when `perch.maestro.url` is NOT `https://app.cardinalhq.io`
+  - Wires `MAESTRO_API_KEY` env var into the perch container via `secretKeyRef`
+  - Works in conjunction with the lakerunner change that sends version reports
+    to CardinalHQ and collector inventory to the local maestro
+  - When unset, perch falls back to the license-derived key (preserves
+    behavior for SaaS-only deployments)
+  - Requires lakerunner image with the matching split-traffic change
+
 ## 0.4.0
 
 * **NEW**: Simplified Grafana Cardinal datasource configuration

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.7.4"
-appVersion: "v1.19.3"
+version: "3.8.0"
+appVersion: "v1.20.1"
 keywords:
   - lakerunner
   - logs

--- a/lakerunner/templates/perch-deployment.yaml
+++ b/lakerunner/templates/perch-deployment.yaml
@@ -54,6 +54,13 @@ spec:
                 fieldPath: status.podIP
           - name: OTEL_SERVICE_NAME
             value: {{ include "lakerunner.fullname" . }}-perch
+          {{- if .Values.perch.maestro.apiKey.existingSecret }}
+          - name: MAESTRO_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.perch.maestro.apiKey.existingSecret }}
+                key: {{ .Values.perch.maestro.apiKey.existingSecretKey }}
+          {{- end }}
           {{- include "lakerunner.injectEnv" (list . .Values.perch) | nindent 8 }}
           {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
         {{- include "lakerunner.healthProbes" (list . .Values.perch) | nindent 8 }}

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -544,8 +544,22 @@ perch:
   # Cluster identifier (auto-derived from kube-system UID if empty)
   clusterId: ""
   maestro:
+    # URL of the local maestro (used for collector inventory + config-body
+    # uploads). Version reports always go to the central CardinalHQ-hosted
+    # maestro at https://app.cardinalhq.io and don't need to be configured.
+    # For SaaS-only deployments, set this to https://app.cardinalhq.io.
     url: ""
     reportInterval: "5m"
+    # API key for the local maestro. Required when url is NOT
+    # https://app.cardinalhq.io — the local maestro recognizes a different
+    # set of keys than the license-issuing CardinalHQ maestro. Provision a
+    # key in the local maestro UI (Settings → Integrations → Lakerunner),
+    # store the plaintext in a Kubernetes Secret, and reference it here.
+    # When unset, perch falls back to the license-derived key (correct for
+    # SaaS-only deployments where url == https://app.cardinalhq.io).
+    apiKey:
+      existingSecret: ""
+      existingSecretKey: "api-key"
   registry:
     pollInterval: "10m"
   # Components to track — upstream repos and update policies are configured


### PR DESCRIPTION
## Summary

Adds `perch.maestro.apiKey.existingSecret` + `existingSecretKey` values that wire `MAESTRO_API_KEY` into the perch container via `secretKeyRef`. Required when `perch.maestro.url` is NOT `https://app.cardinalhq.io` — the local maestro recognizes a different set of keys than the license-issuing CardinalHQ maestro, so perch needs a separate locally-minted key for collector inventory uploads.

Bumps `appVersion` to `v1.20.1` which contains the matching lakerunner change ([cardinalhq/lakerunner#671](https://github.com/cardinalhq/lakerunner/pull/671)) — perch now sends version reports to CardinalHQ and collector inventory to the local maestro.

## How customers use it

```yaml
perch:
  maestro:
    url: "http://maestro.<their-maestro-ns>.svc.cluster.local:4200"
    apiKey:
      existingSecret: "perch-local-maestro-key"   # contains key "api-key"
```

```bash
kubectl create secret generic perch-local-maestro-key \
  --from-literal=api-key=<plaintext from local maestro UI>
```

## Test plan

- [x] `helm template` renders correctly when `apiKey.existingSecret` is set (env var injected)
- [x] `helm template` renders correctly when unset (env var omitted, license-fallback path)
- [ ] Customer with split topology confirms collector inventory lands in their local maestro after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)