### PR TITLE
maestro: chart 0.7.50, appVersion v1.41.4

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.49"
-appVersion: "v1.41.0"
+version: "0.7.50"
+appVersion: "v1.41.4"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.41.4 release (per-service log chart severity ordering + min-segment floor).