### PR TITLE
maestro: add dex.allowedOrigins (CORS for cross-origin OIDC)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.19"
+version: "0.8.20"
 appVersion: "v1.50.0"
 keywords:
   - maestro

--- a/maestro/templates/dex-configmap.yaml
+++ b/maestro/templates/dex-configmap.yaml
@@ -4,6 +4,7 @@
 {{- $d := .Values.dex | default dict -}}
 {{- $users := dig "staticUsers" list $d -}}
 {{- $extraRedirects := dig "extraRedirectURIs" list $d -}}
+{{- $allowedOrigins := dig "allowedOrigins" list $d -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,6 +23,22 @@ data:
       type: memory
     web:
       http: 0.0.0.0:{{ $cfg.port }}
+      {{- /* CORS allowed origins for Dex's own HTTP endpoints (discovery,
+          token, keys). A browser SPA served from a DIFFERENT origin than the
+          maestro backend — e.g. a local Vite dev server (`ui-vite-dev`) at
+          http://localhost:5173 — fetches /dex/.well-known/openid-configuration
+          and the token endpoint cross-origin; without Dex emitting CORS
+          headers the OIDC PKCE flow fails at discovery. maestro's own CORS
+          middleware covers /api but NOT the /dex reverse-proxy pass-through,
+          so Dex must allow the origin itself. Pairs with extraRedirectURIs
+          (which whitelists the redirect; this whitelists the fetch origin).
+          Empty in prod (SPA is same-origin with maestro, no CORS needed). */}}
+      {{- with $allowedOrigins }}
+      allowedOrigins:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
     oauth2:
       skipApprovalScreen: true
     enablePasswordDB: true

--- a/maestro/tests/dex_test.yaml
+++ b/maestro/tests/dex_test.yaml
@@ -292,6 +292,41 @@ tests:
           path: data["config.yaml"]
           pattern: "localhost"
 
+  - it: emits web.allowedOrigins when dex.allowedOrigins is set
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+      dex.allowedOrigins:
+        - http://localhost:5173
+    template: dex-configmap.yaml
+    asserts:
+      # allowedOrigins nested under web:, before oauth2:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "web:\\s*\\n\\s*http: 0.0.0.0:5556\\s*\\n\\s*allowedOrigins:\\s*\\n\\s*- \"http://localhost:5173\""
+
+  - it: omits web.allowedOrigins when dex.allowedOrigins is unset
+    set:
+      dex.enabled: true
+      ingress.enabled: true
+      ingress.host: m.example.com
+      dex.staticUsers:
+        - email: a@example.com
+          username: a
+          userID: u1
+          hash: "$2a$10$abc"
+    template: dex-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "allowedOrigins"
+
   - it: dex deployment mounts a writable /tmp emptyDir
     set:
       dex.enabled: true

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -459,6 +459,18 @@ dex:
   # in prod so only the real base URL is accepted.
   # extraRedirectURIs:
   #   - http://localhost:5173/
+  #
+  # CORS origins Dex allows on its own HTTP endpoints (discovery, token,
+  # keys). Needed when a browser SPA served from a DIFFERENT origin than
+  # the maestro backend completes OIDC against the bundled Dex — e.g. a
+  # local Vite dev server (`ui-vite-dev`) at http://localhost:5173, which
+  # fetches /dex/.well-known/openid-configuration cross-origin. maestro's
+  # CORS middleware covers /api but not the /dex reverse-proxy, so Dex must
+  # allow the origin itself. Values are origins (scheme+host[:port], no
+  # path/trailing slash) — the redirect counterpart is extraRedirectURIs.
+  # Leave empty ([]) in prod (SPA is same-origin with maestro).
+  # allowedOrigins:
+  #   - http://localhost:5173
 
 # Global settings
 global:


### PR DESCRIPTION
## What

Adds an optional `dex.allowedOrigins` list, emitted as Dex's native `web.allowedOrigins` so Dex returns `Access-Control-Allow-Origin` on its own HTTP endpoints (discovery, token, keys).

## Why

A browser SPA served from a **different origin** than the maestro backend completes OIDC against the bundled Dex by fetching `/dex/.well-known/openid-configuration` and the token endpoint **cross-origin**. maestro's CORS middleware covers `/api` but **not** the `/dex` reverse-proxy pass-through, so the flow is blocked at discovery — before the redirect even happens.

This is the CORS counterpart to [#188](https://github.com/cardinalhq/charts/pull/188) (`extraRedirectURIs`): that whitelists the *redirect URI*, this whitelists the *fetch origin*. Both are required for a cross-origin SPA (e.g. the `ui-vite-dev` loop at `http://localhost:5173`) to log in. Discovered when an actual Playwright login against the kubepi sandbox failed at OIDC discovery with a CORS error.

> Note: prod doesn't hit this because it fronts Keycloak, not a live Dex on `/dex`; the path falls through to maestro's CORS-wrapped catch-all. Any **Dex-backed** maestro with a cross-origin SPA needs this.

## Behavior

- Empty/unset by default → no `web.allowedOrigins` emitted (prod SPA is same-origin; no change to existing installs).
- Set in non-prod values:
  ```yaml
  dex:
    allowedOrigins:
      - http://localhost:5173
  ```

## Tests

Two new `dex_test.yaml` cases (emit under `web:` when set, omit when unset). Full suite: 119 passing.

Chart `0.8.19 -> 0.8.20` (additive, `appVersion` unchanged).

## Verified live

Applied to the kubepi SaaS sandbox via `helm upgrade` + Dex restart; `curl -H 'Origin: http://localhost:5173' .../dex/.well-known/openid-configuration` now returns `access-control-allow-origin: http://localhost:5173`, and a full Playwright login (discovery → Dex sign-in → redirect → token) succeeds.