### PR TITLE
lakerunner: chart 3.14.0, appVersion v1.41.1 (agent-sessions tap inside process-logs)

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.13.2"
-appVersion: "v1.36.0"
+version: "3.14.0"
+appVersion: "v1.41.0"
 keywords:
   - lakerunner
   - logs

--- a/lakerunner/templates/process-logs-deployment.yaml
+++ b/lakerunner/templates/process-logs-deployment.yaml
@@ -53,6 +53,18 @@ spec:
             value: {{ include "lakerunner.fullname" . }}-process-logs
           - name: TMPDIR
             value: /scratch
+          {{- if .Values.processLogs.agentSessions.enabled }}
+          # Enable the in-process agent-sessions sub-processor (taps
+          # claude-code records from each ingested Parquet bin, UPSERTs
+          # into the agent_sessions table). See
+          # docs/specs/agent-sessions.md in the lakerunner repo.
+          - name: LAKERUNNER_AGENT_SESSIONS_ENABLE
+            value: "true"
+          {{- if .Values.processLogs.agentSessions.rulesConfigMap.enabled }}
+          - name: AGENT_SESSIONS_RULES_PATH
+            value: /etc/lakerunner/agent-sessions-rules.yaml
+          {{- end }}
+          {{- end }}
           {{- if eq .Values.cloudProvider.provider "azure" }}
           - name: AZURE_AUTH_TYPE
             value: {{ .Values.cloudProvider.azure.authType | quote }}
@@ -78,6 +90,12 @@ spec:
         {{- end }}
         - name: scratch
           mountPath: /scratch
+        {{- if and .Values.processLogs.agentSessions.enabled .Values.processLogs.agentSessions.rulesConfigMap.enabled }}
+        - name: agent-sessions-rules
+          mountPath: /etc/lakerunner/agent-sessions-rules.yaml
+          subPath: rules.yaml
+          readOnly: true
+        {{- end }}
         {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
         {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
       {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.processLogs.nodeSelector) | nindent 6 }}
@@ -89,6 +107,11 @@ spec:
       - name: storage-profiles
         configMap:
           name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- if and .Values.processLogs.agentSessions.enabled .Values.processLogs.agentSessions.rulesConfigMap.enabled }}
+      - name: agent-sessions-rules
+        configMap:
+          name: {{ .Values.processLogs.agentSessions.rulesConfigMap.name | default (printf "%s-agent-sessions-rules" (include "lakerunner.fullname" .)) }}
       {{- end }}
       {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
       {{- include "lakerunner.licenseVolume" . | nindent 6 }}

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -397,6 +397,30 @@ processLogs:
     maxReplicas: 10
   healthProbes:
     enabled: null # null = inherit from global.healthProbes.enabled
+  # Optional in-process agent-sessions sub-processor. When enabled, the
+  # log-ingest hook scans each just-written Parquet bin for claude-code
+  # records and UPSERTs them into the agent_sessions table that powers
+  # the Outcome Observability dashboard. Off by default — turning it
+  # on requires the v1.41.1+ lakerunner image. See
+  # docs/specs/agent-sessions.md in the lakerunner repo for the design.
+  #
+  # Resource cost is small: the tap is one extra DuckDB read per bin
+  # (negligible when no claude-code rows are present, which is the
+  # common case). The consumer goroutine is bounded by lrdb write
+  # throughput, not memory.
+  #
+  # When rulesConfigMap.enabled is false (default), the sweeper falls
+  # back to the "stale-pending → unknown" path — counters/context/
+  # lifecycle still populate; only verdict classification is inactive.
+  agentSessions:
+    enabled: false
+    # Mount a ConfigMap at /etc/lakerunner/agent-sessions-rules.yaml.
+    # The operator owns the rules.yaml content; the chart only wires
+    # the volume.
+    rulesConfigMap:
+      enabled: false
+      # Defaults to "<release>-agent-sessions-rules" if empty.
+      name: ""
   labels: {}
   annotations: {}
   nodeSelector: {}
@@ -458,6 +482,7 @@ processTraces:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
 
 # Control-plane configuration.
 #


### PR DESCRIPTION
## Summary

Wires the lakerunner v1.41.1 in-process agent-sessions tap (from [cardinalhq/lakerunner#852](https://github.com/cardinalhq/lakerunner/pull/852)) onto the existing process-logs container via env vars + an optional rules ConfigMap. **No new Deployment template.**

The original revision of this PR added a standalone `process-agent-sessions` Deployment template paired with the v1.41.0 cobra command. That command was retired in #852 (poll-based separate pod was wrong — claude-code records pass through process-logs in real time anyway), so this PR is rewritten to match.

## What's in (revised)

- `templates/process-logs-deployment.yaml`:
  - Conditional `LAKERUNNER_AGENT_SESSIONS_ENABLE=true` env var.
  - Conditional `AGENT_SESSIONS_RULES_PATH` env var + ConfigMap mount when `rulesConfigMap.enabled`.
- `values.yaml`:
  - New `processLogs.agentSessions:` sub-block, **disabled by default**.
  - Removed the unused top-level `processAgentSessions:` block.
- `Chart.yaml` → `version: 3.14.0`, `appVersion: v1.41.1`.

## Diff vs. v3.13.x

- Default render (`agentSessions.enabled: false`) — zero changes to process-logs Deployment vs. v3.13.x. Verified via `helm template`: zero lines containing `LAKERUNNER_AGENT_SESSIONS` or `agent-sessions`.
- Enabled render: adds 2 env vars + (optional) one volume + one volumeMount.

## Compatibility

Operators on appVersion v1.41.0 or earlier **must not** turn this on — the binary won't recognize the env var. The Chart.yaml `appVersion` bump means the chart's default render targets the right binary.

## Test plan

- [x] `helm lint .` passes
- [x] `helm template` with `agentSessions.enabled=true rulesConfigMap.enabled=true` renders the env vars, mount, ConfigMap volume
- [x] Default render is byte-identical to v3.13.x for the process-logs Deployment (no env vars added, no volumes added)
- [ ] kubernetes-clusters PR enabling this for prod-global (follows after lakerunner v1.41.1 + this chart land)

## Companion changes

- lakerunner PR #852 (the tap implementation; will be tagged v1.41.1)
- conductor PR #1000 (dashboard + maestro routes; unchanged)