### PR TITLE
lakerunner: chart 3.12.20, appVersion v1.34.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.12.19"
-appVersion: "v1.33.0"
+version: "3.12.20"
+appVersion: "v1.34.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.34.0 release (allowance-adjusted worklane age hints + compaction 5m default, #809).