### PR TITLE
gateway: add virtual_node_peer_attributes to servicegraph connector

### DIFF
--- a/base-collector-manifests/gateway/configmap.yaml
+++ b/base-collector-manifests/gateway/configmap.yaml
@@ -13,6 +13,16 @@ data:
         metrics_flush_interval: 10s
         store:
           ttl: 10s
+        virtual_node_peer_attributes:
+          - peer.service
+          - server.address
+          - http.url
+          - url.full
+          - net.peer.name
+          - rpc.service
+          - db.system
+          - db.name
+          - db.instance.id
 
     receivers:
       # Pre-delta'd data from agent/poller


### PR DESCRIPTION
## Summary
- Add `virtual_node_peer_attributes` to the gateway's `servicegraph` connector so client spans without a paired server span (or whose pair arrives outside the 10s `store.ttl`) render with a real peer name instead of `unknown`.
- Attributes chosen to cover: HTTP edges via `peer.service` / `server.address` / `url.full` / `net.peer.name`, RPC via `rpc.service`, DB virtual nodes via `db.system` / `db.name` / `db.instance.id`.

## Why
Currently the service graph shows edges like `loadgen → unknown` and the payment-service → hdfc-prod-03 DB edge does not render at all. The OTel contrib defaults for `virtual_node_peer_attributes` don't include `peer.service`, `server.address`, or `db.instance.id`, which are exactly the attributes our instrumentation (otelhttp + griffin-commerce-demo payment service) sets.

## Test plan
- [ ] Apply via the matching kubernetes-clusters PR (prod gateway uses an inlined copy of this config); confirm `loadgen → payment` and `payment → hdfc-prod-03` edges appear in the service graph within 1–2 minutes of collector restart.
- [ ] Verify no regression in existing edges.