### PR TITLE
maestro: chart 0.7.27, appVersion v1.27.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.26"
-appVersion: "v1.26.4"
+version: "0.7.27"
+appVersion: "v1.27.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for the `maestro/v1.27.0` release.

- `version`: 0.7.26 → **0.7.27**
- `appVersion`: v1.26.4 → **v1.27.0**

No template changes. After merge: `helm package` + push to `oci://public.ecr.aws/cardinalhq.io`, then referenced from the kubernetes-clusters deploy PR (`helmCharts version: 0.7.27`).