### PR TITLE
maestro: chart 0.7.47 — stable github-cache VCT labels

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.46"
+version: "0.7.47"
 appVersion: "v1.34.1"
 keywords:
   - maestro

--- a/maestro/templates/github-cache-statefulset.yaml
+++ b/maestro/templates/github-cache-statefulset.yaml
@@ -126,8 +126,12 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: mirrors
+      # volumeClaimTemplates is IMMUTABLE: use only stable selector labels here.
+      # maestro.labels embeds app.kubernetes.io/version + helm.sh/chart, which
+      # change every release and make the StatefulSet un-updatable (forbidden
+      # immutable-field patch). Stable labels keep future releases syncable.
       labels:
-        {{- include "maestro.labels" . | nindent 8 }}
+        {{- include "maestro.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: github-cache
     spec:
       accessModes:


### PR DESCRIPTION
The github-cache StatefulSet stamped `app.kubernetes.io/version` + `helm.sh/chart` into its volumeClaimTemplate via `maestro.labels`. Those change every release; `volumeClaimTemplates` is immutable, so every release's SS patch was rejected (ArgoCD SyncFailed, github-cache stuck on old image). Switch the VCT to `maestro.selectorLabels` (stable). Requires a one-time SS recreate to reset live VCT labels.