### PR TITLE
lakerunner: rebalance worker pod memory math + MALLOC_ARENA_MAX

### DIFF
--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 3.9.0
+
+* **CHANGED**: Rebalanced worker pod memory math (process-logs, process-metrics, process-traces)
+  - Replaced `LAKERUNNER_DUCKDB_MEMORY_LIMIT = container - 1Gi` (constant carve-out) with
+    `LAKERUNNER_DUCKDB_MEMORY_LIMIT = 40% of container` (percentage-based, floor 512 MB)
+  - Replaced `GOMEMLIMIT = 750MiB` (constant) with `GOMEMLIMIT = 20% of container`,
+    clamped to `[256, 1024]` MiB
+  - Reserves ~40% of the container for cgo allocator overhead, DuckDB peak overshoot,
+    and transient allocations not tracked by DuckDB's `memory_limit`. Empirically
+    real RSS overshoots `memory_limit` ~2× under heavy hash builds / sorts.
+  - Operators with explicit overrides for `LAKERUNNER_DUCKDB_MEMORY_LIMIT` or `GOMEMLIMIT`
+    are unaffected (existing `hasEnvVar` guard).
+* **NEW**: `MALLOC_ARENA_MAX=2` injected by `duckdbRuntimeEnv` and `queryWorkerRuntimeEnv`
+  - Collapses glibc per-thread arena fragmentation for cgo-heavy DuckDB workloads
+  - Measured impact: process-metrics RSS dropped from 3.3 GiB → 1.25 GiB on a primed
+    pod with no other change; eliminated 64-MiB sub-heap fragmentation pattern in
+    `/proc/<pid>/smaps`
+  - Operators may override per-component or in `global.env`
+
 ## 3.8.0
 
 * **NEW**: Optional `perch.maestro.apiKey.existingSecret` value for self-hosted

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.8.0"
+version: "3.9.0"
 appVersion: "v1.20.1"
 keywords:
   - lakerunner

--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -939,11 +939,22 @@ Usage: {{ include "lakerunner.goRuntimeEnv" (list . .Values.componentName .Value
 {{/*
 Generate DuckDB-specific runtime environment variables for ingest/compact/rollup services.
 These services use DuckDB internally and need specific memory tuning.
+
+Memory budget split (worker pods):
+  duckdb_memory_limit  ≈ 40% of container memory
+  go_runtime_budget    ≈ 20% of container memory  (clamped 256–1024 MiB)
+  reserved             ≈ 40% (cgo allocator overhead, DuckDB peak overshoot,
+                              transient allocations not tracked by DuckDB's
+                              memory_limit). Empirically RSS overshoots
+                              memory_limit ~2× under hash builds/sorts.
+
 Settings:
-  - GOMEMLIMIT = 750MiB (fixed, leaves room for DuckDB)
+  - GOMEMLIMIT = clamp(20% of container, 256MiB..1024MiB)
   - GOGC = 100 (fixed)
-  - LAKERUNNER_DUCKDB_MEMORY_LIMIT = scaled based on container memory
+  - LAKERUNNER_DUCKDB_MEMORY_LIMIT = 40% of container, in MB (min 512)
   - LAKERUNNER_DUCKDB_TEMP_DIRECTORY = /scratch
+  - MALLOC_ARENA_MAX = 2 (collapses glibc per-thread arena fragmentation
+                          for cgo-heavy DuckDB workloads)
 Takes three args:
   0: the root chart context
   1: the component's values block (must have .resources.limits.memory)
@@ -961,32 +972,39 @@ Usage: {{ include "lakerunner.duckdbRuntimeEnv" (list . .Values.componentName .V
 {{- end -}}
 {{- if $memLimit -}}
   {{- $bytes := include "lakerunner.parseMemoryToBytes" $memLimit | int64 -}}
+  {{- $oneMiB := 1048576 -}}
+  {{- $totalMiB := divf $bytes $oneMiB | int64 -}}
   {{- $hasGomemlimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOMEMLIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOMEMLIMIT")) "true") -}}
   {{- $hasGogc := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOGC")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOGC")) "true") -}}
   {{- $hasDuckdbMemLimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") -}}
   {{- $hasDuckdbTempDir := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") -}}
+  {{- $hasMallocArenaMax := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "MALLOC_ARENA_MAX")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "MALLOC_ARENA_MAX")) "true") -}}
 {{- if not $hasGomemlimit }}
+{{- /* GOMEMLIMIT = 20% of container, clamped to [256, 1024] MiB */}}
+{{- $gomemlimitMiB := mulf $totalMiB 0.20 | int64 -}}
+{{- if lt $gomemlimitMiB 256 -}}{{- $gomemlimitMiB = 256 -}}{{- end -}}
+{{- if gt $gomemlimitMiB 1024 -}}{{- $gomemlimitMiB = 1024 -}}{{- end }}
 - name: GOMEMLIMIT
-  value: "750MiB"
+  value: {{ printf "%dMiB" $gomemlimitMiB | quote }}
 {{- end }}
 {{- if not $hasGogc }}
 - name: GOGC
   value: "100"
 {{- end }}
 {{- if not $hasDuckdbMemLimit }}
-{{- /* Calculate DuckDB memory: total - 1GiB for Go/OS, in MB */}}
-{{- $oneGiB := 1073741824 -}}
-{{- $duckdbBytes := sub $bytes $oneGiB -}}
-{{- if lt $duckdbBytes 536870912 -}}
-{{- $duckdbBytes = 536870912 -}}
-{{- end -}}
-{{- $duckdbMB := divf $duckdbBytes 1048576 | int64 }}
+{{- /* DuckDB target = 40% of container, in MB; floor 512 MB */}}
+{{- $duckdbMB := mulf $totalMiB 0.40 | int64 -}}
+{{- if lt $duckdbMB 512 -}}{{- $duckdbMB = 512 -}}{{- end }}
 - name: LAKERUNNER_DUCKDB_MEMORY_LIMIT
   value: {{ $duckdbMB | quote }}
 {{- end }}
 {{- if not $hasDuckdbTempDir }}
 - name: LAKERUNNER_DUCKDB_TEMP_DIRECTORY
   value: "/scratch"
+{{- end }}
+{{- if not $hasMallocArenaMax }}
+- name: MALLOC_ARENA_MAX
+  value: "2"
 {{- end }}
 {{- end -}}
 {{- end -}}
@@ -998,6 +1016,8 @@ Settings:
   - GOMEMLIMIT = 75% of the remaining 50% (37.5% of total)
   - GOGC = calculated based on total memory
   - LAKERUNNER_DUCKDB_TEMP_DIRECTORY = /scratch
+  - MALLOC_ARENA_MAX = 2 (cgo-heavy DuckDB workload — collapses glibc
+                          per-thread arena fragmentation)
 Takes three args:
   0: the root chart context
   1: the component's values block (must have .resources.limits.memory)
@@ -1021,6 +1041,7 @@ Usage: {{ include "lakerunner.queryWorkerRuntimeEnv" (list . .Values.queryWorker
   {{- $hasGogc := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOGC")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOGC")) "true") -}}
   {{- $hasDuckdbMemLimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") -}}
   {{- $hasDuckdbTempDir := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") -}}
+  {{- $hasMallocArenaMax := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "MALLOC_ARENA_MAX")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "MALLOC_ARENA_MAX")) "true") -}}
 {{- if not $hasGomemlimit }}
 {{- /* GOMEMLIMIT = 75% of half the memory = 37.5% of total */}}
 {{- $halfMiB := divf $totalMiB 2 | int64 -}}
@@ -1041,6 +1062,10 @@ Usage: {{ include "lakerunner.queryWorkerRuntimeEnv" (list . .Values.queryWorker
 {{- if not $hasDuckdbTempDir }}
 - name: LAKERUNNER_DUCKDB_TEMP_DIRECTORY
   value: "/scratch"
+{{- end }}
+{{- if not $hasMallocArenaMax }}
+- name: MALLOC_ARENA_MAX
+  value: "2"
 {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary
Two changes to `templates/_helpers.tpl` for ingest/compact/rollup workers (process-logs, process-metrics, process-traces) and query-worker. Both motivated by today's prod OOM investigation in `aws-prod-us-east-2-global`.

### 1. Replace constant `1Gi` carve-out with percentage-based formula (workers)

Old `duckdbRuntimeEnv` math:
- `LAKERUNNER_DUCKDB_MEMORY_LIMIT = container - 1Gi` (constant carve-out)
- `GOMEMLIMIT = 750MiB` (fixed)

Problem: doesn't scale. At 2 GiB container, DuckDB=1 GiB and ~1 GiB headroom for everything else (worked). At 4 GiB, DuckDB=3 GiB and **still only ~1 GiB headroom** — but DuckDB was given 3× the budget. Empirically DuckDB's RSS overshoots its `memory_limit` by ~2× under heavy hash builds / sorts (we measured MaxRSS = 3.99 GiB on a 4 GiB container with `LAKERUNNER_DUCKDB_MEMORY_LIMIT=2048`). Result: pods with high workload variance OOM.

New math:
- `LAKERUNNER_DUCKDB_MEMORY_LIMIT = 40% of container` (floor 512 MB)
- `GOMEMLIMIT = clamp(20% of container, 256MiB..1024MiB)`
- Reserves ~40% of the container for cgo allocator overhead + DuckDB peak overshoot + Go RSS over GOMEMLIMIT (it's a soft target).

| Container | DuckDB MB | GOMEMLIMIT | Reserved |
|---|---|---|---|
| 1 GiB | 512 (floor) | 256 MiB (clamp) | ~256 MiB |
| 2 GiB | 819 | 409 MiB | ~796 MiB |
| 4 GiB | 1638 | 819 MiB | ~1635 MiB |
| 8 GiB | 3276 | 1024 MiB (clamp) | ~3892 MiB |

`queryWorker` keeps its existing 50/37.5% split — that path is closer to right and has lower observed peak overshoot.

### 2. Inject `MALLOC_ARENA_MAX=2` (both helpers)

DuckDB allocates heavily through cgo/glibc malloc. Default glibc creates one arena per CPU (with thread-local growth) and each arena can balloon to 64 MiB+ from cgo churn. We measured **116 anonymous mappings totalling 3.2 GiB RSS while Go heap was 78 MiB** — classic glibc multi-arena fragmentation.

Setting `MALLOC_ARENA_MAX=2` collapsed RSS from **3.3 GiB → 1.25 GiB** on a primed pod with no other change. The 64-MiB sub-heap fragmentation pattern in `/proc/<pid>/smaps` disappeared (1 consolidated heap + a handful of small anon mappings).

Workers run at GOMAXPROCS=1, so the contention cost of fewer arenas is zero.

## Backward compat
Both helpers preserve the existing `hasEnvVar` guard pattern. Operators with explicit `LAKERUNNER_DUCKDB_MEMORY_LIMIT`, `GOMEMLIMIT`, or `MALLOC_ARENA_MAX` overrides (per-component or `global.env`) are unaffected.

## Test plan
- [x] `make test` (helm lint + unittest, 290 tests) passes
- [x] Spot-checked rendered env at 1/2/4/8 GiB sizes; numbers match table above
- [x] Verified via prod test: kubernetes-clusters PR cardinalhq/kubernetes-clusters#94 applied the equivalent values directly to `aws-prod-us-east-2-global` (DuckDB=1536, MALLOC_ARENA_MAX=2). After rollout: 10/10 pods, 0 restarts, top RSS 2846 MiB (vs. baseline 4055 MiB pre-tuning, with OOMs).

## Bumps
Chart: `3.8.0` → `3.9.0`.