### PR TITLE
maestro: chart 0.8.17, appVersion v1.50.0

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.16"
-appVersion: "v1.49.0"
+version: "0.8.17"
+appVersion: "v1.50.0"
 keywords:
   - maestro
   - ai


### PR DESCRIPTION
Tracks the maestro v1.50.0 release tag. No template / values changes — appVersion + chart-patch bump only. v1.50.0 bundles #905 (SP3 trial wizard), #907 (cold-login fix), #910 (demo passthrough), #912 (SPA-shadow fix) into a stable release off the rc1–rc5 line.