### PR TITLE
maestro: chart 0.7.12, appVersion v1.18.30

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.11"
-appVersion: "v1.18.29"
+version: "0.7.12"
+appVersion: "v1.18.30"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.18.30 release (kubernetes tag in TOOL_TAGS + auto-stamp X-Kube-* on agent calls).