### PR TITLE
lakerunner: distinct pprof ports per control-plane container (chart 3.13.1)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-colocate-control-plane-design.md
+++ b/docs/superpowers/specs/2026-06-01-colocate-control-plane-design.md
@@ -54,6 +54,17 @@ collide. Confirmed in the lakerunner repo that
 env, **no binary change required**. Port audit confirmed only admin-api binds a
 second port (HTTP `:9091`); the others bind only their health port.
 
+The same shared-namespace collision applies to the **pprof** debug server
+(`:6060`, gated by `ENABLE_PPROF`): when pprof is enabled (commonly via
+`global.env ENABLE_PPROF=true`), all four containers would bind `:6060`. The
+binary honors `PPROF_PORT`, so each container gets a distinct
+`PPROF_PORT = controlPlane.pprof.basePort + offset` (default base `6060`:
+admin-api 6060, alert-evaluator 6061, monitoring 6062, sweeper 6063). PPROF_PORT
+is always emitted; the binary only honors it when pprof is on. A
+`controlPlane.pprof.enabled` flag sets `ENABLE_PPROF=true` per container.
+(Added in chart 3.13.1, after the 3.13.0 rollout surfaced the collision in
+prod.)
+
 ## Design
 
 ### New template: `templates/control-plane-deployment.yaml`

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.13.0"
+version: "3.13.1"
 appVersion: "v1.35.0"
 keywords:
   - lakerunner

--- a/lakerunner/templates/control-plane-deployment.yaml
+++ b/lakerunner/templates/control-plane-deployment.yaml
@@ -15,6 +15,18 @@ each container's probes target its own listener.
 {{- $hcAlert := add $hcBase 1 -}}
 {{- $hcMon := add $hcBase 2 -}}
 {{- $hcSweep := add $hcBase 3 -}}
+{{/*
+pprof (gated by ENABLE_PPROF in the binary, which may come from the chart flag
+controlPlane.pprof.enabled or from global.env). Each container gets a distinct
+PPROF_PORT = basePort + offset so the four don't collide on the shared pod
+network namespace. PPROF_PORT is always emitted; the binary only honors it when
+pprof is enabled.
+*/}}
+{{- $pprofBase := .Values.controlPlane.pprof.basePort | int -}}
+{{- $pprofAdmin := $pprofBase -}}
+{{- $pprofAlert := add $pprofBase 1 -}}
+{{- $pprofMon := add $pprofBase 2 -}}
+{{- $pprofSweep := add $pprofBase 3 -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,6 +94,12 @@ spec:
             value: /scratch
           - name: HEALTH_CHECK_PORT
             value: {{ $hcAdmin | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofAdmin | quote }}
           {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.adminApi.env | default list) "resources" .Values.controlPlane.resources.adminApi)) | nindent 8 }}
           {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
         {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-admin") | nindent 8 }}
@@ -123,6 +141,12 @@ spec:
             value: /scratch
           - name: HEALTH_CHECK_PORT
             value: {{ $hcAlert | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofAlert | quote }}
           - name: ALERT_EVALUATOR_QUERY_API_URL
             value: {{ .Values.alertEvaluator.queryApiUrl | default (printf "http://%s-query-api:%v" (include "lakerunner.fullname" .) .Values.queryApi.service.port) | quote }}
           {{- if eq .Values.cloudProvider.provider "azure" }}
@@ -177,6 +201,12 @@ spec:
             value: /scratch
           - name: HEALTH_CHECK_PORT
             value: {{ $hcMon | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofMon | quote }}
           {{- include "lakerunner.autoscalerEnv" . | nindent 10 }}
           {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.monitoring.env | default list) "resources" .Values.controlPlane.resources.monitoring)) | nindent 8 }}
           {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
@@ -219,6 +249,12 @@ spec:
             value: /scratch
           - name: HEALTH_CHECK_PORT
             value: {{ $hcSweep | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofSweep | quote }}
           {{- if eq .Values.cloudProvider.provider "azure" }}
           - name: AZURE_AUTH_TYPE
             value: {{ .Values.cloudProvider.azure.authType | quote }}

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -473,6 +473,15 @@ controlPlane:
     repository: ghcr.io/cardinalhq/lakerunner
     tag: ""
     pullPolicy: ""
+  # pprof debug server. The four containers share the pod network namespace, so
+  # each gets a distinct PPROF_PORT = basePort + offset (admin-api +0,
+  # alert-evaluator +1, monitoring +2, sweeper +3) to avoid colliding on the
+  # default 6060. PPROF_PORT is always set per container; the binary only honors
+  # it when pprof is enabled (via this flag, or globally via global.env
+  # ENABLE_PPROF=true).
+  pprof:
+    enabled: false # sets ENABLE_PPROF=true on each control-plane container
+    basePort: 6060
   podSecurityContext: {}
   containerSecurityContext: {}
   labels: {}


### PR DESCRIPTION
## What
Fixes a port collision surfaced by the 3.13.0 control-plane rollout in prod:

```
level=ERROR msg="Pprof server error" service=lakerunner-alert-evaluator error="listen tcp :6060: bind: address already in use"
```

With pprof enabled (prod sets `ENABLE_PPROF=true` via `global.env`), all four control-plane containers tried to bind `:6060` in the shared pod network namespace — only one wins, the other three error. Non-fatal (services stay ready) but pprof was broken on 3/4 and it spammed ERROR logs.

## Fix (chart only — binary already honors `PPROF_PORT`)
Each container gets a distinct `PPROF_PORT = controlPlane.pprof.basePort + offset`:

| container | PPROF_PORT |
|---|---|
| admin-api | 6060 |
| alert-evaluator | 6061 |
| monitoring | 6062 |
| sweeper | 6063 |

- `PPROF_PORT` is always emitted; the binary only honors it when pprof is enabled.
- New `controlPlane.pprof.enabled` flag sets `ENABLE_PPROF=true` per container; `controlPlane.pprof.basePort` (default `6060`) is configurable.
- Same pattern as the existing `HEALTH_CHECK_PORT` (8090–8093) collision fix.

Patch bump `3.13.0` → `3.13.1`; appVersion unchanged.