### PR TITLE
maestro: chart 0.7.28, appVersion v1.27.1

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.27"
-appVersion: "v1.27.0"
+version: "0.7.28"
+appVersion: "v1.27.1"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.27.1 release — fix(mcp-gateway): make discover_service_graph return non-zero for paired edges (conductor #685).