### PR TITLE
maestro: chart 0.8.10, appVersion v1.45.12

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.9"
-appVersion: "v1.45.11"
+version: "0.8.10"
+appVersion: "v1.45.12"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.45.12 release ([cardinalhq/conductor#888](https://github.com/cardinalhq/conductor/pull/888)).