### PR TITLE
lakerunner: chart 3.11.0, appVersion v1.22.2

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.10.1"
-appVersion: "v1.21.1"
+version: "3.11.0"
+appVersion: "v1.22.2"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
## Summary
- Bump lakerunner chart to 3.11.0
- Bump appVersion to v1.22.2

## Test plan
- [ ] `helm lint lakerunner`
- [ ] `helm template test-release lakerunner --values lakerunner/values.yaml`