### PR TITLE
lakerunner: emit 0 replicas for disabled signals in autoscaler env

### DIFF
--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -586,7 +586,9 @@ Usage: {{ include "lakerunner.image" (list .Values.componentName.image .) }}
 
 {{/*
 Generate autoscaler environment variables for the monitoring deployment.
-Emits LAKERUNNER_AUTOSCALER_* env vars for all enabled worker services.
+Emits LAKERUNNER_AUTOSCALER_* env vars for all worker services. When a
+signal's processing is disabled, its MIN/MAX replicas are emitted as 0
+so the autoscaler treats it as scaled-to-zero.
 Usage: {{ include "lakerunner.autoscalerEnv" . }}
 */}}
 {{- define "lakerunner.autoscalerEnv" -}}
@@ -594,30 +596,24 @@ Usage: {{ include "lakerunner.autoscalerEnv" . }}
   value: "true"
 - name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
   value: {{ .Values.monitoring.autoscaler.observeOnly | quote }}
-{{- if .Values.processLogs.enabled }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
   value: {{ include "lakerunner.fullname" . }}-process-logs
 - name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
-  value: {{ .Values.processLogs.autoscaling.minReplicas | quote }}
+  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
-  value: {{ .Values.processLogs.autoscaling.maxReplicas | quote }}
-{{- end }}
-{{- if .Values.processMetrics.enabled }}
+  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
   value: {{ include "lakerunner.fullname" . }}-process-metrics
 - name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS
-  value: {{ .Values.processMetrics.autoscaling.minReplicas | quote }}
+  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
-  value: {{ .Values.processMetrics.autoscaling.maxReplicas | quote }}
-{{- end }}
-{{- if .Values.processTraces.enabled }}
+  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
   value: {{ include "lakerunner.fullname" . }}-process-traces
 - name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
-  value: {{ .Values.processTraces.autoscaling.minReplicas | quote }}
+  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
-  value: {{ .Values.processTraces.autoscaling.maxReplicas | quote }}
-{{- end }}
+  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
 {{- end -}}
 
 {{/*

--- a/lakerunner/tests/scaling_test.yaml
+++ b/lakerunner/tests/scaling_test.yaml
@@ -82,18 +82,28 @@ tests:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "10"
 
-  - it: should not inject autoscaler env vars for disabled services
+  - it: should emit zero replicas for disabled services
     set:
       monitoring.enabled: true
       processTraces.enabled: false
     templates:
       - monitoring-deployment.yaml
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-traces
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
+            value: "0"
 
   - it: should set observe-only mode when configured
     set:

--- a/lakerunner/tests/scaling_test.yaml
+++ b/lakerunner/tests/scaling_test.yaml
@@ -82,7 +82,7 @@ tests:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "10"
 
-  - it: should emit zero replicas for disabled services
+  - it: should emit zero replicas for disabled traces
     set:
       monitoring.enabled: true
       processTraces.enabled: false
@@ -99,6 +99,112 @@ tests:
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
             value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
+            value: "0"
+
+  - it: should emit zero replicas for disabled logs
+    set:
+      monitoring.enabled: true
+      processLogs.enabled: false
+    templates:
+      - monitoring-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
+            value: RELEASE-NAME-lakerunner-process-logs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
+            value: "0"
+
+  - it: should emit zero replicas for disabled metrics
+    set:
+      monitoring.enabled: true
+      processMetrics.enabled: false
+    templates:
+      - monitoring-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
+            value: RELEASE-NAME-lakerunner-process-metrics
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
+            value: "0"
+
+  - it: should override configured replica values when signal is disabled
+    set:
+      monitoring.enabled: true
+      processTraces.enabled: false
+      processTraces.autoscaling.minReplicas: 3
+      processTraces.autoscaling.maxReplicas: 7
+    templates:
+      - monitoring-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
+            value: "0"
+
+  - it: should emit all services with zero replicas when every signal is disabled
+    set:
+      monitoring.enabled: true
+      processLogs.enabled: false
+      processMetrics.enabled: false
+      processTraces.enabled: false
+    templates:
+      - monitoring-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
+            value: RELEASE-NAME-lakerunner-process-logs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
+            value: RELEASE-NAME-lakerunner-process-metrics
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
+            value: RELEASE-NAME-lakerunner-process-traces
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
## Summary
- `lakerunner.autoscalerEnv` now always emits `LAKERUNNER_AUTOSCALER_SERVICES_{LOGS,METRICS,TRACES}_{DEPLOYMENT,MIN_REPLICAS,MAX_REPLICAS}` for the monitoring deployment.
- When a signal's processing (`processLogs`/`processMetrics`/`processTraces`) is disabled, both MIN and MAX replicas are emitted as `"0"` so the autoscaler treats it as scaled-to-zero rather than not seeing the signal at all.

## Test plan
- [x] `helm unittest .` — 290 tests pass
- [x] `helm lint .` — passes
- [x] Updated `scaling_test.yaml` "disabled service" test to assert the zero values are emitted