### PR TITLE
lakerunner: chart 3.12.16, appVersion v1.31.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.12.15"
-appVersion: "v1.30.3"
+version: "3.12.16"
+appVersion: "v1.31.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.31.0 release. Includes streaming FetchArtifact RPC, per-stream log segments, dim-split removal, and compaction re-enqueue fix.