### PR TITLE
griffin-commerce-demo: chart 0.1.0, appVersion v0.3.0

### DIFF
--- a/griffin-commerce-demo/Chart.yaml
+++ b/griffin-commerce-demo/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: griffin-commerce-demo
+description: A Helm chart for the Griffin Commerce demo application
+type: application
+version: "0.1.0"
+appVersion: "v0.3.0"
+keywords:
+  - griffin
+  - demo
+  - commerce
+  - cardinalhq
+home: https://github.com/cardinalhq/griffin-commerce-demo
+maintainers:
+  - name: Cardinal HQ
+    email: support@cardinalhq.com

--- a/griffin-commerce-demo/Makefile
+++ b/griffin-commerce-demo/Makefile
@@ -1,0 +1,93 @@
+# Makefile for griffin-commerce-demo Helm Chart Testing
+
+CHART_NAME := griffin-commerce-demo
+TEST_RELEASE_NAME := test-release
+
+.PHONY: help test check lint template unittest clean package publish verify-icon
+
+help:  ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+test: lint template unittest verify-icon  ## Run all tests (Layer 1 + Layer 2)
+
+check: test  ## Alias for test - run lints and tests
+
+lint:  ## Run helm lint on the chart
+	@echo "Linting $(CHART_NAME) chart..."
+	helm lint .
+
+template:  ## Test template rendering with various configurations
+	@helm template $(TEST_RELEASE_NAME) . --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set image.tag=v1.2.3 --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set ingress.enabled=false --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set ingress.host=griffin.example.com --set ingress.className=nginx --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set otel.endpoint=http://otel-collector.observability.svc.cluster.local:4318 --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set otel.useHostIp=true --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set chaos.enabled=true --dry-run > /dev/null 2>&1
+	@helm template $(TEST_RELEASE_NAME) . --set chaos.enabled=true --set otel.endpoint=http://otel:4318 --dry-run > /dev/null 2>&1
+
+unittest:  ## Run helm unittest tests
+	@echo "Running unit tests..."
+	@if [ -d tests ] && [ -n "$$(ls tests/*_test.yaml 2>/dev/null)" ]; then \
+		helm unittest .; \
+	else \
+		echo "No unit tests found"; \
+	fi
+
+verify-icon:  ## Verify chart icon URL is accessible
+	@echo "Verifying chart icon URL..."
+	@ICON_URL=$$(yq e '.icon' Chart.yaml); \
+	if [ -z "$$ICON_URL" ] || [ "$$ICON_URL" = "null" ]; then \
+		echo "Warning: No icon URL defined in Chart.yaml"; \
+	else \
+		HTTP_CODE=$$(curl -s -o /dev/null -w "%{http_code}" --head "$$ICON_URL"); \
+		if [ "$$HTTP_CODE" = "200" ]; then \
+			echo "Icon URL verified: $$ICON_URL"; \
+		else \
+			echo "Error: Icon URL returned HTTP $$HTTP_CODE: $$ICON_URL"; \
+			exit 1; \
+		fi \
+	fi
+
+clean:  ## Clean up test artifacts and packaged charts
+	@echo "Cleaning up test artifacts and packaged charts..."
+	rm -f *.tgz
+	rm -rf charts/ $(OUT_DIR)/
+
+# Development helpers
+template-debug:  ## Render templates and show output for debugging
+	@echo "Rendering templates for debugging..."
+	helm template $(TEST_RELEASE_NAME) . --debug
+
+template-save:  ## Save rendered templates to file for inspection
+	@echo "Saving rendered templates to $(CHART_NAME)-rendered.yaml..."
+	helm template $(TEST_RELEASE_NAME) . > $(CHART_NAME)-rendered.yaml
+	@echo "Templates saved to $(CHART_NAME)-rendered.yaml"
+
+test-with-values:  ## Test with custom values file (usage: make test-with-values VALUES_FILE=my-values.yaml)
+ifndef VALUES_FILE
+	@echo "Please specify VALUES_FILE=<path-to-values-file>"
+	@exit 1
+endif
+	@echo "Testing with custom values file: $(VALUES_FILE)"
+	helm lint . --values $(VALUES_FILE)
+	helm template $(TEST_RELEASE_NAME) . --values $(VALUES_FILE) --dry-run > /dev/null 2>&1
+	@echo "Template rendering successful with $(VALUES_FILE)"
+
+# Chart packaging and publishing
+REGISTRY := public.ecr.aws/cardinalhq.io
+CHART_VERSION := $(shell yq e '.version' Chart.yaml)
+OUT_DIR := packages
+
+package:  ## Package the chart for distribution
+	@echo "Packaging $(CHART_NAME) chart version $(CHART_VERSION)..."
+	@mkdir -p $(OUT_DIR)
+	helm package . --destination $(OUT_DIR)
+	@echo "Chart packaged: $(OUT_DIR)/$(CHART_NAME)-$(CHART_VERSION).tgz"
+
+publish: package  ## Package and publish chart to ECR registry (assumes you're already logged in)
+	@echo "Publishing $(CHART_NAME) chart version $(CHART_VERSION) to $(REGISTRY)..."
+	helm push "$(OUT_DIR)/$(CHART_NAME)-$(CHART_VERSION).tgz" "oci://$(REGISTRY)"
+	@echo "Chart published successfully!"
+	@echo "To install: helm install my-release oci://$(REGISTRY)/$(CHART_NAME) --version $(CHART_VERSION)"

--- a/griffin-commerce-demo/templates/_helpers.tpl
+++ b/griffin-commerce-demo/templates/_helpers.tpl
@@ -1,0 +1,161 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "griffin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "griffin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label string.
+*/}}
+{{- define "griffin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "griffin.labels" -}}
+helm.sh/chart: {{ include "griffin.chart" . }}
+app.kubernetes.io/name: {{ include "griffin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Resolve the container image: image.repository:image.tag, falling back to
+.Chart.appVersion when image.tag is empty.
+*/}}
+{{- define "griffin.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Render imagePullSecrets when any are set.
+*/}}
+{{- define "griffin.imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Static list of backend services. Defined here (rather than in values) so
+operators don't accidentally drop or rename a service the demo's inter-
+service URLs depend on. Each entry: name, port, optional extraEnv, and
+optional resources override (defaults match the kustomize base).
+*/}}
+{{- define "griffin.backends" -}}
+- name: catalog
+  port: 8080
+- name: payment
+  port: 8081
+- name: cart
+  port: 8082
+  extraEnv:
+    - name: CATALOG_SERVICE_URL
+      value: "http://catalog:8080"
+- name: images
+  port: 8083
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "300m"
+- name: shipping
+  port: 8084
+- name: recommendations
+  port: 8085
+  extraEnv:
+    - name: CATALOG_SERVICE_URL
+      value: "http://catalog:8080"
+{{- end -}}
+
+{{/*
+Default backend resources, used when a backend entry omits its own
+resources override.
+*/}}
+{{- define "griffin.defaultBackendResources" -}}
+requests:
+  memory: "128Mi"
+  cpu: "50m"
+limits:
+  memory: "256Mi"
+  cpu: "200m"
+{{- end -}}
+
+{{/*
+OTLP env vars for a single backend. Args: dict with `root` and `name`.
+Emits nothing when no telemetry source is configured.
+*/}}
+{{- define "griffin.otelEnv" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $otel := $root.Values.otel | default dict -}}
+{{- $endpoint := "" -}}
+{{- if $otel.useHostIp -}}
+{{- $endpoint = "http://$(HOST_IP):4318" -}}
+{{- else if $otel.endpoint -}}
+{{- $endpoint = $otel.endpoint -}}
+{{- end -}}
+{{- if $endpoint }}
+{{- if $otel.useHostIp }}
+- name: HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+{{- end }}
+- name: OTEL_SERVICE_NAME
+  value: {{ $name | quote }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ $endpoint | quote }}
+- name: OTEL_INSECURE
+  value: {{ $otel.insecure | default false | quote }}
+{{- if $root.Values.chaos.enabled }}
+- name: OTEL_METRIC_EXPORT_INTERVAL
+  value: {{ $root.Values.chaos.metricExportIntervalMs | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chaos env vars for a single backend. Emits nothing when chaos is off.
+Args: dict with `root` and `name`.
+*/}}
+{{- define "griffin.chaosEnv" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- if $root.Values.chaos.enabled }}
+- name: CONTROLPLANE_URL
+  value: "http://controlplane:8086"
+{{- if eq $name "recommendations" }}
+- name: RECS_REFRESH_INTERVAL
+  value: {{ $root.Values.chaos.recsRefreshInterval | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/griffin-commerce-demo/templates/backends.yaml
+++ b/griffin-commerce-demo/templates/backends.yaml
@@ -1,0 +1,73 @@
+{{- $root := . -}}
+{{- range (include "griffin.backends" . | fromYamlArray) }}
+{{- $svc := . }}
+{{- $resources := $svc.resources | default (include "griffin.defaultBackendResources" $root | fromYaml) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $svc.name }}
+  labels:
+    {{- include "griffin.labels" $root | nindent 4 }}
+    app: {{ $svc.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $svc.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $svc.name }}
+    spec:
+      {{- include "griffin.imagePullSecrets" $root | nindent 6 }}
+      securityContext:
+        {{- toYaml $root.Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ $svc.name }}
+          image: {{ include "griffin.image" $root | quote }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ $svc.port }}
+          env:
+            - name: SERVICE_NAME
+              value: {{ $svc.name | quote }}
+            - name: PORT
+              value: {{ $svc.port | quote }}
+            {{- with $svc.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- include "griffin.otelEnv" (dict "root" $root "name" $svc.name) | nindent 12 }}
+            {{- include "griffin.chaosEnv" (dict "root" $root "name" $svc.name) | nindent 12 }}
+          securityContext:
+            {{- toYaml $root.Values.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml $resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ $svc.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ $svc.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $svc.name }}
+  labels:
+    {{- include "griffin.labels" $root | nindent 4 }}
+    app: {{ $svc.name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $svc.name }}
+  ports:
+    - port: {{ $svc.port }}
+      targetPort: {{ $svc.port }}
+{{- end }}

--- a/griffin-commerce-demo/templates/controlplane.yaml
+++ b/griffin-commerce-demo/templates/controlplane.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.chaos.enabled -}}
+# Fault-injection control plane. Single-replica + Recreate by design — the
+# active knob is held in memory; horizontal scale or a rolling-update window
+# would split the single-knob-at-a-time invariant.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controlplane
+  labels:
+    {{- include "griffin.labels" . | nindent 4 }}
+    app: controlplane
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: controlplane
+  template:
+    metadata:
+      labels:
+        app: controlplane
+    spec:
+      {{- include "griffin.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: controlplane
+          image: {{ include "griffin.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8086
+          env:
+            - name: SERVICE_NAME
+              value: "controlplane"
+            - name: PORT
+              value: "8086"
+            - name: GRIFFIN_ADMIN_ENABLED
+              value: "true"
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "20m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8086
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8086
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controlplane
+  labels:
+    {{- include "griffin.labels" . | nindent 4 }}
+    app: controlplane
+spec:
+  type: ClusterIP
+  selector:
+    app: controlplane
+  ports:
+    - port: 8086
+      targetPort: 8086
+{{- end }}

--- a/griffin-commerce-demo/templates/frontend.yaml
+++ b/griffin-commerce-demo/templates/frontend.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    {{- include "griffin.labels" . | nindent 4 }}
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      {{- include "griffin.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: frontend
+          image: {{ include "griffin.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 5173
+          env:
+            - name: SERVICE_NAME
+              value: "frontend"
+            - name: PORT
+              value: "5173"
+            - name: NODE_ENV
+              value: "production"
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5173
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5173
+            initialDelaySeconds: 10
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    {{- include "griffin.labels" . | nindent 4 }}
+    app: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - port: 5173
+      targetPort: 5173
+      protocol: TCP

--- a/griffin-commerce-demo/templates/ingress.yaml
+++ b/griffin-commerce-demo/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "griffin.fullname" . }}
+  labels:
+    {{- include "griffin.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - {{ if .Values.ingress.host -}}host: {{ .Values.ingress.host | quote }}
+      {{ end -}}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 5173
+{{- end }}

--- a/griffin-commerce-demo/values.yaml
+++ b/griffin-commerce-demo/values.yaml
@@ -1,0 +1,59 @@
+# Default values for griffin-commerce-demo.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Single image used for every backend, the frontend, and the controlplane.
+# The container's SERVICE_NAME env selects which component to run.
+image:
+  repository: ghcr.io/cardinalhq/griffin-commerce-demo
+  tag: ""              # defaults to .Chart.appVersion when empty
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Optional Ingress for the frontend. Disable to manage routing yourself.
+ingress:
+  enabled: true
+  className: ""        # leave empty to use the cluster's default IngressClass
+  host: ""             # leave empty to accept any hostname
+  path: /
+  pathType: Prefix
+  annotations: {}
+  tls: []
+
+# OTLP telemetry. When endpoint is empty no OTEL_* env vars are injected.
+#
+# Two patterns are supported:
+#   1. endpoint: "http://otel-collector.observability.svc.cluster.local:4318"
+#      A single URL that every backend exports to.
+#   2. useHostIp: true (endpoint ignored)
+#      Each pod resolves its endpoint to its Node IP at startup, matching
+#      the per-node DaemonSet + hostPort pattern from the
+#      with-otlp-nodelocal kustomize overlay.
+otel:
+  endpoint: ""
+  insecure: true
+  useHostIp: false
+
+# Chaos overlay. Adds a single-replica controlplane Deployment + Service
+# and wires CONTROLPLANE_URL into every backend so they poll for fault
+# injection. WARNING: this enables GRIFFIN_ADMIN_ENABLED=true on the
+# controlplane — anyone who can reach :8086 can inject faults. Do not
+# enable in production.
+chaos:
+  enabled: false
+  metricExportIntervalMs: 10000
+  recsRefreshInterval: 30s
+
+# Pod- and container-level securityContext applied to every workload.
+# Defaults match the kustomize base patch and keep the chart compatible
+# with namespaces enforcing PSS restricted:latest.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]


### PR DESCRIPTION
## Summary
- Add new Helm chart `griffin-commerce-demo` derived from the kustomize manifests in `cardinalhq/griffin-commerce-demo/k8s/`.
- Renders the 6 backend services + frontend from a single image, with optional Ingress, OTLP wiring (URL or per-node `HOST_IP`), and a chaos overlay that adds the `controlplane` Deployment.
- `appVersion` pinned to `v0.3.0` (latest upstream release). Already published to `oci://public.ecr.aws/cardinalhq.io/griffin-commerce-demo:0.1.0`.

## Test plan
- [x] `make lint` clean
- [x] `make template` (default, custom tag, ingress on/off, otel URL, otel hostIp, chaos, chaos+otel) all render
- [x] `helm pull` + `helm template` against the published `oci://` artifact renders 15 resources by default and 17 with chaos enabled