### PR TITLE
maestro: chart 0.7.46, appVersion v1.34.1

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.45"
-appVersion: "v1.34.0"
+version: "0.7.46"
+appVersion: "v1.34.1"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.34.1 release (github-cache single-home routing fix, conductor #771).