### PR TITLE
maestro: chart 0.8.13, appVersion v1.47.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.12"
-appVersion: "v1.46.1"
+version: "0.8.13"
+appVersion: "v1.47.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Bump for maestro/v1.47.0 release (PR #896 — license token kind: manually_installed vs operator_managed).