### PR TITLE
feat(maestro): PrometheusRule for pending operator-workload token alert

### DIFF
--- a/maestro/templates/prometheusrule.yaml
+++ b/maestro/templates/prometheusrule.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.prometheusRules.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "maestro.fullname" . }}-alerts
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRules.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: maestro.lakerunner
+      rules:
+        # Maestro G.2 (operator config bundling): pending operator-managed
+        # Lakerunner workloads whose license token is within 7 days of
+        # expiry. Pre-G.3 reconciliation, a token expiry forces
+        # destructive recovery (uninstall-pending deletes labeled PVCs).
+        # Any non-zero count pages so the operator can either deploy G.3
+        # or remediate the affected workloads before the token dies.
+        - alert: MaestroPendingOperatorWorkloadTokenExpiringSoon
+          expr: maestro_pending_operator_workloads_token_expiring_soon > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "{{ "{{ $value }}" }} pending operator-managed Lakerunner workloads have license tokens expiring within 7 days"
+            description: |
+              At least one operator-managed Lakerunner workload has been
+              awaiting G.3 reconciliation long enough that its license
+              token is within 7 days of expiry. If the token expires
+              before reconciliation, recovery is destructive
+              (uninstall-pending wipes Lakerunner PVCs, losing telemetry).
+              Either ship G.3 reconciliation or uninstall+re-add the
+              affected workload(s) before the token expires.
+
+              See maestro G.2 spec (lakerunner-grouping-g2-operator-config-bundling-design.md)
+              §Error handling.
+{{- end }}

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -306,3 +306,12 @@ global:
         - ALL
     seccompProfile:
       type: RuntimeDefault
+
+# Maestro G.2: Prometheus alert rule for operator-managed pending workloads
+# whose license token is within 7 days of expiry. Requires the
+# prometheus-operator's PrometheusRule CRD. Disabled by default; enable
+# in clusters with prometheus-operator. The maestro PR for G.2 also
+# requires this chart change — see maestro G.2 spec §Error handling.
+prometheusRules:
+  enabled: false
+  additionalLabels: {}


### PR DESCRIPTION
## Summary

Adds an opt-in `PrometheusRule` template to the maestro chart with the `MaestroPendingOperatorWorkloadTokenExpiringSoon` alert.

Pairs with maestro G.2 (cardinalhq/conductor) — operator config bundling. The maestro server now emits the OTel gauge `maestro_pending_operator_workloads_token_expiring_soon` (count of operator-managed Lakerunner workloads with license tokens expiring within 7 days). Pre-G.3 reconciliation, an expiring token forces destructive recovery (uninstall-pending wipes PVCs). This alert pages on-call before that happens.

## Toggle

Disabled by default. Enable in clusters with `prometheus-operator`:
\`\`\`yaml
prometheusRules:
  enabled: true
  additionalLabels:
    release: prometheus  # match your prometheus-operator selector
\`\`\`

## Coordination

- Companion maestro PR: forthcoming (cardinalhq/conductor — grouping G.2).
- Do not merge this chart PR before the maestro PR lands and the OTel gauge is emitting; otherwise the alert metric won't exist and the rule will trigger no-data alerts depending on operator config.

## Test plan

- [x] `helm lint maestro --set prometheusRules.enabled=true` clean
- [x] `helm template ... --set prometheusRules.enabled=true` renders correctly
- [ ] Reviewer: confirm the alert label conventions match the cluster's prometheus-operator selector before enabling per-cluster