### PR TITLE
Update third-party images/packages to latest

### DIFF
--- a/grafana-init/Dockerfile
+++ b/grafana-init/Dockerfile
@@ -3,7 +3,7 @@
 # and (optionally) pre-installing the CardinalHQ LakeRunner datasource plugin
 # into a shared volume so the main Grafana container can load it without
 # a runtime HTTP pull.
-FROM postgres:13-alpine AS base
+FROM postgres:18-alpine AS base
 
 # Install bash, curl and unzip for scripts and plugin download
 RUN apk add --no-cache bash curl unzip
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash curl unzip
 # image can be deployed into air-gapped clusters without runtime network
 # access to github.com.
 FROM base AS plugin
-ARG CARDINAL_PLUGIN_VERSION=v2.4.0
+ARG CARDINAL_PLUGIN_VERSION=v2.5.0
 ARG CARDINAL_PLUGIN_URL=https://github.com/cardinalhq/cardinalhq-lakerunner-datasource/releases/download/${CARDINAL_PLUGIN_VERSION}/cardinalhq-lakerunner-datasource.zip
 RUN mkdir -p /opt/plugins \
  && curl -fsSL "$CARDINAL_PLUGIN_URL" -o /tmp/plugin.zip \

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -906,7 +906,7 @@ grafana:
     # Grafana downloads the plugin zip at startup via GF_INSTALL_PLUGINS.
     # Air-gapped deployments should either host the zip internally and point
     # this at it, or enable initContainer mode below.
-    url: "https://github.com/cardinalhq/cardinalhq-lakerunner-datasource/releases/download/v2.4.0/cardinalhq-lakerunner-datasource.zip;cardinalhq-lakerunner-datasource"
+    url: "https://github.com/cardinalhq/cardinalhq-lakerunner-datasource/releases/download/v2.5.0/cardinalhq-lakerunner-datasource.zip;cardinalhq-lakerunner-datasource"
     # Pre-install the Cardinal datasource plugin via an init container that
     # carries the plugin baked into its image, instead of relying on Grafana
     # pulling it over HTTP at startup. Recommended for air-gapped clusters

--- a/maestro/tests/tls_test.yaml
+++ b/maestro/tests/tls_test.yaml
@@ -281,7 +281,7 @@ tests:
           path: spec.template.spec.initContainers
           content:
             name: tls-init
-            image: alpine/openssl:3.5.4@sha256:42c7389ef077aed0eb4e96d0abbd094083d701bbaff1313073b061c0c9cd8278
+            image: alpine/openssl:3.5.6@sha256:87adbe7a8c904b825b9068d5a4060799b1e8280c67a64684f72cef376f627a46
           any: true
 
   - it: cert-init openssl config uses the correct distinguished_name section

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -160,7 +160,7 @@ maestro:
     # Sidecar image. Overridable for air-gapped registries.
     image:
       repository: nginxinc/nginx-unprivileged
-      tag: "1.27-alpine"
+      tag: "1.31-alpine"
       pullPolicy: IfNotPresent
     # Additional resources for the sidecar.
     resources:
@@ -191,12 +191,12 @@ maestro:
       # anonymously pullable, and is distroless (no /bin/sh — but the tls-init
       # container overrides command: ["/bin/sh","-c"]). alpine/openssl is
       # publicly pullable, Alpine-based (has /bin/sh), and ships the openssl CLI.
-      # Digest resolved via `crane digest alpine/openssl:3.5.4` (2026-06-02) and
+      # Digest resolved via `crane digest alpine/openssl:3.5.6` (2026-06-06) and
       # mirrors the server default in
       # packages/maestro/src/lib/maestro-workload-config.ts.
       image:
         repository: alpine/openssl
-        tag: "3.5.4@sha256:42c7389ef077aed0eb4e96d0abbd094083d701bbaff1313073b061c0c9cd8278"
+        tag: "3.5.6@sha256:87adbe7a8c904b825b9068d5a4060799b1e8280c67a64684f72cef376f627a46"
         pullPolicy: IfNotPresent
       # Inline-provided PEM certificate and private key. When both are
       # non-empty, the chart creates a kubernetes.io/tls Secret named


### PR DESCRIPTION
Bumps third-party container images and packages to their latest versions. No chart version bumps (intentional — to be handled separately).

| Item | Where | Old → New |
|------|-------|-----------|
| Cardinal datasource plugin | `grafana-init/Dockerfile`, `lakerunner/values.yaml` | `v2.4.0` → `v2.5.0` |
| postgres base image | `grafana-init/Dockerfile` | `13-alpine` → `18-alpine` |
| nginx sidecar | `maestro/values.yaml` | `1.27-alpine` → `1.31-alpine` |
| alpine/openssl (digest-pinned) | `maestro/values.yaml` + `tls_test.yaml` | `3.5.4` → `3.5.6` |

Notes:
- postgres init image is used only as a client (psql/pg_isready) + bake scripts; newer clients are backward-compatible with older servers.
- First-party CardinalHQ app images (lakerunner/maestro/watcher) left untouched — those track `appVersion`.
- apk packages stay unpinned (`apk add --no-cache`), already latest at build.

Verification: `helm lint` clean on both charts; `helm unittest` passes (maestro tls 19/19, lakerunner grafana 21/21).