### PR TITLE
maestro: chart 0.7.29, appVersion v1.27.2

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.28"
-appVersion: "v1.27.1"
+version: "0.7.29"
+appVersion: "v1.27.2"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.27.2 — feat(mcp-gateway): drop unknown edges from discover_service_graph (#686).