### PR TITLE
maestro: chart 0.7.54, appVersion v1.43.11

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.7.53"
-appVersion: "v1.43.6"
+version: "0.7.54"
+appVersion: "v1.43.11"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.43.11 release (cardinalhq/conductor#818). Adds in-cluster Cloud Map http:// support and route-side URL validation.