### PR TITLE
maestro: chart 0.7.43, appVersion v1.33.3

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.42"
-appVersion: "v1.33.2"
+version: "0.7.43"
+appVersion: "v1.33.3"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.33.3 release (conductor #768: BYO lakerunner URL write-through).