### PR TITLE
lakerunner: chart 3.12.18, appVersion v1.32.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.12.17"
-appVersion: "v1.31.1"
+version: "3.12.18"
+appVersion: "v1.32.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.32.0 release (log message truncation, 10K char cap).