### PR TITLE
maestro: chart 0.7.26, appVersion v1.26.4

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.25"
-appVersion: "v1.26.2"
+version: "0.7.26"
+appVersion: "v1.26.4"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.26.4 release (Test Connection auto-discovers SA namespace from JWT).