### PR TITLE
maestro: mount agent-cache emptyDir, chart 0.7.31

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.30"
+version: "0.7.31"
 appVersion: "v1.27.3"
 keywords:
   - maestro

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -146,6 +146,12 @@ spec:
             value: "http://{{ include "maestro.fullname" . }}-mcp-gateway:{{ .Values.mcpGateway.port }}"
           - name: PORT
             value: {{ .Values.maestro.port | quote }}
+          # Maestro writes agent caches under
+          # ${WORKING_DIRECTORY}/<agent>/.cache/<namespace>. Point at the
+          # always-mounted agent-cache emptyDir so writes succeed under
+          # readOnlyRootFilesystem=true.
+          - name: WORKING_DIRECTORY
+            value: "/var/cache/maestro"
           {{- if .Values.maestro.persistence.enabled }}
           - name: ONTOLOGY_WORKSPACE_DIR
             value: {{ printf "%s/git-checkouts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
@@ -189,6 +195,8 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: agent-cache
+          mountPath: /var/cache/maestro
         {{- if .Values.maestro.persistence.enabled }}
         - name: data
           mountPath: {{ .Values.maestro.persistence.mountPath | default "/var/lib/maestro" | quote }}
@@ -238,6 +246,8 @@ spec:
       {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.maestro.affinity)     | nindent 6 }}
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: agent-cache
         emptyDir: {}
       {{- if .Values.maestro.persistence.enabled }}
       - name: data

--- a/maestro/tests/dex_test.yaml
+++ b/maestro/tests/dex_test.yaml
@@ -176,14 +176,14 @@ tests:
             name: OIDC_ISSUER_URL
             value: http://m.example.com/dex
       # Lock in the ordering: built-in OIDC_ISSUER_URL is emitted
-      # immediately after PORT (env[8]), so it lands at env[9] —
-      # comfortably before any user maestro.env entry, and Kubernetes
-      # picks the first occurrence on duplicates.
+      # immediately after WORKING_DIRECTORY (env[9]), so it lands at
+      # env[10] — comfortably before any user maestro.env entry, and
+      # Kubernetes picks the first occurrence on duplicates.
       - equal:
-          path: spec.template.spec.containers[0].env[9].name
+          path: spec.template.spec.containers[0].env[10].name
           value: OIDC_ISSUER_URL
       - equal:
-          path: spec.template.spec.containers[0].env[9].value
+          path: spec.template.spec.containers[0].env[10].value
           value: http://m.example.com/dex
 
   - it: ingress lists /dex before / when dex enabled

--- a/maestro/tests/env_test.yaml
+++ b/maestro/tests/env_test.yaml
@@ -3,6 +3,25 @@ templates:
   - maestro-deployment.yaml
   - mcp-gateway-deployment.yaml
 tests:
+  - it: mounts an agent-cache emptyDir and points WORKING_DIRECTORY at it
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WORKING_DIRECTORY
+            value: "/var/cache/maestro"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: agent-cache
+            mountPath: /var/cache/maestro
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: agent-cache
+            emptyDir: {}
+
   - it: should render maestro.env into the maestro container
     set:
       maestro.env:


### PR DESCRIPTION
## Summary
- Mount an always-on `agent-cache` emptyDir at `/var/cache/maestro` and set `WORKING_DIRECTORY` to that path so the agent can write `${WORKING_DIRECTORY}/<agent>/.cache/<namespace>` under `readOnlyRootFilesystem=true`.
- Bump maestro chart to 0.7.31 (appVersion unchanged).

## Test plan
- [x] `helm unittest .` — 58/58 pass
- [x] `helm lint maestro`
- [x] `helm template` renders `WORKING_DIRECTORY`, mount, and volume as expected