### PR TITLE
maestro: fix cert-init openssl image + DN section (tls-init crash-loop)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.18"
+version: "0.8.19"
 appVersion: "v1.50.0"
 keywords:
   - maestro

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -86,7 +86,7 @@ spec:
             if [ -n "${EXTRA_SANS}" ]; then SAN="${SAN},${EXTRA_SANS}"; fi
             cat >/tmp/openssl.cnf <<EOF
             [req]
-            distinguished_name=req
+            distinguished_name=req_distinguished_name
             prompt=no
             req_extensions=v3
             [req_distinguished_name]

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -270,6 +270,36 @@ tests:
             image: registry.example.com/openssl:3.3
           any: true
 
+  - it: cert-init defaults to the pinned immutable openssl image
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+    asserts:
+      # SP5: default openssl image must be an immutable digest pin, never :latest.
+      - template: maestro-deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: tls-init
+            image: alpine/openssl:3.5.4@sha256:42c7389ef077aed0eb4e96d0abbd094083d701bbaff1313073b061c0c9cd8278
+          any: true
+
+  - it: cert-init openssl config uses the correct distinguished_name section
+    set:
+      maestro.baseUrl: https://m.example.com
+      maestro.tls.enabled: true
+    asserts:
+      # A `distinguished_name=req` typo makes openssl reject the config and the
+      # tls-init container crash-loops. The DN must reference the actual section.
+      - template: maestro-deployment.yaml
+        matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="tls-init")].args[0]
+          pattern: "distinguished_name=req_distinguished_name"
+      - template: maestro-deployment.yaml
+        notMatchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="tls-init")].args[0]
+          pattern: "distinguished_name=req\\n"
+
   - it: cert-init injects host derived from baseUrl into env
     set:
       maestro.baseUrl: https://m.example.com:8443

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -186,10 +186,17 @@ maestro:
       # `maestro.baseUrl`. Used only by the autoGenerate path.
       sans: []
       # Image used by the cert-init container. openssl CLI is the only
-      # requirement.
+      # requirement. Pinned to an immutable digest (SP5): the previous
+      # cgr.dev/chainguard/openssl:latest is a mutable floating tag, is not
+      # anonymously pullable, and is distroless (no /bin/sh — but the tls-init
+      # container overrides command: ["/bin/sh","-c"]). alpine/openssl is
+      # publicly pullable, Alpine-based (has /bin/sh), and ships the openssl CLI.
+      # Digest resolved via `crane digest alpine/openssl:3.5.4` (2026-06-02) and
+      # mirrors the server default in
+      # packages/maestro/src/lib/maestro-workload-config.ts.
       image:
-        repository: cgr.dev/chainguard/openssl
-        tag: latest
+        repository: alpine/openssl
+        tag: "3.5.4@sha256:42c7389ef077aed0eb4e96d0abbd094083d701bbaff1313073b061c0c9cd8278"
         pullPolicy: IfNotPresent
       # Inline-provided PEM certificate and private key. When both are
       # non-empty, the chart creates a kubernetes.io/tls Secret named


### PR DESCRIPTION
## What

Fixes two independent bugs that crash-loop the `tls-init` cert-init container when `maestro.tls.enabled=true` on the default (`autoGenerate`) cert path.

1. **Default cert-init image.** Was `cgr.dev/chainguard/openssl:latest` — a mutable floating tag, **not anonymously pullable**, and **distroless (no `/bin/sh`)** even though the container runs `command: ["/bin/sh","-c"]`. So as shipped it either can't pull or can't exec. Pinned to `alpine/openssl:3.5.4@sha256:42c7389...` — publicly pullable, Alpine-based (has `/bin/sh`), ships the openssl CLI — an immutable digest mirroring the server-side default in `packages/maestro/src/lib/maestro-workload-config.ts`.

2. **openssl DN section.** The req config set `distinguished_name=req`, pointing the DN at the wrong section; it must reference `[req_distinguished_name]` (the section that holds the DN fields). As written openssl rejects the config and tls-init crash-loops.

## Tests

Two new `tls_test.yaml` cases: default image is the pinned immutable digest, and the openssl config references `distinguished_name=req_distinguished_name` (not the bare `req` typo). Full suite: 117 passing.

Chart `0.8.18 -> 0.8.19` (bugfix, `appVersion` unchanged).

## Provenance

This was finished-but-uncommitted work found stranded in the chart working tree (looks like a prior unmerged session). Verified correct and tested, split out from the unrelated Dex redirect change ([#188](https://github.com/cardinalhq/charts/pull/188)) and landed on its own.