### PR TITLE
base-collector-manifests: agent+poller balance directly into gateway L2

### DIFF
--- a/base-collector-manifests/README.md
+++ b/base-collector-manifests/README.md
@@ -143,32 +143,53 @@ patches:
   ┌──────────────┐     ┌──────────────┐
   │  agent (DS)  │     │ poller (1x)  │
   │  per-node    │     │ k8s_cluster  │
-  └──────┬───────┘     └──────┬───────┘
-         │                    │
-         │   OTLP/HTTP :24318 │
-         └────────┬───────────┘
-                  ▼
-         ┌────────────────┐     External OTLP
-         │  gateway (2x)  │◄─── (4317/4318)
-         │  servicegraph  │
-         │  S3 export     │──► S3 bucket
-         └────────────────┘
+  └──┬────────┬──┘     └───────┬──────┘
+     │ logs   │ metrics+traces │ metrics
+     │        │ (LB by stream/ │ (LB by streamID)
+     │        │  traceID)      │
+     │  :24318│      :14317    │ :14317
+     ▼        ▼                ▼
+  ┌──────────────────────────────────┐    External OTLP
+  │           gateway (2x)           │◄── (4317/4318)
+  │   L1 (external) → L2 (balanced)  │
+  │   servicegraph + S3 export       │──► S3 bucket
+  └──────────────────────────────────┘
 ```
 
 ## Data Flow
 
-**Agent/Poller → Gateway (interproc, port 24318)**:
+The gateway runs a two-stage (L1/L2) pipeline for metrics and traces. L1 is
+stateless and load-balances by stream/trace ID across gateway pods over the
+`collector-gateway-headless` Service on port 14317; L2 receives the balanced
+data and runs stateful processors (`cumulativetodelta`, `aggregation/s3`,
+`servicegraph`).
 
-- Agent and poller pre-convert cumulative metrics to delta before sending.
-- Gateway receives pre-delta'd data and writes straight to S3 (no load-balancing needed).
+**Agent/Poller → Gateway**:
+
+- Logs: agent → gateway interproc HTTP (`collector-gateway-interproc:24318`).
+- Metrics: agent and poller pre-convert cumulative to delta locally, then
+  use a `loadbalancing` exporter (`routing_key: streamID`) to send straight
+  into gateway L2 on port 14317, skipping the gateway's L1 hop.
+- Traces: agent uses a `loadbalancing` exporter (`routing_key: traceID`)
+  to send straight into gateway L2 on port 14317, so `servicegraph` sees
+  complete traces.
+- The agent/poller need a namespace `Role` granting `endpoints` watch (the
+  `loadbalancing` exporter's k8s resolver discovers gateway pods via the
+  headless Service's endpoints). The default `agent/role.yaml` and
+  `poller/role.yaml` provide this.
 
 **External OTLP → Gateway (ports 4317/4318)**:
 
 - External sources may send cumulative metrics.
-- Gateway load-balances external metrics by stream ID across pods, then applies cumulative-to-delta conversion before writing to S3.
-- External logs and traces go straight to S3.
+- Gateway load-balances external metrics by stream ID across pods (L1 →
+  L2), then applies cumulative-to-delta conversion before writing to S3.
+- External traces fan out to both the load balancer (for `servicegraph`)
+  and directly to S3 from L1, so raw spans land in S3 without an extra
+  hop.
+- External logs go straight to S3.
 
-**Servicegraph**: All traces (interproc and external) feed into the `servicegraph` connector, which generates span-derived metrics (call counts, latency) written to S3.
+**Servicegraph**: runs in the L2 traces pipeline only, so a given trace's
+spans always land on a single pod regardless of source.
 
 ## Troubleshooting
 

--- a/base-collector-manifests/agent/configmap.yaml
+++ b/base-collector-manifests/agent/configmap.yaml
@@ -37,10 +37,37 @@ data:
           k8s.pod.uptime: {enabled: true}
 
     exporters:
+      # Logs go to the gateway's interproc HTTP listener (any pod is fine).
       otlphttp/upstream:
         endpoint: "http://collector-gateway-interproc:24318"
         tls:
           insecure: true
+      # Metrics: streamID-balanced directly into gateway L2 so cumulativetodelta
+      # / aggregation/s3 land on a consistent pod (skipping the gateway's L1 hop).
+      loadbalancing/metrics:
+        protocol:
+          otlp:
+            timeout: 10s
+            tls:
+              insecure: true
+        resolver:
+          k8s:
+            ports: [14317]
+            service: "${env:GATEWAY_HEADLESS_SERVICE_NAME}.${env:GATEWAY_NAMESPACE}"
+        routing_key: streamID
+      # Traces: traceID-balanced directly into gateway L2 so servicegraph sees
+      # complete traces (skipping the gateway's L1 hop).
+      loadbalancing/traces:
+        protocol:
+          otlp:
+            timeout: 10s
+            tls:
+              insecure: true
+        resolver:
+          k8s:
+            ports: [14317]
+            service: "${env:GATEWAY_HEADLESS_SERVICE_NAME}.${env:GATEWAY_NAMESPACE}"
+        routing_key: traceID
 
     processors:
       memory_limiter:
@@ -130,6 +157,8 @@ data:
           exporters: [forward/enriched]
 
         # --- Export to gateway ---
+        # Logs to L1 (interproc HTTP); metrics/traces skip L1 and balance
+        # directly into L2 by streamID/traceID.
         logs/export:
           receivers: [forward/enriched]
           processors: [batch]
@@ -137,11 +166,11 @@ data:
         metrics/export:
           receivers: [forward/enriched]
           processors: [cumulativetodelta, batch]
-          exporters: [otlphttp/upstream]
+          exporters: [loadbalancing/metrics]
         traces/export:
           receivers: [forward/enriched]
           processors: [batch]
-          exporters: [otlphttp/upstream]
+          exporters: [loadbalancing/traces]
 
       telemetry:
         resource:

--- a/base-collector-manifests/agent/daemonset.yaml
+++ b/base-collector-manifests/agent/daemonset.yaml
@@ -70,6 +70,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: K8S_CLUSTER_NAME
               value: "REPLACE_ME"
+            - name: GATEWAY_HEADLESS_SERVICE_NAME
+              value: "collector-gateway-headless"
+            - name: GATEWAY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - {containerPort: 4317, name: otlp-grpc, protocol: TCP}
             - {containerPort: 4318, name: otlp-http, protocol: TCP}

--- a/base-collector-manifests/agent/role.yaml
+++ b/base-collector-manifests/agent/role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: collector-agent
+  labels:
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: collector-agent
+    app.kubernetes.io/name: cardinalhq-otel-collector
+rules:
+  - apiGroups: [""]
+    resources: [endpoints]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: collector-agent
+  labels:
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: collector-agent
+    app.kubernetes.io/name: cardinalhq-otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: collector-agent
+subjects:
+  - kind: ServiceAccount
+    name: collector-agent

--- a/base-collector-manifests/gateway/configmap.yaml
+++ b/base-collector-manifests/gateway/configmap.yaml
@@ -117,19 +117,12 @@ data:
     service:
       extensions: [cgroupruntime, health_check]
       pipelines:
-        # --- Interproc: pre-delta'd from agent/poller, straight to S3 ---
+        # --- Interproc: only logs land here; agent/poller balance their
+        # metrics/traces directly into L2 (otlp/l2) and skip this hop. ---
         logs:
           receivers: [otlp/interproc]
           processors: [batch]
           exporters: [awss3]
-        metrics/interproc:
-          receivers: [otlp/interproc]
-          processors: [batch]
-          exporters: [awss3]
-        traces/interproc:
-          receivers: [otlp/interproc]
-          processors: [batch]
-          exporters: [loadbalancing/traces, awss3]
 
         # --- External OTLP: logs and traces straight through ---
         logs/external:

--- a/base-collector-manifests/kustomization.yaml
+++ b/base-collector-manifests/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - agent/serviceaccount.yaml
   - agent/clusterrole.yaml
   - agent/clusterrolebinding.yaml
+  - agent/role.yaml
   - agent/service.yaml
   - agent/configmap.yaml
   - agent/daemonset.yaml
@@ -19,6 +20,7 @@ resources:
   - poller/serviceaccount.yaml
   - poller/clusterrole.yaml
   - poller/clusterrolebinding.yaml
+  - poller/role.yaml
   - poller/configmap.yaml
   - poller/deployment.yaml
 

--- a/base-collector-manifests/poller/configmap.yaml
+++ b/base-collector-manifests/poller/configmap.yaml
@@ -11,10 +11,19 @@ data:
         allocatable_types_to_report: [cpu, memory, ephemeral-storage, storage]
 
     exporters:
-      otlphttp/upstream:
-        endpoint: "http://collector-gateway-interproc:24318"
-        tls:
-          insecure: true
+      # Metrics: streamID-balanced directly into gateway L2 so cumulativetodelta
+      # / aggregation/s3 land on a consistent pod (skipping the gateway's L1 hop).
+      loadbalancing/metrics:
+        protocol:
+          otlp:
+            timeout: 10s
+            tls:
+              insecure: true
+        resolver:
+          k8s:
+            ports: [14317]
+            service: "${env:GATEWAY_HEADLESS_SERVICE_NAME}.${env:GATEWAY_NAMESPACE}"
+        routing_key: streamID
 
     processors:
       resource/core:
@@ -46,7 +55,7 @@ data:
         metrics:
           receivers: [k8s_cluster]
           processors: [resource/core, cumulativetodelta, batch]
-          exporters: [otlphttp/upstream]
+          exporters: [loadbalancing/metrics]
 
       telemetry:
         resource:

--- a/base-collector-manifests/poller/deployment.yaml
+++ b/base-collector-manifests/poller/deployment.yaml
@@ -63,6 +63,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: K8S_CLUSTER_NAME
               value: "REPLACE_ME"
+            - name: GATEWAY_HEADLESS_SERVICE_NAME
+              value: "collector-gateway-headless"
+            - name: GATEWAY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - {containerPort: 13133, name: healthz, protocol: TCP}
           readinessProbe:

--- a/base-collector-manifests/poller/role.yaml
+++ b/base-collector-manifests/poller/role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: collector-poller
+  labels:
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: collector-poller
+    app.kubernetes.io/name: cardinalhq-otel-collector
+rules:
+  - apiGroups: [""]
+    resources: [endpoints]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: collector-poller
+  labels:
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: collector-poller
+    app.kubernetes.io/name: cardinalhq-otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: collector-poller
+subjects:
+  - kind: ServiceAccount
+    name: collector-poller


### PR DESCRIPTION
## Summary
- Agent and poller now send metrics (streamID) and traces (traceID) straight into the gateway's `otlp/l2` listener on port 14317 via `loadbalancing` exporters, skipping the gateway's L1 hop.
- Only logs continue to use the gateway's interproc HTTP endpoint (`collector-gateway-interproc:24318`).
- Servicegraph state is now consistent: a given trace's spans always land on a single gateway pod regardless of source.
- Gateway's now-dead `metrics/interproc` and `traces/interproc` pipelines removed; `otlp/interproc` receiver remains for the logs pipeline.
- Agent and poller get a namespace `Role` granting `endpoints` get/list/watch so the loadbalancing exporter's k8s resolver can discover gateway pods (mirrors the gateway's existing Role).
- New env vars on the agent DaemonSet and poller Deployment: `GATEWAY_HEADLESS_SERVICE_NAME` (defaults to `collector-gateway-headless`) and `GATEWAY_NAMESPACE` (downward-API'd from `metadata.namespace`).
- README architecture diagram + data-flow section updated.

This mirrors the same change just shipped in the kubepi cluster (skandragon/kubernetes-clusters).

## Test plan
- [x] `kustomize build base-collector-manifests/` clean; render shows 3 Roles + 3 RoleBindings (agent, poller, gateway) and the existing 3 ConfigMaps/DaemonSet/Deployments.
- [ ] Apply to a test cluster and verify agent/poller logs show successful endpoint resolution for `collector-gateway-headless`.
- [ ] Verify metrics arrive at gateway L2 pods (look for traffic on port 14317, not 24318).
- [ ] Verify `servicegraph` metrics in S3 still produce reasonable call counts.