### PR TITLE
lakerunner: chart 3.9.1, appVersion v1.20.3

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.9.0"
-appVersion: "v1.20.1"
+version: "3.9.1"
+appVersion: "v1.20.3"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
## Summary

Bumps lakerunner image to `v1.20.3` (from `v1.20.1`). No chart-shape changes; appVersion-only bump.

Notable in v1.20.2..v1.20.3:
- `duckdbx`: per-workload memory probe with signal/action attribution ([cardinalhq/lakerunner#682](https://github.com/cardinalhq/lakerunner/pull/682))
- `debug`: `--profile` for ingest, per-span peak RSS report ([#683](https://github.com/cardinalhq/lakerunner/pull/683))
- `ci`: disable osv-scanner (the duckdb-go CGo issue we hit before) ([#679](https://github.com/cardinalhq/lakerunner/pull/679))
- `metric_descriptions`: per-metric `label_names` served from `/metrics/tags` ([#675](https://github.com/cardinalhq/lakerunner/pull/675))
- Remove legacy `c_*` table dependencies from configdb ([#674](https://github.com/cardinalhq/lakerunner/pull/674))

## Test plan

- [x] `helm template` still renders cleanly (no shape changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)