### PR TITLE
maestro: rename persistence PVC to scratch (#105)

### DIFF
--- a/maestro/Chart.yaml
+++ b/maestro/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maestro
 description: A Helm chart for Maestro - AI agent server with web UI
 type: application
-version: "0.8.22"
+version: "0.9.0"
 appVersion: "v1.53.0"
 keywords:
   - maestro

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -170,7 +170,7 @@ One `maestro` pod + one `mcp-gateway` pod. The `github-cache` workloads are skip
 
 ### HA mode (`ha.enabled: true`)
 
-Two `maestro` pods + the `github-cache` `StatefulSet` (per-pod RWO PVCs for the mirror disks) and its singleton provisioner. **`mcp-gateway` runs as a native sidecar inside each maestro and github-cache pod** — there is no standalone `mcp-gateway` Deployment or Service. Artifact bytes are required to land in an S3-compatible object store. Maestro `persistence.enabled` is forbidden under HA (the RWO PVC + `Recreate` strategy combination deadlocks rolling updates at `replicas > 1`).
+Two `maestro` pods + the `github-cache` `StatefulSet` (per-pod RWO PVCs for the mirror disks) and its singleton provisioner. **`mcp-gateway` runs as a native sidecar inside each maestro and github-cache pod** — there is no standalone `mcp-gateway` Deployment or Service. Artifact bytes are required to land in an S3-compatible object store. Maestro `temporaryStorage.enabled` is forbidden under HA (the RWO PVC + `Recreate` strategy combination deadlocks rolling updates at `replicas > 1`).
 
 **Why mcp-gateway is a sidecar, not a Deployment**: most MCP drivers in the gateway (kube, lakerunner, jira, github, built-in tool servers) use stateful Streamable HTTP — a session opened on one pod can't be served by another. A standalone gateway Deployment with `replicas > 1` would round-robin and produce "session not found" errors. Co-locating one gateway per consumer pod and talking to it over loopback eliminates the cross-pod routing entirely. Sessions stay pod-local, no Service in the path. See `cardinalhq/conductor#838` for the upstream tracking issue.
 

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -177,7 +177,7 @@ Two `maestro` pods + the `github-cache` `StatefulSet` (per-pod RWO PVCs for the 
 The chart fails template rendering — at install time, not silently at runtime — when any HA invariant is violated:
 
 * `ha.enabled=true` and `objectStore.bucket` is empty
-* `ha.enabled=true` and `maestro.persistence.enabled: true`
+* `ha.enabled=true` and `maestro.temporaryStorage.enabled: true`
 * `ha.enabled=true` and explicit `githubCache.enabled: false`
 * `ha.enabled=true` and explicit `maestro.replicas` or `mcpGateway.replicas` `< 2`
 * `objectStore.auth.existingSecret` set but a key-name field is blank

--- a/maestro/templates/NOTES.txt
+++ b/maestro/templates/NOTES.txt
@@ -17,6 +17,17 @@ Note: objectStore.bucket is set but ha.enabled=false. The S3 backend is wired
 but artifact persistence isn't strictly required in POC mode — set ha.enabled=true
 to commit to multi-pod operation.
 {{- end }}
+{{- if include "maestro.temporaryStorageEnabled" . }}
+
+Scratch PVC: {{ include "maestro.fullname" . }}-scratch (rebuildable cache — git
+checkouts + artifacts; safe to exclude from backups).
+{{- if .Release.IsUpgrade }}
+UPGRADE NOTE: the scratch PVC was renamed from `-data` to `-scratch` (chart
+0.9.0). If your StorageClass uses a Retain reclaim policy, delete the orphaned
+{{ include "maestro.fullname" . }}-data PVC/PV after this upgrade. With a Delete
+reclaim policy (typical EBS default) it is cleaned up automatically.
+{{- end }}
+{{- end }}
 
 To verify:
   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/maestro/templates/_helpers.tpl
+++ b/maestro/templates/_helpers.tpl
@@ -128,7 +128,7 @@ key=`) as unset, so both produce the auto-derived default.
 
 {{/*
 Strict bool reader for mode-critical toggles (ha.enabled, githubCache.enabled,
-maestro.persistence.enabled). Returns "true" (string) when the value is the
+maestro.temporaryStorage.enabled). Returns "true" (string) when the value is the
 YAML/Go bool true, "" when it's bool false or nil. Fails template rendering
 on any other type (e.g. operator typed `--set-string ha.enabled=true` and
 got a string instead of a bool — silently treating "true" as false is the
@@ -158,12 +158,12 @@ HA mode toggle — returns "true" (string) when ha.enabled is the bool true,
 Effective maestro persistence enablement. Same strict-bool semantics as
 haEnabled. Centralizes the gate so every consumer (PVC, Deployment
 strategy block, env injection, volume mount) reads the same narrowed
-value — and stringly `--set-string maestro.persistence.enabled=false`
+value — and stringly `--set-string maestro.temporaryStorage.enabled=false`
 can't accidentally render as truthy in some gates and falsy in others.
 */}}
-{{- define "maestro.persistenceEnabled" -}}
-{{- $v := dig "enabled" false (dig "persistence" dict (.Values.maestro | default dict)) -}}
-{{- include "maestro.boolOrFail" (dict "value" $v "path" "maestro.persistence.enabled") -}}
+{{- define "maestro.temporaryStorageEnabled" -}}
+{{- $v := dig "enabled" false (dig "temporaryStorage" dict (.Values.maestro | default dict)) -}}
+{{- include "maestro.boolOrFail" (dict "value" $v "path" "maestro.temporaryStorage.enabled") -}}
 {{- end -}}
 
 {{/*
@@ -277,14 +277,14 @@ file the operator looks at.
 The strict-bool narrow on mode-critical toggles runs UNCONDITIONALLY —
 even in POC mode — so a stringly `--set-string ha.enabled=true`,
 `--set-string githubCache.enabled=...`, or `--set-string
-maestro.persistence.enabled=...` fails with a clear message regardless
+maestro.temporaryStorage.enabled=...` fails with a clear message regardless
 of whether the helper is otherwise reached during this particular
 template's render path.
 */}}
 {{- define "maestro.haValidate" -}}
 {{- /* Force-narrow the mode-critical bools so stringly inputs fail loud. */ -}}
 {{- $_ := include "maestro.haEnabled" . -}}
-{{- $_ = include "maestro.persistenceEnabled" . -}}
+{{- $_ = include "maestro.temporaryStorageEnabled" . -}}
 {{- $ghExplicitNarrow := dig "enabled" nil (.Values.githubCache | default dict) -}}
 {{- if not (include "maestro.isUnset" $ghExplicitNarrow) -}}
   {{- $_ = include "maestro.boolOrFail" (dict "value" $ghExplicitNarrow "path" "githubCache.enabled") -}}
@@ -296,8 +296,8 @@ template's render path.
     {{- fail "ha.enabled=true requires objectStore.bucket to be set (artifacts must be durable across pods). See values.yaml for AWS-S3 and Rook-Ceph examples." -}}
   {{- end -}}
   {{- /* HA is incompatible with the maestro RWO PVC (Recreate strategy + replicas>1 deadlocks). */ -}}
-  {{- if include "maestro.persistenceEnabled" . -}}
-    {{- fail "ha.enabled=true is incompatible with maestro.persistence.enabled=true (Recreate strategy + RWO PVC deadlocks rolling updates under replicas>1). Use objectStore for artifacts; the github-cache StatefulSet already handles its own per-pod PVCs." -}}
+  {{- if include "maestro.temporaryStorageEnabled" . -}}
+    {{- fail "ha.enabled=true is incompatible with maestro.temporaryStorage.enabled=true (Recreate strategy + RWO PVC deadlocks rolling updates under replicas>1). Use objectStore for artifacts; the github-cache StatefulSet already handles its own per-pod PVCs." -}}
   {{- end -}}
   {{- /* HA requires the split github-cache. Explicit bool false fails. */ -}}
   {{- $ghExplicit := dig "enabled" nil (.Values.githubCache | default dict) -}}

--- a/maestro/templates/deprecation-warnings.yaml
+++ b/maestro/templates/deprecation-warnings.yaml
@@ -1,0 +1,29 @@
+{{/*
+Deprecation warnings for removed or renamed features.
+This template doesn't produce any resources, it only validates configuration.
+*/}}
+
+{{- if .Values.maestro.persistence }}
+{{- fail `
+================================================================================
+DEPRECATION WARNING: maestro.persistence has been renamed to maestro.temporaryStorage
+
+The maestro scratch PVC and its values key were renamed to reflect cache
+semantics (rebuildable artifacts + git checkouts, not durable state) and to
+match the lakerunner scratch-volume convention. The backing PVC is now named
+<release>-maestro-scratch instead of <release>-maestro-data.
+
+To fix this error:
+  1. Rename the maestro.persistence section in your values.yaml to
+     maestro.temporaryStorage (all sub-keys are unchanged: enabled, size,
+     accessMode, storageClass, mountPath, seLinuxLevel).
+
+Upgrade impact:
+  The old <release>-maestro-data PVC is replaced by a new (empty)
+  <release>-maestro-scratch PVC. Contents are cache, so the only effect is a
+  one-time warm-up. With a Delete-reclaim StorageClass the old PVC/PV/volume
+  are cleaned up automatically on upgrade; with a Retain StorageClass, delete
+  the orphaned <release>-maestro-data PV manually.
+================================================================================
+` }}
+{{- end }}

--- a/maestro/templates/deprecation-warnings.yaml
+++ b/maestro/templates/deprecation-warnings.yaml
@@ -3,7 +3,7 @@ Deprecation warnings for removed or renamed features.
 This template doesn't produce any resources, it only validates configuration.
 */}}
 
-{{- if .Values.maestro.persistence }}
+{{- if (.Values.maestro | default dict).persistence }}
 {{- fail `
 ================================================================================
 DEPRECATION WARNING: maestro.persistence has been renamed to maestro.temporaryStorage

--- a/maestro/templates/github-cache-statefulset.yaml
+++ b/maestro/templates/github-cache-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ include "maestro.serviceAccountName" . }}
       {{- /*
         Pin SELinux MCS categories so a re-attached PVC's mirror bytes stay
-        readable across pod restarts (same rationale as maestro.persistence).
+        readable across pod restarts (same rationale as maestro.temporaryStorage).
         Operators can override seLinuxOptions in serving.podSecurityContext.
       */}}
       {{- $podSec := $serving.podSecurityContext | default dict -}}

--- a/maestro/templates/maestro-deployment.yaml
+++ b/maestro/templates/maestro-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   {{ include "maestro.annotations" . | nindent 2 }}
 spec:
   replicas: {{ include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas) }}
-  {{- if and (include "maestro.persistenceEnabled" .) (ne .Values.maestro.persistence.accessMode "ReadWriteMany") }}
+  {{- if and (include "maestro.temporaryStorageEnabled" .) (ne .Values.maestro.temporaryStorage.accessMode "ReadWriteMany") }}
   # RWO volumes can only attach to one node at a time. Rolling update would
   # deadlock the rollout (new pod scheduled to a different node, can't mount
   # the in-use volume). Recreate forces tear-down → reattach → new pod.
@@ -37,10 +37,10 @@ spec:
         maestro.podSecurityContext to change the level or add type/role.
       */}}
       {{- $podSec := .Values.maestro.podSecurityContext | default dict -}}
-      {{- if and (include "maestro.persistenceEnabled" .) (not (hasKey $podSec "seLinuxOptions")) -}}
+      {{- if and (include "maestro.temporaryStorageEnabled" .) (not (hasKey $podSec "seLinuxOptions")) -}}
         {{- $merged := dict -}}
         {{- range $k, $v := $podSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
-        {{- $_ := set $merged "seLinuxOptions" (dict "level" .Values.maestro.persistence.seLinuxLevel) -}}
+        {{- $_ := set $merged "seLinuxOptions" (dict "level" .Values.maestro.temporaryStorage.seLinuxLevel) -}}
         {{- $podSec = $merged -}}
       {{- end }}
       {{- include "maestro.podSecurityContext" (dict "root" . "override" $podSec) | nindent 6 }}
@@ -146,11 +146,11 @@ spec:
           - name: GITHUB_CACHE_REMOTE
             value: "1"
           {{- end }}
-          {{- if (include "maestro.persistenceEnabled" .) }}
+          {{- if (include "maestro.temporaryStorageEnabled" .) }}
           - name: ONTOLOGY_WORKSPACE_DIR
-            value: {{ printf "%s/git-checkouts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
+            value: {{ printf "%s/git-checkouts" (.Values.maestro.temporaryStorage.mountPath | default "/var/lib/maestro") | quote }}
           - name: ORCHESTRA_ARTIFACT_DIR
-            value: {{ printf "%s/artifacts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
+            value: {{ printf "%s/artifacts" (.Values.maestro.temporaryStorage.mountPath | default "/var/lib/maestro") | quote }}
           {{- end }}
           {{- include "maestro.objectStoreEnv" . | nindent 10 }}
           {{- include "maestro.objectStoreAuthEnv" . | nindent 10 }}
@@ -193,9 +193,9 @@ spec:
           mountPath: /tmp
         - name: agent-cache
           mountPath: /var/cache/maestro
-        {{- if (include "maestro.persistenceEnabled" .) }}
-        - name: data
-          mountPath: {{ .Values.maestro.persistence.mountPath | default "/var/lib/maestro" | quote }}
+        {{- if (include "maestro.temporaryStorageEnabled" .) }}
+        - name: scratch
+          mountPath: {{ .Values.maestro.temporaryStorage.mountPath | default "/var/lib/maestro" | quote }}
         {{- end }}
         {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
         {{- with .Values.maestro.extraVolumeMounts }}
@@ -245,10 +245,10 @@ spec:
         emptyDir: {}
       - name: agent-cache
         emptyDir: {}
-      {{- if (include "maestro.persistenceEnabled" .) }}
-      - name: data
+      {{- if (include "maestro.temporaryStorageEnabled" .) }}
+      - name: scratch
         persistentVolumeClaim:
-          claimName: {{ include "maestro.fullname" . }}-data
+          claimName: {{ include "maestro.fullname" . }}-scratch
       {{- end }}
       {{- include "maestro.licenseVolume" . | nindent 6 }}
       {{- if dig "tls" "enabled" false .Values.maestro }}

--- a/maestro/templates/maestro-pvc.yaml
+++ b/maestro/templates/maestro-pvc.yaml
@@ -1,23 +1,23 @@
-{{- if and .Values.maestro.enabled (include "maestro.persistenceEnabled" .) -}}
+{{- if and .Values.maestro.enabled (include "maestro.temporaryStorageEnabled" .) -}}
 {{- $effectiveReplicas := int (include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas)) -}}
-{{- if and (gt $effectiveReplicas 1) (ne .Values.maestro.persistence.accessMode "ReadWriteMany") -}}
-{{- fail "maestro.persistence is enabled with replicas > 1, but accessMode is not ReadWriteMany. Set maestro.persistence.accessMode=ReadWriteMany (e.g. EFS) or scale to 1 replica." -}}
+{{- if and (gt $effectiveReplicas 1) (ne .Values.maestro.temporaryStorage.accessMode "ReadWriteMany") -}}
+{{- fail "maestro.temporaryStorage is enabled with replicas > 1, but accessMode is not ReadWriteMany. Set maestro.temporaryStorage.accessMode=ReadWriteMany (e.g. EFS) or scale to 1 replica." -}}
 {{- end -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "maestro.fullname" . }}-data
+  name: {{ include "maestro.fullname" . }}-scratch
   labels:
     {{- include "maestro.labels" . | nindent 4 }}
     app.kubernetes.io/component: maestro
   {{ include "maestro.annotations" . | nindent 2 }}
 spec:
   accessModes:
-    - {{ .Values.maestro.persistence.accessMode | quote }}
+    - {{ .Values.maestro.temporaryStorage.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.maestro.persistence.size | quote }}
-  {{- with .Values.maestro.persistence.storageClass }}
+      storage: {{ .Values.maestro.temporaryStorage.size | quote }}
+  {{- with .Values.maestro.temporaryStorage.storageClass }}
   storageClassName: {{ . | quote }}
   {{- end }}
 {{- end }}

--- a/maestro/tests/ha_test.yaml
+++ b/maestro/tests/ha_test.yaml
@@ -297,15 +297,15 @@ tests:
       - failedTemplate:
           errorMessage: "ha.enabled=true is incompatible with explicit githubCache.enabled=false (in-process github-cache holds per-pod state and a single PVC, neither of which scales). Remove the override or set ha.enabled=false."
 
-  - it: "HA with maestro.persistence.enabled=true fails template rendering"
+  - it: "HA with maestro.temporaryStorage.enabled=true fails template rendering"
     template: maestro-deployment.yaml
     set:
       ha.enabled: true
       objectStore.bucket: my-bucket
-      maestro.persistence.enabled: true
+      maestro.temporaryStorage.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "ha.enabled=true is incompatible with maestro.persistence.enabled=true (Recreate strategy + RWO PVC deadlocks rolling updates under replicas>1). Use objectStore for artifacts; the github-cache StatefulSet already handles its own per-pod PVCs."
+          errorMessage: "ha.enabled=true is incompatible with maestro.temporaryStorage.enabled=true (Recreate strategy + RWO PVC deadlocks rolling updates under replicas>1). Use objectStore for artifacts; the github-cache StatefulSet already handles its own per-pod PVCs."
 
   - it: "HA with maestro.replicas=1 fails template rendering"
     template: maestro-deployment.yaml
@@ -393,13 +393,13 @@ tests:
       - failedTemplate:
           errorMessage: "githubCache.enabled must be a YAML boolean (true or false), got false of type string. Use `--set githubCache.enabled=true` / `=false`, not `--set-string`."
 
-  - it: "stringly maestro.persistence.enabled (--set-string) fails loud"
+  - it: "stringly maestro.temporaryStorage.enabled (--set-string) fails loud"
     template: maestro-deployment.yaml
     set:
-      maestro.persistence.enabled: "true"
+      maestro.temporaryStorage.enabled: "true"
     asserts:
       - failedTemplate:
-          errorMessage: "maestro.persistence.enabled must be a YAML boolean (true or false), got true of type string. Use `--set maestro.persistence.enabled=true` / `=false`, not `--set-string`."
+          errorMessage: "maestro.temporaryStorage.enabled must be a YAML boolean (true or false), got true of type string. Use `--set maestro.temporaryStorage.enabled=true` / `=false`, not `--set-string`."
 
   # ---- region default for S3-compat endpoint ----------------------------
   - it: "HA with endpoint defaults region to us-east-1 (AWS SDK requires one)"

--- a/maestro/tests/persistence_test.yaml
+++ b/maestro/tests/persistence_test.yaml
@@ -2,10 +2,11 @@ suite: test persistent storage for artifacts and ontology checkouts
 templates:
   - maestro-deployment.yaml
   - maestro-pvc.yaml
+  - deprecation-warnings.yaml
 tests:
   - it: omits PVC when persistence disabled
     set:
-      maestro.persistence.enabled: false
+      maestro.temporaryStorage.enabled: false
     template: maestro-pvc.yaml
     asserts:
       - hasDocuments:
@@ -13,7 +14,7 @@ tests:
 
   - it: omits volume mount and env vars when persistence disabled
     set:
-      maestro.persistence.enabled: false
+      maestro.temporaryStorage.enabled: false
     template: maestro-deployment.yaml
     asserts:
       - notContains:
@@ -27,8 +28,8 @@ tests:
 
   - it: renders PVC, mount, and env vars when persistence enabled
     set:
-      maestro.persistence.enabled: true
-      maestro.persistence.size: 5Gi
+      maestro.temporaryStorage.enabled: true
+      maestro.temporaryStorage.size: 5Gi
     template: maestro-pvc.yaml
     asserts:
       - hasDocuments:
@@ -42,10 +43,13 @@ tests:
       - equal:
           path: spec.accessModes[0]
           value: ReadWriteOnce
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-maestro-scratch
 
   - it: wires the volume mount and env vars when persistence enabled
     set:
-      maestro.persistence.enabled: true
+      maestro.temporaryStorage.enabled: true
     template: maestro-deployment.yaml
     asserts:
       - contains:
@@ -61,19 +65,19 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
-            name: data
+            name: scratch
             mountPath: "/var/lib/maestro"
       - contains:
           path: spec.template.spec.volumes
           content:
-            name: data
+            name: scratch
             persistentVolumeClaim:
-              claimName: RELEASE-NAME-maestro-data
+              claimName: RELEASE-NAME-maestro-scratch
 
   - it: respects custom mountPath
     set:
-      maestro.persistence.enabled: true
-      maestro.persistence.mountPath: /data/maestro
+      maestro.temporaryStorage.enabled: true
+      maestro.temporaryStorage.mountPath: /data/maestro
     template: maestro-deployment.yaml
     asserts:
       - contains:
@@ -84,18 +88,18 @@ tests:
 
   - it: fails when replicas > 1 with default RWO accessMode
     set:
-      maestro.persistence.enabled: true
+      maestro.temporaryStorage.enabled: true
       maestro.replicas: 2
     template: maestro-pvc.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "maestro.persistence is enabled with replicas > 1, but accessMode is not ReadWriteMany. Set maestro.persistence.accessMode=ReadWriteMany (e.g. EFS) or scale to 1 replica."
+          errorMessage: "maestro.temporaryStorage is enabled with replicas > 1, but accessMode is not ReadWriteMany. Set maestro.temporaryStorage.accessMode=ReadWriteMany (e.g. EFS) or scale to 1 replica."
 
   - it: allows replicas > 1 when accessMode is ReadWriteMany
     set:
-      maestro.persistence.enabled: true
+      maestro.temporaryStorage.enabled: true
       maestro.replicas: 2
-      maestro.persistence.accessMode: ReadWriteMany
+      maestro.temporaryStorage.accessMode: ReadWriteMany
     template: maestro-pvc.yaml
     asserts:
       - hasDocuments:
@@ -103,3 +107,11 @@ tests:
       - equal:
           path: spec.accessModes[0]
           value: ReadWriteMany
+
+  - it: fails when the renamed maestro.persistence key is still set
+    set:
+      maestro.persistence.enabled: true
+    template: deprecation-warnings.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "DEPRECATION WARNING: maestro.persistence has been renamed to maestro.temporaryStorage"

--- a/maestro/tests/persistence_test.yaml
+++ b/maestro/tests/persistence_test.yaml
@@ -4,7 +4,7 @@ templates:
   - maestro-pvc.yaml
   - deprecation-warnings.yaml
 tests:
-  - it: omits PVC when persistence disabled
+  - it: omits PVC when temporaryStorage disabled
     set:
       maestro.temporaryStorage.enabled: false
     template: maestro-pvc.yaml
@@ -12,7 +12,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: omits volume mount and env vars when persistence disabled
+  - it: omits volume mount and env vars when temporaryStorage disabled
     set:
       maestro.temporaryStorage.enabled: false
     template: maestro-deployment.yaml
@@ -26,7 +26,7 @@ tests:
           content:
             name: ONTOLOGY_WORKSPACE_DIR
 
-  - it: renders PVC, mount, and env vars when persistence enabled
+  - it: renders PVC, mount, and env vars when temporaryStorage enabled
     set:
       maestro.temporaryStorage.enabled: true
       maestro.temporaryStorage.size: 5Gi
@@ -47,7 +47,7 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-maestro-scratch
 
-  - it: wires the volume mount and env vars when persistence enabled
+  - it: wires the volume mount and env vars when temporaryStorage enabled
     set:
       maestro.temporaryStorage.enabled: true
     template: maestro-deployment.yaml
@@ -111,6 +111,16 @@ tests:
   - it: fails when the renamed maestro.persistence key is still set
     set:
       maestro.persistence.enabled: true
+    template: deprecation-warnings.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "DEPRECATION WARNING: maestro.persistence has been renamed to maestro.temporaryStorage"
+
+  # The guard tests map truthiness, so it must fire on ANY leftover subkey —
+  # e.g. an operator who renamed `enabled` but left `size`/`storageClass` behind.
+  - it: deprecation fires on any persistence subkey, not just .enabled
+    set:
+      maestro.persistence.size: 10Gi
     template: deprecation-warnings.yaml
     asserts:
       - failedTemplate:

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -218,14 +218,21 @@ maestro:
     # cert.autoGenerate=true and cert.crt/cert.key.
     # secretName: ""
 
-  # Persistent storage for ephemeral working data: orchestra artifact
-  # payloads (per-run subdirs) and ontology git checkouts. Off by default
-  # — when enabled, mounts a PVC at `mountPath` and sets the env vars
-  # ORCHESTRA_ARTIFACT_DIR and ONTOLOGY_WORKSPACE_DIR so maestro routes
-  # both into the volume. Recommended for SaaS deployments where memory
-  # budgets are tight; not required for small/dev installs (orchestra
-  # falls back to its in-memory artifact store).
-  persistence:
+  # Scratch storage for rebuildable working data: orchestra artifact
+  # payloads (per-run subdirs) and ontology git checkouts. This is a
+  # throw-away cache, not durable state — contents are re-fetchable /
+  # re-clonable, so the backing PVC (<release>-maestro-scratch) carries
+  # the `scratch` token for data-classification tooling (matches the
+  # lakerunner scratch-volume convention; "definitely-no-backup").
+  # Off by default — when enabled, mounts a PVC at `mountPath` and sets
+  # the env vars ORCHESTRA_ARTIFACT_DIR and ONTOLOGY_WORKSPACE_DIR so
+  # maestro routes both into the volume. Recommended for SaaS deployments
+  # where memory budgets are tight; not required for small/dev installs
+  # (orchestra falls back to its in-memory artifact store).
+  #
+  # Renamed from `maestro.persistence` (chart 0.9.0). The old key now
+  # fails template rendering — see templates/deprecation-warnings.yaml.
+  temporaryStorage:
     enabled: false
     size: 5Gi
     accessMode: ReadWriteOnce
@@ -327,7 +334,7 @@ githubCache:
       # storageClass: ""   # leave empty to use the cluster default
       mountPath: /var/lib/github-cache
       # SELinux MCS level pinned across pod restarts so a re-attached PVC's
-      # mirror bytes stay readable (same rationale as maestro.persistence).
+      # mirror bytes stay readable (same rationale as maestro.temporaryStorage).
       seLinuxLevel: "s0:c100,c200"
     resources:
       requests:

--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 #   ha.enabled=true — HA: two maestro pods + two mcp-gateway pods (operator
 #     can override higher), github-cache split into its StatefulSet +
 #     singleton provisioner, S3-compat object store REQUIRED for artifacts.
-#     Maestro `persistence.enabled` must be false (RWO PVC + Recreate
+#     Maestro `temporaryStorage.enabled` must be false (RWO PVC + Recreate
 #     strategy deadlocks rolling updates under replicas>1).
 #
 # Defaults for `maestro.replicas` and `githubCache.enabled` auto-derive


### PR DESCRIPTION
Closes #105.

Renames the maestro cache volume to reflect that its contents are rebuildable scratch (git checkouts + artifacts), not durable state — so it matches the lakerunner `scratch` convention and reads clearly in EBS data-classification / SOC 2 tooling.

## Changes
- **Values key:** `maestro.persistence` → `maestro.temporaryStorage` (lakerunner's actual key name; all sub-keys unchanged).
- **PVC name:** `<release>-maestro-data` → `<release>-maestro-scratch`; in-pod volume name `data` → `scratch`.
- **Old-key detection (no auto-migration):** new `templates/deprecation-warnings.yaml` hard-`fail`s if `maestro.persistence` is still set, pointing users at the new key.
- **Tests:** updated `persistence_test.yaml` + `ha_test.yaml`; added PVC-name assertion and a deprecation-fail test. 120/120 pass, `helm lint` clean.
- **Docs:** values comment, README, conditional NOTES.txt upgrade callout.
- **Chart:** 0.8.22 → 0.9.0 (breaking values change).

## Upgrade / PV impact
On upgrade Helm deletes the old `-data` PVC (no `resource-policy: keep`) and creates an empty `-scratch` PVC. Contents are cache, so the only effect is a one-time warm-up.
- **Delete-reclaim StorageClass** (EBS default): old PVC/PV/volume cleaned up automatically — no stray PVs.
- **Retain StorageClass:** the old `-data` PV is left `Released`; NOTES.txt + the deprecation message tell operators to delete it manually. (This is pre-existing reclaim-policy behavior, not introduced by the rename.)