### PR TITLE
maestro: chart 0.7.24, appVersion v1.27.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.2"
-appVersion: "v1.18.0"
+version: "0.7.24"
+appVersion: "v1.27.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for the `maestro/v1.27.0` release.

- `version`: 0.7.2 → **0.7.24** (reconciles the stale Chart.yaml; ECR already has 0.7.23, kubernetes-clusters pins 0.7.23)
- `appVersion`: v1.18.0 → **v1.27.0**

No template changes. Will be `helm package`d + pushed to `oci://public.ecr.aws/cardinalhq.io` after merge, and referenced from the kubernetes-clusters deploy PR.