### PR TITLE
lakerunner: set LAKERUNNER_SCRATCH_DISK_SIZE_BYTES for emptyDir scratch (#783)

### DIFF
--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -605,6 +605,47 @@ Usage: {{ include "lakerunner.autoscalerEnv" . }}
 {{- end -}}
 
 {{/*
+Emit the LAKERUNNER_SCRATCH_DISK_SIZE_BYTES env var for scratch-using services.
+
+Behavior (issue #783):
+  - global.temporaryStorage.type == "ephemeral" (a real PersistentVolume via
+    volumeClaimTemplate): emit NOTHING. The app falls back to statfs(), which is
+    accurate on a dedicated PV. Setting an explicit size here would only cap the
+    real volume.
+  - otherwise (emptyDir backed by the node disk, with a sizeLimit): emit the
+    sizeLimit converted to bytes so the app treats it as its authoritative scratch
+    slice and stays within it. statfs on an emptyDir reports the whole node disk,
+    not the pod's slice, so the explicit value is required.
+
+The size value is the same one passed to lakerunner.ephemeralVolume, so the env
+var always matches the emptyDir sizeLimit. Emits nothing if no size is set or it
+parses to <= 0.
+
+Takes two args:
+  0: the root chart context
+  1: the component's values block (must have .temporaryStorage.size)
+Usage:
+  {{ include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
+*/}}
+{{- define "lakerunner.scratchDiskSizeEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- if ne $root.Values.global.temporaryStorage.type "ephemeral" -}}
+{{- $size := "" -}}
+{{- if and $comp.temporaryStorage $comp.temporaryStorage.size -}}
+  {{- $size = $comp.temporaryStorage.size -}}
+{{- end -}}
+{{- if $size -}}
+{{- $bytes := include "lakerunner.parseMemoryToBytes" $size | int64 -}}
+{{- if gt $bytes 0 }}
+- name: LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+  value: {{ $bytes | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Generate ephemeral volume configuration based on global settings.
 Takes three arguments: volume name, storage size, and root context
 Usage: {{ include "lakerunner.ephemeralVolume" (list "scratch" .Values.componentName.temporaryStorage.size .) }}
@@ -993,6 +1034,7 @@ Usage: {{ include "lakerunner.duckdbRuntimeEnv" (list . .Values.componentName .V
   value: "2"
 {{- end }}
 {{- end -}}
+{{- include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
 {{- end -}}
 
 {{/*
@@ -1054,6 +1096,7 @@ Usage: {{ include "lakerunner.queryWorkerRuntimeEnv" (list . .Values.queryWorker
   value: "2"
 {{- end }}
 {{- end -}}
+{{- include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
 {{- end -}}
 
 {{/*

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -29,13 +29,29 @@ global:
     tag: ""
     # Default pull policy for all images
     pullPolicy: "IfNotPresent"
-  # Global temporary storage configuration
-  # This allows switching between emptyDir and ephemeral volume claim templates
-  # Storage sizes are configured per-service in their respective temporaryStorage.size settings
+  # Global temporary storage (scratch / DuckDB temp / cache) configuration.
+  # This allows switching between emptyDir and ephemeral volume claim templates.
+  # Storage sizes are configured per-service in their respective temporaryStorage.size settings.
+  #
+  # Scratch-disk-size behavior (LAKERUNNER_SCRATCH_DISK_SIZE_BYTES):
+  #   The scratch-using services (process-logs/metrics/traces, query-worker) tell
+  #   the app how much scratch they may use via LAKERUNNER_SCRATCH_DISK_SIZE_BYTES.
+  #   How that env var is set depends on `type` below:
+  #   - type: "ephemeral" (a dedicated PersistentVolume via volumeClaimTemplate):
+  #       LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is left UNSET. The app probes the
+  #       filesystem with statfs(), which is accurate on a real PV.
+  #   - type: "emptyDir" (node-disk-backed, with a sizeLimit): the env var is set
+  #       to the per-service temporaryStorage.size converted to bytes. statfs on an
+  #       emptyDir reports the whole node disk, not the pod's slice, so the app
+  #       needs the explicit value to stay within its slice.
   temporaryStorage:
     # Type of temporary storage: "emptyDir" or "ephemeral"
-    # - emptyDir: Traditional emptyDir volumes (default)
+    # - emptyDir: Traditional emptyDir volumes (default). The pod's scratch slice
+    #   is bounded by sizeLimit, and LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is set to
+    #   that size so the app stays within it.
     # - ephemeral: Uses ephemeral volume claim templates for CSI-based storage
+    #   (a real PV). LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is left unset so the app
+    #   uses statfs(), which is accurate for a dedicated PV.
     type: "emptyDir"
     # Configuration for ephemeral volume claim templates (only used when type: "ephemeral")
     ephemeral:
@@ -391,6 +407,12 @@ processLogs:
       cpu: "1"
       memory: 2Gi
   temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
     size: "10Gi"
   autoscaling:
     minReplicas: 1
@@ -419,6 +441,12 @@ processMetrics:
       cpu: "1"
       memory: 2Gi
   temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
     size: "10Gi"
   autoscaling:
     minReplicas: 1
@@ -447,6 +475,12 @@ processTraces:
       cpu: "1"
       memory: 2Gi
   temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
     size: "10Gi"
   autoscaling:
     minReplicas: 1
@@ -790,6 +824,12 @@ queryWorker:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
   temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
     size: "100Gi"
   labels: {}
   annotations: {}


### PR DESCRIPTION
Chart side of cardinalhq/lakerunner#783 (app PR: cardinalhq/lakerunner#850).

The app can now be told its scratch/cache disk slice via `LAKERUNNER_SCRATCH_DISK_SIZE_BYTES` instead of probing the filesystem with `statfs`. On a node-disk-backed `emptyDir`, `statfs` reports the whole node, not the pod's slice, so the app could overrun its limit and get evicted. On a dedicated PV, `statfs` is accurate and preferred.

## Changes

- New `lakerunner.scratchDiskSizeEnv` helper, wired into `lakerunner.duckdbRuntimeEnv` and `lakerunner.queryWorkerRuntimeEnv` so the four scratch-heavy services (process-logs/metrics/traces, query-worker) emit the env var:
  - `global.temporaryStorage.type == "ephemeral"` (real PV via `volumeClaimTemplate`) → **unset**, so the app uses `statfs()`.
  - otherwise (`emptyDir`) → set to the per-service `temporaryStorage.size` converted to bytes (reusing the existing `lakerunner.parseMemoryToBytes`), matching the `emptyDir` `sizeLimit`.
- `values.yaml`: documents the PV-vs-emptyDir behavior on `global.temporaryStorage` and each service's `temporaryStorage.size` (no default values changed).

The env var is wired from the `emptyDir` `sizeLimit` value (not a downward-API `resourceFieldRef`) because this chart bounds scratch with an `emptyDir` `sizeLimit`, not an `ephemeral-storage` resource limit — using the same size value keeps the env var and the `sizeLimit` consistent.

## Testing

`helm lint` passes for both `type=emptyDir` (default) and `type=ephemeral`. Rendered output: emptyDir services get `LAKERUNNER_SCRATCH_DISK_SIZE_BYTES` (e.g. `10Gi` → `10737418240`); ephemeral renders no such env var for any service. Non-scratch services (query-api, control-plane, pubsub-*, perch, setup-job) are unaffected.

No chart version bump (left for the release commit, per repo convention).