### PR TITLE
maestro: add dex.extraRedirectURIs for non-prod OIDC origins

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.17"
+version: "0.8.18"
 appVersion: "v1.50.0"
 keywords:
   - maestro

--- a/maestro/templates/dex-configmap.yaml
+++ b/maestro/templates/dex-configmap.yaml
@@ -3,6 +3,7 @@
 {{- include "maestro.dexValidate" . -}}
 {{- $d := .Values.dex | default dict -}}
 {{- $users := dig "staticUsers" list $d -}}
+{{- $extraRedirects := dig "extraRedirectURIs" list $d -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,6 +35,13 @@ data:
         public: true
         redirectURIs:
           - {{ include "maestro.dexRedirectUri" . }}
+          {{- /* Extra dev/CI redirect URIs (e.g. a local Vite dev server at
+              http://localhost:5173/ pointed at this backend). Appended verbatim
+              so non-prod origins can complete the OIDC PKCE flow without
+              hand-patching the live ConfigMap. Leave empty in prod. */}}
+          {{- range $extraRedirects }}
+          - {{ . | quote }}
+          {{- end }}
     staticPasswords:
       {{- toYaml $users | nindent 6 }}
 {{- end }}

--- a/maestro/tests/dex_test.yaml
+++ b/maestro/tests/dex_test.yaml
@@ -257,6 +257,41 @@ tests:
           path: data["config.yaml"]
           pattern: "- maestro-superadmin"
 
+  - it: appends extraRedirectURIs after the canonical base-url redirect
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+      dex.extraRedirectURIs:
+        - http://localhost:5173/
+    template: dex-configmap.yaml
+    asserts:
+      # canonical base-url redirect still first, extra appended after it
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "redirectURIs:\\s*\\n\\s*- http://m.example.com/\\s*\\n\\s*- \"http://localhost:5173/\""
+
+  - it: registers only the base-url redirect when extraRedirectURIs is unset
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: dex-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "localhost"
+
   - it: dex deployment mounts a writable /tmp emptyDir
     set:
       dex.enabled: true

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -443,6 +443,15 @@ dex:
   # maestro pod returns 404 for /<pathPrefix>/* and an Ingress is
   # required for the OIDC flow to work).
   # proxyEnabled: true
+  #
+  # Extra redirect URIs to whitelist on the maestro-ui Dex client, in
+  # addition to the canonical "<baseUrl>/" the chart always registers.
+  # Use this for non-prod origins that complete the same OIDC PKCE flow —
+  # e.g. a local Vite dev server (`ui-vite-dev`) pointed at this backend,
+  # which sends redirect_uri = http://localhost:5173/. Leave empty ([])
+  # in prod so only the real base URL is accepted.
+  # extraRedirectURIs:
+  #   - http://localhost:5173/
 
 # Global settings
 global:


### PR DESCRIPTION
## What

Adds an optional `dex.extraRedirectURIs` list to the maestro chart. Entries are appended verbatim to the bundled Dex `maestro-ui` client's `redirectURIs`, after the canonical `<baseUrl>/` the chart always registers.

## Why

The bundled Dex only whitelists `<baseUrl>/` as a redirect URI. When you run the `ui-vite-dev` loop (a local Vite dev server pointed at a real maestro backend), the SPA does OIDC PKCE in the browser and sends `redirect_uri = window.location.origin + "/" = http://localhost:5173/`. Dex rejects that with `invalid_redirect_uri` unless it's whitelisted — today the only fix is hand-patching the live ConfigMap, which evaporates on the next `helm upgrade`. This makes the dev origin a durable, declarative value.

## Behavior

- Empty/unset by default → prod accepts only the real base URL (no change to existing installs).
- Set in non-prod values to whitelist extra origins, e.g.:
  ```yaml
  dex:
    extraRedirectURIs:
      - http://localhost:5173/
  ```

## Tests

Two new `helm-unittest` cases in `dex_test.yaml`: one asserts the extra URI is appended after the canonical redirect, one asserts the default emits no extra (no `localhost`). Full suite: 115 passing.

Chart `0.8.17 -> 0.8.18` (additive, `appVersion` unchanged).

## Companion

The consumer wiring (trial-testenv `make trial-up` passing `http://localhost:5173/`) lands separately in the conductor repo.