### PR TITLE
lakerunner: chart 3.12.0, appVersion v1.23.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.11.0"
-appVersion: "v1.22.2"
+version: "3.12.0"
+appVersion: "v1.23.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump lakerunner chart to 3.12.0 with appVersion v1.23.0 (image built in lakerunner run 26260003144).