### PR TITLE
maestro: opt-in external Service + secret-sourced MCP_API_KEY (0.8.4)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.3"
+version: "0.8.4"
 appVersion: "v1.44.8"
 keywords:
   - maestro

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -247,6 +247,12 @@ Usage (inside a pod template's initContainers list):
     {{- if .root.Values.mcpGateway.apiKey }}
     - name: MCP_API_KEY
       value: {{ .root.Values.mcpGateway.apiKey | quote }}
+    {{- else if and .root.Values.mcpGateway.apiKeySecret .root.Values.mcpGateway.apiKeySecret.name }}
+    - name: MCP_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ .root.Values.mcpGateway.apiKeySecret.name | quote }}
+          key: {{ .root.Values.mcpGateway.apiKeySecret.key | default "MCP_API_KEY" | quote }}
     {{- end }}
     {{- include "maestro.cardinalTelemetryEnv" .root | nindent 4 }}
     {{- with .root.Values.global.env }}

--- a/maestro/templates/mcp-gateway-service.yaml
+++ b/maestro/templates/mcp-gateway-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.mcpGateway.service.enabled -}}
+{{/*
+ClusterIP fronting the mcp-gateway sidecar. The sidecar lives inside the
+maestro pod (chart 0.8+), so this Service uses the maestro selector and
+targets the sidecar's named port (`mcp`, default 8080). External traffic
+reaches the gateway via an operator-managed Ingress/IngressRoute pointed
+at this Service; in-cluster maestro continues to use localhost.
+
+Disabled by default to preserve the local-dev / self-hosted contract
+where the gateway is never reachable outside the pod. SaaS operators
+who terminate TLS at Traefik and gate the gateway with an API key flip
+this on.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.fullname" . }}-mcp-gateway
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-gateway
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.mcpGateway.port }}
+      targetPort: mcp
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+{{- end }}

--- a/maestro/tests/mcp_gateway_external_test.yaml
+++ b/maestro/tests/mcp_gateway_external_test.yaml
@@ -1,0 +1,85 @@
+suite: mcp-gateway external Service + apiKey secret wiring
+templates:
+  - maestro-deployment.yaml
+  - mcp-gateway-service.yaml
+tests:
+  - it: does not render the external Service by default
+    template: mcp-gateway-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an external ClusterIP Service when mcpGateway.service.enabled=true
+    set:
+      mcpGateway.service.enabled: true
+    template: mcp-gateway-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: mcp
+      # Selector must match the maestro pod (which hosts the sidecar),
+      # not a defunct mcp-gateway component label.
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: maestro
+
+  - it: sidecar emits MCP_API_KEY as a secretKeyRef when apiKeySecret.name is set
+    set:
+      mcpGateway.apiKeySecret.name: mcp-gateway-creds
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "mcp-gateway")].env
+          content:
+            name: MCP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "mcp-gateway-creds"
+                key: "MCP_API_KEY"
+
+  - it: apiKeySecret.key overrides the default key name
+    set:
+      mcpGateway.apiKeySecret.name: mcp-gateway-creds
+      mcpGateway.apiKeySecret.key: api-token
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "mcp-gateway")].env
+          content:
+            name: MCP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "mcp-gateway-creds"
+                key: "api-token"
+
+  - it: plaintext apiKey wins over apiKeySecret when both are set
+    set:
+      mcpGateway.apiKey: "plaintext-wins"
+      mcpGateway.apiKeySecret.name: mcp-gateway-creds
+    template: maestro-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "mcp-gateway")].env
+          content:
+            name: MCP_API_KEY
+            value: "plaintext-wins"
+
+  - it: emits no MCP_API_KEY env when neither apiKey nor apiKeySecret.name is set
+    template: maestro-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers[?(@.name == "mcp-gateway")].env
+          content:
+            name: MCP_API_KEY
+          any: true

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -248,6 +248,19 @@ mcpGateway:
   port: 8080
   debugPort: 9090
   apiKey: ""
+  # External ClusterIP Service in front of the sidecar. Off by default
+  # so the gateway stays pod-local in self-hosted installs. SaaS
+  # operators who terminate TLS at an Ingress/IngressRoute and gate the
+  # endpoint with an API key flip this on. Maestro itself always reaches
+  # the sidecar via localhost; this Service is only for external traffic.
+  service:
+    enabled: false
+  # Alternative to plaintext `apiKey`: source MCP_API_KEY from an
+  # existing Secret. When `apiKey` is set it wins; otherwise the sidecar
+  # emits a secretKeyRef. Leave both empty for unauthenticated local dev.
+  apiKeySecret:
+    name: ""
+    key: "MCP_API_KEY"
   # Resources for the sidecar container. CPU is generously over-provisioned
   # at the default request (1 CPU) given observed steady-state usage of
   # 1-2 millicores; operators tight on node capacity can drop the request


### PR DESCRIPTION
## Summary
- Re-adds an external ClusterIP Service in front of the mcp-gateway sidecar (selects the maestro pod, targets the sidecar's named `mcp` port). Gated by `mcpGateway.service.enabled` (default `false`) — self-hosted operators see no change.
- Lets the sidecar source `MCP_API_KEY` from an existing Secret via `mcpGateway.apiKeySecret.{name,key}`. Plaintext `mcpGateway.apiKey` still wins when set, so local-dev UX is unchanged. Required so SaaS operators don't have to put the key in plaintext values when they front the Service with an Ingress.
- Bumps `Chart.yaml` to `0.8.4` (appVersion unchanged at `v1.44.8`).

## Motivation
For SaaS operators (specifically Cardinal HQ's `app.cardinalhq.io` stack) we want to wire the mcp-gateway up as a Claude Code MCP endpoint at `mcp.cardinalhq.io`. That needs a Service in front of the sidecar plus a way to inject the API key from a sealed Secret rather than a plaintext values field. Self-hosted installs keep the existing pod-local, optional-auth contract.

## Test plan
- [x] `make test` passes (113/113 unit tests including 6 new cases covering default-off, service-on rendering, secretKeyRef wiring, custom key name, plaintext precedence, and unauthenticated path).
- [ ] Follow-up PR in `kubernetes-clusters` flips `mcpGateway.service.enabled=true` + adds the IngressRoute + sealed secret on the `aws-prod-us-east-2-global` overlay.