### PR TITLE
maestro: chart 0.7.14, appVersion v1.19.1

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.13"
-appVersion: "v1.18.32"
+version: "0.7.14"
+appVersion: "v1.19.1"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.19.1 release (kube events modal entry-step fix + agent X-Kube-* via static headers).