### PR TITLE
maestro: chart 0.7.25, appVersion v1.26.2

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.24"
-appVersion: "v1.26.1"
+version: "0.7.25"
+appVersion: "v1.26.2"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.26.2 release (namespace-scoped kube tokens — Role+RoleBinding install path for OpenShift).