### PR TITLE
maestro: chart 0.7.42, appVersion v1.33.2

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.41"
-appVersion: "v1.33.0"
+version: "0.7.42"
+appVersion: "v1.33.2"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.33.2 release (conductor #766: gate POC ServiceNow ticket + affected customer on SaaS mode). Also brings appVersion current (was lagging at v1.33.0).