### PR TITLE
Right-size base collector resources + load-dependence note

### DIFF
--- a/base-collector-manifests/agent/daemonset.yaml
+++ b/base-collector-manifests/agent/daemonset.yaml
@@ -80,12 +80,16 @@ spec:
               port: 13133
             initialDelaySeconds: 3
             periodSeconds: 10
+          # NOTE: resource needs are highly load-dependent (telemetry volume,
+          # node density). These are sane low-load defaults; agent memory in
+          # particular scales with throughput (observed up to ~480Mi under load).
+          # Re-measure (kubectl top) and adjust per cluster.
           resources:
             requests:
-              cpu: "1"
+              cpu: 100m
               memory: 500Mi
             limits:
-              cpu: "1"
+              cpu: 500m
               memory: 500Mi
           volumeMounts:
             - name: config

--- a/base-collector-manifests/gateway/deployment.yaml
+++ b/base-collector-manifests/gateway/deployment.yaml
@@ -115,13 +115,17 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          # NOTE: the gateway is the ingest data plane — resource needs scale
+          # directly with telemetry throughput and can spike well above idle.
+          # These are sane low-load defaults; size on PEAK (not instantaneous)
+          # usage per cluster and re-measure as load grows.
           resources:
             requests:
-              cpu: "2"
-              memory: 2Gi
+              cpu: "1"
+              memory: 1Gi
             limits:
-              cpu: "2"
-              memory: 2Gi
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /app/config

--- a/base-collector-manifests/poller/deployment.yaml
+++ b/base-collector-manifests/poller/deployment.yaml
@@ -78,13 +78,16 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          # NOTE: resource needs are highly load-dependent (cluster size, object
+          # count). These are sane low-load defaults; re-measure (kubectl top)
+          # and adjust per cluster.
           resources:
             requests:
-              cpu: "1"
-              memory: 500Mi
+              cpu: 100m
+              memory: 256Mi
             limits:
-              cpu: "1"
-              memory: 500Mi
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: config
               mountPath: /app/config


### PR DESCRIPTION
The base collector manifests shipped with heavily over-provisioned CPU (agent/poller `1` core, gateway `2`) vs measured single-digit-to-tens-of-millicores actual use across prod + kubepi. Aligns defaults with the right-sized kubepi values:

- **agent**: `1`/500Mi → req `100m`/500Mi, limit `500m`/500Mi (memory kept — scales with throughput).
- **poller**: `1`/500Mi → req `100m`/256Mi, limit `500m`/512Mi.
- **gateway**: `2`/2Gi → `1`/1Gi.

Each block gets a comment noting resource needs are highly load-dependent and should be re-measured per cluster (gateway sized on peak, not idle).