### PR TITLE
maestro: github-cache split mode (default on)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.44"
+version: "0.7.45"
 appVersion: "v1.34.0"
 keywords:
   - maestro

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -149,6 +149,29 @@ Database environment variables shared across components.
 {{- end }}
 
 {{/*
+github-cache: fully qualified names for the serving StatefulSet + headless
+Service and the provisioner Deployment.
+*/}}
+{{- define "maestro.githubCacheFullname" -}}
+{{- printf "%s-github-cache" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "maestro.githubCacheProvisionerFullname" -}}
+{{- printf "%s-github-cache-provisioner" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+github-cache reads its Postgres DSN from DATABASE_URL (not maestro's
+MAESTRO_DATABASE_URL). Emit it as an alias composed from the same
+MAESTRO_DB_* vars that maestro.databaseEnv defines, so it must follow that
+helper in the env list (the $(VAR) refs resolve against the earlier entries).
+*/}}
+{{- define "maestro.databaseUrlAlias" -}}
+- name: DATABASE_URL
+  value: "postgresql://$(MAESTRO_DB_USER):$(MAESTRO_DB_PASSWORD)@$(MAESTRO_DB_HOST):$(MAESTRO_DB_PORT)/$(MAESTRO_DB_NAME)?sslmode=$(MAESTRO_DB_SSLMODE)"
+{{- end -}}
+
+{{/*
 Return the secret name for the Cardinal API key.
 */}}
 {{- define "maestro.cardinalApiKeySecretName" -}}

--- a/maestro/templates/github-cache-provisioner-deployment.yaml
+++ b/maestro/templates/github-cache-provisioner-deployment.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.githubCache.enabled -}}
+{{- $prov := .Values.githubCache.provisioner -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maestro.githubCacheProvisionerFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache-provisioner
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  # Singleton — the ontology poll + dead-row sweeper is guarded by a persisted
+  # lease, but Recreate avoids two overlapping pods during a rollout.
+  replicas: {{ $prov.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: github-cache-provisioner
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache-provisioner
+        {{- with $prov.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- include "maestro.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" $prov.podSecurityContext) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: github-cache-provisioner
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $prov.containerSecurityContext) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/app/entrypoint.sh"]
+        args: ["github-cache-provisioner"]
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          {{- include "maestro.databaseUrlAlias" . | nindent 10 }}
+          # The ontology provisioner (which moves here in remote mode) calls
+          # the mcp-gateway for the runtime topology overlay; without this the
+          # overlay is silently skipped.
+          - name: MCP_GATEWAY_URL
+            value: "http://{{ include "maestro.fullname" . }}-mcp-gateway:{{ .Values.mcpGateway.port }}"
+          # git writes ~/.gitconfig etc.; point HOME at the writable tmp
+          # emptyDir so readOnlyRootFilesystem=true doesn't break it.
+          - name: HOME
+            value: /tmp
+          {{- with .Values.githubCache.diskBudgetBytes }}
+          - name: GITHUB_CACHE_DISK_BUDGET_BYTES
+            value: {{ . | quote }}
+          {{- end }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.githubCache.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml $prov.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector $prov.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  $prov.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     $prov.affinity)     | nindent 6 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/maestro/templates/github-cache-service.yaml
+++ b/maestro/templates/github-cache-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.githubCache.enabled -}}
+# Headless Service: clusterIP None gives each serving pod stable per-pod DNS
+# (github-cache-0.<svc>.<ns>.svc.cluster.local) so the placement directory can
+# address replicas directly. There is no load-balanced VIP — maestro routes to
+# a specific replica chosen from the directory, not to the Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.githubCacheFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.githubCache.serving.port }}
+      targetPort: http
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+{{- end }}

--- a/maestro/templates/github-cache-statefulset.yaml
+++ b/maestro/templates/github-cache-statefulset.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.githubCache.enabled -}}
+{{- $svc := include "maestro.githubCacheFullname" . -}}
+{{- $serving := .Values.githubCache.serving -}}
+{{- $mountPath := $serving.persistence.mountPath | default "/var/lib/github-cache" -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "maestro.githubCacheFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  serviceName: {{ $svc }}
+  replicas: {{ $serving.replicas }}
+  # RWO volumes attach to one node at a time; parallel pod management avoids a
+  # serial rollout deadlock and lets warm replicas come back independently.
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: github-cache
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache
+        {{- with $serving.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- include "maestro.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- /*
+        Pin SELinux MCS categories so a re-attached PVC's mirror bytes stay
+        readable across pod restarts (same rationale as maestro.persistence).
+        Operators can override seLinuxOptions in serving.podSecurityContext.
+      */}}
+      {{- $podSec := $serving.podSecurityContext | default dict -}}
+      {{- if not (hasKey $podSec "seLinuxOptions") -}}
+        {{- $merged := dict -}}
+        {{- range $k, $v := $podSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
+        {{- $_ := set $merged "seLinuxOptions" (dict "level" $serving.persistence.seLinuxLevel) -}}
+        {{- $podSec = $merged -}}
+      {{- end }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" $podSec) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: github-cache
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $serving.containerSecurityContext) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/app/entrypoint.sh"]
+        args: ["github-cache"]
+        ports:
+        - containerPort: {{ $serving.port }}
+          name: http
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          {{- include "maestro.databaseUrlAlias" . | nindent 10 }}
+          - name: GITHUB_CACHE_PORT
+            value: {{ $serving.port | quote }}
+          # Stable per-pod identity: the StatefulSet ordinal hostname.
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: GITHUB_CACHE_REPLICA_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # Endpoint the placement directory advertises to maestro. Code
+          # appends ":<port>", so this is host-only — the stable per-pod DNS
+          # backed by the headless Service.
+          - name: GITHUB_CACHE_ENDPOINT
+            value: "$(POD_NAME).{{ $svc }}.{{ .Release.Namespace }}.svc"
+          - name: MIRROR_ROOT
+            value: {{ printf "%s/mirrors" $mountPath | quote }}
+          # git writes ~/.gitconfig etc.; point HOME at the writable tmp
+          # emptyDir so readOnlyRootFilesystem=true doesn't break it.
+          - name: HOME
+            value: /tmp
+          {{- with .Values.githubCache.diskBudgetBytes }}
+          - name: GITHUB_CACHE_DISK_BUDGET_BYTES
+            value: {{ . | quote }}
+          {{- end }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.githubCache.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml $serving.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: mirrors
+          mountPath: {{ $mountPath | quote }}
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector $serving.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  $serving.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     $serving.affinity)     | nindent 6 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: mirrors
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache
+    spec:
+      accessModes:
+        - {{ $serving.persistence.accessMode | quote }}
+      resources:
+        requests:
+          storage: {{ $serving.persistence.size | quote }}
+      {{- with $serving.persistence.storageClass }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -152,6 +152,13 @@ spec:
           # readOnlyRootFilesystem=true.
           - name: WORKING_DIRECTORY
             value: "/var/cache/maestro"
+          {{- if .Values.githubCache.enabled }}
+          # Split mode: maestro holds no repo bytes. The in-process git client +
+          # ontology poller are disabled and git tool calls route to the
+          # github-cache serving replicas via the placement directory.
+          - name: GITHUB_CACHE_REMOTE
+            value: "1"
+          {{- end }}
           {{- if .Values.maestro.persistence.enabled }}
           - name: ONTOLOGY_WORKSPACE_DIR
             value: {{ printf "%s/git-checkouts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}

--- a/maestro/tests/dex_test.yaml
+++ b/maestro/tests/dex_test.yaml
@@ -155,6 +155,9 @@ tests:
 
   - it: built-in OIDC_ISSUER_URL wins over a user maestro.env duplicate
     set:
+      # Disabled so this ordering check stays isolated from split mode's
+      # GITHUB_CACHE_REMOTE built-in (which otherwise lands at env[10]).
+      githubCache.enabled: false
       dex.enabled: true
       ingress.enabled: true
       ingress.host: m.example.com

--- a/maestro/tests/github_cache_test.yaml
+++ b/maestro/tests/github_cache_test.yaml
@@ -1,0 +1,176 @@
+suite: github-cache split mode
+templates:
+  - github-cache-statefulset.yaml
+  - github-cache-service.yaml
+  - github-cache-provisioner-deployment.yaml
+  - maestro-deployment.yaml
+tests:
+  # ---- serving StatefulSet ----------------------------------------------
+  - it: renders the serving StatefulSet with two replicas by default
+    template: github-cache-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-maestro-github-cache
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["github-cache"]
+
+  - it: gives each serving pod a 10Gi RWO mirror PVC
+    template: github-cache-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: mirrors
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+
+  - it: wires DATABASE_URL, MIRROR_ROOT, and stable per-pod identity env
+    template: github-cache-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://$(MAESTRO_DB_USER):$(MAESTRO_DB_PASSWORD)@$(MAESTRO_DB_HOST):$(MAESTRO_DB_PORT)/$(MAESTRO_DB_NAME)?sslmode=$(MAESTRO_DB_SSLMODE)"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MIRROR_ROOT
+            value: "/var/lib/github-cache/mirrors"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_CACHE_REPLICA_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_CACHE_ENDPOINT
+            value: "$(POD_NAME).RELEASE-NAME-maestro-github-cache.NAMESPACE.svc"
+
+  - it: mounts the license into the serving pod
+    template: github-cache-statefulset.yaml
+    set:
+      license.create: false
+      license.secretName: my-license
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: license
+            mountPath: /app/license
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: my-license
+
+  - it: applies a custom disk budget override when set
+    template: github-cache-statefulset.yaml
+    set:
+      githubCache.diskBudgetBytes: "8589934592"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_CACHE_DISK_BUDGET_BYTES
+            value: "8589934592"
+
+  # ---- headless Service --------------------------------------------------
+  - it: exposes a headless Service for per-pod DNS
+    template: github-cache-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: github-cache
+
+  # ---- provisioner -------------------------------------------------------
+  - it: renders the provisioner as a singleton Deployment with no PVC
+    template: github-cache-provisioner-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["github-cache-provisioner"]
+      - notExists:
+          path: spec.volumeClaimTemplates
+      # Ontology provisioning moves here in remote mode and calls mcp-gateway.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_GATEWAY_URL
+            value: "http://RELEASE-NAME-maestro-mcp-gateway:8080"
+
+  - it: mounts the license into the provisioner pod
+    template: github-cache-provisioner-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: license
+            mountPath: /app/license
+            readOnly: true
+
+  # ---- maestro client wiring --------------------------------------------
+  - it: sets GITHUB_CACHE_REMOTE on maestro when split mode is on
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_CACHE_REMOTE
+            value: "1"
+
+  # ---- disabled (legacy in-process) path ---------------------------------
+  - it: emits no github-cache resources when disabled
+    set:
+      githubCache.enabled: false
+    template: github-cache-statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: provisioner is absent when disabled
+    set:
+      githubCache.enabled: false
+    template: github-cache-provisioner-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: leaves GITHUB_CACHE_REMOTE off maestro when disabled
+    set:
+      githubCache.enabled: false
+    template: maestro-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_CACHE_REMOTE
+            value: "1"

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -179,6 +179,86 @@ mcpGateway:
   affinity: {}
   env: []
 
+# GitHub Cache Service (split mode).
+#
+# When enabled (the default), the per-tenant VCS repo mirror cache + git
+# code-search/read tools and the ontology poller/provisioner run as their own
+# pods instead of in-process inside maestro. Maestro then runs as a pure client
+# (GITHUB_CACHE_REMOTE=1): it holds no repo bytes and routes every git tool call
+# to a serving replica via the Postgres placement directory, with failover.
+#
+# Two roles, both off the unified image:
+#   - serving (`github-cache`): a StatefulSet; each pod owns a stable RWO PVC
+#     holding its bare mirrors and answers MCP-over-HTTP. A headless Service
+#     gives each pod stable per-pod DNS so the directory can address it directly.
+#   - provisioner (`github-cache-provisioner`): a singleton Deployment that runs
+#     the ontology poller + dead-row sweeper (guarded by a persisted lease).
+#     Required whenever split mode is on — in remote mode maestro disables its
+#     in-process poller, so without this pod ontology refresh stops.
+#
+# Set githubCache.enabled=false to fall back to the legacy in-process path
+# (maestro holds the mirrors itself; no extra pods). That is the rollback path.
+#
+# NOTE: split mode is on by default and the serving StatefulSet provisions one
+# RWO PVC per replica. The cluster therefore needs a default StorageClass (or
+# serving.persistence.storageClass set) — without dynamic provisioning the
+# serving pods stay Pending. Self-hosted installs that don't want the extra
+# pods/storage should set githubCache.enabled=false.
+githubCache:
+  enabled: true
+
+  # Serving replicas — the mirror cache + git tool hosts.
+  serving:
+    replicas: 2
+    port: 4300
+    # Per-pod mirror storage. Each StatefulSet pod is the sole writer to its
+    # own RWO volume (volumeClaimTemplate), so a restart re-attaches a warm
+    # disk → delta-fetch instead of a full re-clone.
+    persistence:
+      size: 10Gi
+      accessMode: ReadWriteOnce
+      # storageClass: ""   # leave empty to use the cluster default
+      mountPath: /var/lib/github-cache
+      # SELinux MCS level pinned across pod restarts so a re-attached PVC's
+      # mirror bytes stay readable (same rationale as maestro.persistence).
+      seLinuxLevel: "s0:c100,c200"
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  # Ontology poller + sweeper singleton. Holds no mirror PVC.
+  provisioner:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  # Optional override of the per-replica disk-budget LRU ceiling (bytes).
+  # Leave empty to use the service default (10 GiB), which matches the
+  # serving PVC size above.
+  diskBudgetBytes: ""
+
+  # Additional env vars applied to both the serving and provisioner containers.
+  env: []
+
 # License configuration
 # A valid license is required for Maestro to operate.
 # The license secret is mounted to /app/license in the maestro and


### PR DESCRIPTION
Adds the `github-cache` split-mode topology to the maestro chart and makes it the **default**.

## What
- **New `githubCache` values block** (`enabled: true` by default).
- **Serving StatefulSet** (`github-cache`): `replicas: 2`, each pod gets a stable **10Gi RWO** mirror PVC (`volumeClaimTemplates`), SELinux level pinned for warm restarts, `/ready` + `/healthz` probes, license mounted. Advertises stable per-pod DNS via `GITHUB_CACHE_ENDPOINT`.
- **Headless Service** (`clusterIP: None`, `publishNotReadyAddresses: true`) for per-pod addressing — maestro routes to a directory-chosen replica, not a VIP.
- **Provisioner Deployment** (`github-cache-provisioner`): singleton (`Recreate`), runs the ontology poller + sweeper. Required in remote mode (maestro disables its in-process poller). Carries `MCP_GATEWAY_URL` so ontology provisioning's topology overlay still works.
- **Maestro** flips to client mode: `GITHUB_CACHE_REMOTE=1` when `githubCache.enabled` (holds no repo bytes, routes git tool calls to the serving replicas).
- 12 new helm-unittest cases; `dex_test` ordering case pinned to `githubCache.enabled=false` to stay isolated.

## Topology
2 serving replicas + 1 provisioner singleton. github-cache reads `DATABASE_URL` (alias of the maestro DB DSN) + `MIRROR_ROOT`; default disk budget (10 GiB) matches the PVC.

## ⚠️ Operator note
Split mode is **default-on**, so the cluster needs a default StorageClass (or `serving.persistence.storageClass`) for the per-replica RWO PVCs — without dynamic provisioning the serving pods stay Pending. Self-hosted installs that don't want the extra pods/storage set `githubCache.enabled=false` (legacy in-process path / rollback).

## Verification
`helm lint` clean; all 70 helm-unittest tests pass. Codex-reviewed (fixed: cluster-domain hardcode → `.svc`; added provisioner `MCP_GATEWAY_URL`).

Companion to conductor #767 (maestro/v1.34.0).