### PR TITLE
maestro: chart 0.8.9, appVersion v1.45.11

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.8"
-appVersion: "v1.45.7"
+version: "0.8.9"
+appVersion: "v1.45.11"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Catches the chart up to the maestro releases since v1.45.7:

- v1.45.8 (#882): code_find leanness + B-hybrid rebuke
- v1.45.9: artifact-sweeper fix
- v1.45.10 (#886): branch-aware code search (GitHub PR-head refspec + clear ref errors)
- v1.45.11 (#887): URL-shaped embeddings cache name sanitization + bounded bolt.Open

No template, values, or operator-facing changes — purely a metadata bump so self-hosted deployments default to the latest tested image (Cardinal's prod overrides `image.tag` in values-local.yaml so this only affects self-hosted users).