### PR TITLE
lakerunner: chart 3.10.0, appVersion v1.21.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.9.2"
-appVersion: "v1.20.4"
+version: "3.10.0"
+appVersion: "v1.21.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump appVersion to v1.21.0 (latest lakerunner release).

Release notes (v1.20.5 → v1.21.0) are internal fixes and a duckdb-binpb v1.x attrs-map migration — no chart-side config changes required.