### PR TITLE
Unified conductor chart: merge lakerunner + maestro into one chart

### DIFF
--- a/conductor/.helmignore
+++ b/conductor/.helmignore
@@ -1,0 +1,1 @@
+packages/

--- a/conductor/Chart.yaml
+++ b/conductor/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: conductor
+description: Unified Helm chart for CardinalHQ LakeRunner + Maestro
+type: application
+version: "0.1.0"
+# appVersion is nominal only — component image tags are pinned per-component in values.yaml
+# (both lakerunner.* and maestro.* image helpers would otherwise default the tag to this).
+appVersion: "v1.53.0"
+keywords:
+  - lakerunner
+  - maestro
+  - logs
+  - metrics
+  - traces
+  - observability
+home: https://docs.cardinalhq.io/lakerunner
+maintainers:
+  - name: Cardinal HQ
+    email: support@cardinalhq.com

--- a/conductor/templates/NOTES.txt
+++ b/conductor/templates/NOTES.txt
@@ -3,6 +3,11 @@
 {{- $mReplicas := include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas) -}}
 {{- $gReplicas := include "maestro.replicas" (dict "root" . "explicit" .Values.mcpGateway.replicas) -}}
 {{- $bucket := dig "bucket" "" (.Values.objectStore | default dict) -}}
+conductor — the unified CardinalHQ chart — is installed. It deploys BOTH:
+  - lakerunner: the log/metrics/trace pipeline (process-logs/metrics/traces,
+    query-api, query-worker, control-plane, pubsub ingest, setup job)
+  - maestro: the UI + mcp-gateway + (optional) Dex OIDC, with github-cache in HA
+
 Mode:               {{ if $ha }}HA{{ else }}POC{{ end }}
 Maestro replicas:   {{ $mReplicas }}
 MCP-gateway replicas: {{ $gReplicas }}
@@ -18,6 +23,22 @@ but artifact persistence isn't strictly required in POC mode — set ha.enabled=
 to commit to multi-pod operation.
 {{- end }}
 
-To verify:
-  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+Reach the maestro UI:
+{{- if .Values.ingress.enabled }}
+  Ingress is enabled — browse to https://{{ .Values.ingress.host | default "<ingress.host>" }}/
+{{- else }}
+  No Ingress configured. Port-forward the maestro Service:
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "maestro.fullname" . }}-maestro {{ .Values.maestro.port }}:{{ .Values.maestro.port }}
+  then open http://localhost:{{ .Values.maestro.port }}/
+{{- end }}
+
+Check the lakerunner pipeline:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/name=lakerunner
+  kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/component=control-plane --tail=50
+
+Check maestro:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/name=maestro
   kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/component=maestro --tail=50
+
+All pods for this release:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/conductor/templates/NOTES.txt
+++ b/conductor/templates/NOTES.txt
@@ -1,0 +1,23 @@
+{{- $ha := include "maestro.haEnabled" . -}}
+{{- $ghEnabled := include "maestro.githubCacheEnabled" . -}}
+{{- $mReplicas := include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas) -}}
+{{- $gReplicas := include "maestro.replicas" (dict "root" . "explicit" .Values.mcpGateway.replicas) -}}
+{{- $bucket := dig "bucket" "" (.Values.objectStore | default dict) -}}
+Mode:               {{ if $ha }}HA{{ else }}POC{{ end }}
+Maestro replicas:   {{ $mReplicas }}
+MCP-gateway replicas: {{ $gReplicas }}
+GitHub-cache:       {{ if $ghEnabled }}split (StatefulSet + provisioner){{ else }}in-process (rolled into maestro){{ end }}
+Artifact bytes:     {{ if $bucket }}S3 → {{ $bucket }}{{ if dig "endpoint" "" .Values.objectStore }} ({{ .Values.objectStore.endpoint }}){{ end }}{{ else }}in-memory (single-pod only){{ end }}
+{{- if and $ha (not $bucket) }}
+WARNING: ha.enabled=true but objectStore.bucket is empty — this combination is rejected at render time. If you see this message, something is wrong.
+{{- end }}
+{{- if and (not $ha) $bucket }}
+
+Note: objectStore.bucket is set but ha.enabled=false. The S3 backend is wired
+but artifact persistence isn't strictly required in POC mode — set ha.enabled=true
+to commit to multi-pod operation.
+{{- end }}
+
+To verify:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/component=maestro --tail=50

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -1182,9 +1182,12 @@ injected. Override with .Values.serviceAccount.name. Per-component SAs
 {{- end -}}
 {{- end }}
 
-{{/* Whether fresh-install bootstrap is active (false when mode=never). */}}
+{{/* Whether fresh-install bootstrap is active. Emits "true" when active and an
+     empty string when mode=never, so callers can use `include` directly in
+     `if`/`and` (a non-empty string is truthy, empty is falsy — unlike the
+     literal string "false", which is truthy). */}}
 {{- define "conductor.bootstrapEnabled" -}}
-{{- ne (.Values.bootstrap.mode | default "auto") "never" -}}
+{{- if ne (.Values.bootstrap.mode | default "auto") "never" -}}true{{- end -}}
 {{- end }}
 
 {{/* Name of the admin-key anchor Secret (operator-supplied or chart-managed). */}}

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -94,11 +94,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "lakerunner.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "lakerunner.fullname" .) .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- .Values.serviceAccount.name }}
-{{- end }}
+{{- include "conductor.serviceAccountName" . -}}
 {{- end }}
 
 {{/*
@@ -1169,5 +1165,19 @@ Usage:
 {{- if $merged }}
 securityContext:
   {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Shared ServiceAccount name for the unified chart. Single SA by default, named
+after the release (the "named install") — the chart name is intentionally NOT
+injected. Override with .Values.serviceAccount.name. Per-component SAs
+(least-privilege) are a future opt-in; for the skeleton every workload uses this one.
+*/}}
+{{- define "conductor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (.Release.Name | trunc 63 | trimSuffix "-") .Values.serviceAccount.name -}}
+{{- else -}}
+{{- .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end }}

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -1,0 +1,1173 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lakerunner.name" -}}
+{{- default "lakerunner" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Render imagePullSecrets.
+*/}}
+{{- define "lakerunner.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lakerunner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "lakerunner" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lakerunner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels, now including .Values.global.labels.
+*/}}
+{{- define "lakerunner.labels" -}}
+  {{- $global := .Values.global.labels | default dict -}}
+  {{- $labels := merge
+      (dict "helm.sh/chart" (include "lakerunner.chart" .))
+      (include "lakerunner.selectorLabels" . | fromYaml)
+  -}}
+  {{- if .Chart.AppVersion -}}
+    {{- $labels = merge $labels (dict "app.kubernetes.io/version" (.Chart.AppVersion)) -}}
+  {{- end -}}
+  {{- $labels = merge $labels (dict "app.kubernetes.io/managed-by" .Release.Service) -}}
+  {{- $labels = merge $labels (dict "lakerunner.cardinalhq.io/instance" .Release.Name) -}}
+  {{- $labels = merge $labels $global -}}
+  {{- toYaml $labels -}}
+{{- end }}
+
+{{/*
+Common labels with component-specific labels support.
+Usage: {{ include "lakerunner.labelsWithComponent" (list . .Values.componentName.labels) }}
+*/}}
+{{- define "lakerunner.labelsWithComponent" -}}
+  {{- $context := index . 0 -}}
+  {{- $componentLabels := index . 1 | default dict -}}
+  {{- $global := $context.Values.global.labels | default dict -}}
+  {{- $coreLabels := merge
+      (dict "helm.sh/chart" (include "lakerunner.chart" $context))
+      (include "lakerunner.selectorLabels" $context | fromYaml)
+  -}}
+  {{- if $context.Chart.AppVersion -}}
+    {{- $coreLabels = merge $coreLabels (dict "app.kubernetes.io/version" ($context.Chart.AppVersion)) -}}
+  {{- end -}}
+  {{- $coreLabels = merge $coreLabels (dict "app.kubernetes.io/managed-by" $context.Release.Service) -}}
+  {{- $coreLabels = merge $coreLabels (dict "lakerunner.cardinalhq.io/instance" $context.Release.Name) -}}
+  {{- $withGlobal := merge $global $coreLabels -}}
+  {{- $finalLabels := merge $componentLabels $withGlobal -}}
+  {{- toYaml $finalLabels -}}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lakerunner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lakerunner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lakerunner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lakerunner.fullname" .) .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common environment variables
+*/}}
+{{- define "lakerunner.commonEnv" -}}
+{{- include "lakerunner.dbEnv" (list . .Values.database .Values.configdb) -}}
+{{- end }}
+
+{{/*
+Database environment variables with optional per-component overrides.
+Args:
+  0: root context
+  1: database config (may have overrides)
+  2: configdb config (may have overrides)
+*/}}
+{{- define "lakerunner.dbEnv" -}}
+{{- $root := index . 0 -}}
+{{- $db := index . 1 -}}
+{{- $cdb := index . 2 -}}
+- name: LRDB_HOST
+  value: {{ $db.lrdb.host | quote }}
+- name: LRDB_PORT
+  value: {{ $db.lrdb.port | quote }}
+- name: LRDB_DBNAME
+  value: {{ $db.lrdb.name | quote }}
+- name: LRDB_USER
+  value: {{ $db.lrdb.username | quote }}
+- name: LRDB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "lakerunner.databaseSecretName" $root }}
+      key: {{ $root.Values.database.passwordKey }}
+- name: LRDB_SSLMODE
+  value: {{ $db.lrdb.sslMode | quote }}
+- name: CONFIGDB_HOST
+  value: {{ $cdb.lrdb.host | quote }}
+- name: CONFIGDB_PORT
+  value: {{ $cdb.lrdb.port | quote }}
+- name: CONFIGDB_DBNAME
+  value: {{ $cdb.lrdb.name | quote }}
+- name: CONFIGDB_USER
+  value: {{ $cdb.lrdb.username | quote }}
+- name: CONFIGDB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "lakerunner.configdbSecretName" $root }}
+      key: {{ $root.Values.configdb.passwordKey }}
+- name: CONFIGDB_SSLMODE
+  value: {{ $cdb.lrdb.sslMode | quote }}
+{{- if eq $root.Values.storageProfiles.source "config" }}
+- name: STORAGE_PROFILE_FILE
+  value: "/app/config/storage_profiles.yaml"
+{{- end -}}
+{{- end }}
+
+{{/*
+Setup job environment variables.
+Merges setup-specific database/configdb overrides with global defaults.
+Empty override values fall back to the global config.
+*/}}
+{{- define "lakerunner.setupEnv" -}}
+{{- $sdb := .Values.setup.database.lrdb -}}
+{{- $gdb := .Values.database.lrdb -}}
+{{- $scdb := .Values.setup.configdb.lrdb -}}
+{{- $gcdb := .Values.configdb.lrdb -}}
+{{- $mergedDb := dict "lrdb" (dict
+  "host" (default $gdb.host $sdb.host)
+  "port" (default $gdb.port $sdb.port)
+  "name" (default $gdb.name $sdb.name)
+  "username" (default $gdb.username $sdb.username)
+  "sslMode" (default $gdb.sslMode $sdb.sslMode)
+) -}}
+{{- $mergedCdb := dict "lrdb" (dict
+  "host" (default $gcdb.host $scdb.host)
+  "port" (default $gcdb.port $scdb.port)
+  "name" (default $gcdb.name $scdb.name)
+  "username" (default $gcdb.username $scdb.username)
+  "sslMode" (default $gcdb.sslMode $scdb.sslMode)
+) -}}
+{{- include "lakerunner.dbEnv" (list . $mergedDb $mergedCdb) -}}
+{{- end }}
+
+{{/*
+Generate OpenTelemetry trace sampling env vars.
+Reads global.monitoring.traces, then merges in per-component <comp>.monitoring.traces
+(component values win for any keys they define).
+Takes one or two args:
+  0: the root chart context
+  1: (optional) the component's values block (may set .monitoring.traces.{sampler,arg})
+Usage:
+  {{ include "lakerunner.tracesEnv" (list . .Values.queryApi) }}
+  {{ include "lakerunner.tracesEnv" (list .) }}
+*/}}
+{{- define "lakerunner.tracesEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := dict -}}
+{{- if gt (len .) 1 -}}
+{{- $compArg := index . 1 -}}
+{{- if $compArg -}}{{- $comp = $compArg -}}{{- end -}}
+{{- end -}}
+{{- $traces := dict -}}
+{{- if and $root.Values.global.monitoring $root.Values.global.monitoring.traces -}}
+{{- $traces = deepCopy $root.Values.global.monitoring.traces -}}
+{{- end -}}
+{{- if and $comp.monitoring $comp.monitoring.traces -}}
+{{- $traces = merge (deepCopy $comp.monitoring.traces) $traces -}}
+{{- end -}}
+{{- if $traces.sampler }}
+- name: OTEL_TRACES_SAMPLER
+  value: {{ $traces.sampler | quote }}
+{{- end }}
+{{- if hasKey $traces "arg" }}
+- name: OTEL_TRACES_SAMPLER_ARG
+  value: {{ $traces.arg | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Inject setup env vars (with database overrides) + component-specific env vars.
+Takes two args:
+  0: the root chart context
+  1: the component's values block (must have .env as a list)
+Usage:
+  {{ include "lakerunner.injectEnvSetup" (list . .Values.setup) | nindent 10 }}
+*/}}
+{{- define "lakerunner.injectEnvSetup" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- include "lakerunner.setupEnv" $root | nindent 2 -}}
+{{- include "lakerunner.goRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
+{{- with $root.Values.global.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- with $comp.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Inject common + component-specific env vars.
+Takes two args:
+  0: the root chart context (so we can call commonEnv with it)
+  1: the component's values block (must have .env as a list)
+Usage:
+  {{ include "lakerunner.injectEnv" (list . .Values.queryWorker) | nindent 10 }}
+*/}}
+{{- define "lakerunner.injectEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- include "lakerunner.commonEnv" $root | nindent 2 -}}
+{{- include "lakerunner.goRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
+{{- with $root.Values.global.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- with $comp.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Inject common + component-specific env vars for DuckDB services (process-logs/metrics/traces).
+These services use DuckDB internally and need specific memory tuning.
+Takes two args:
+  0: the root chart context (so we can call commonEnv with it)
+  1: the component's values block (must have .env as a list)
+Usage:
+  {{ include "lakerunner.injectEnvDuckdb" (list . .Values.processLogs) | nindent 10 }}
+*/}}
+{{- define "lakerunner.injectEnvDuckdb" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- include "lakerunner.commonEnv" $root | nindent 2 -}}
+{{- include "lakerunner.duckdbRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
+{{- with $root.Values.global.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- with $comp.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*}
+Common namespace definition
+*/}}
+{{- define "lakerunner.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespaceOverride -}}
+{{- end -}}
+
+{{/*
+Return only the indented key: value lines for .Values.global.annotations,
+or nothing if the map is empty.
+*/}}
+{{- define "lakerunner.annotationPairs" -}}
+{{- $ann := .Values.global.annotations -}}
+{{- if and $ann (gt (len $ann) 0) -}}
+{{ toYaml $ann | indent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+"Smart" annotations helper: emits the header + pairs when non-empty.
+*/}}
+{{- define "lakerunner.annotations" -}}
+{{- if and .Values.global.annotations (gt (len .Values.global.annotations) 0) -}}
+annotations:
+{{ include "lakerunner.annotationPairs" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+"Smart" annotations helper with component-specific annotations support.
+Usage: {{ include "lakerunner.annotationsWithComponent" (list . .Values.componentName.annotations) }}
+*/}}
+{{- define "lakerunner.annotationsWithComponent" -}}
+  {{- $context := index . 0 -}}
+  {{- $componentAnnotations := index . 1 | default dict -}}
+  {{- $global := $context.Values.global.annotations | default dict -}}
+  {{- $finalAnnotations := merge $componentAnnotations $global -}}
+  {{- if gt (len $finalAnnotations) 0 -}}
+annotations:
+{{ toYaml $finalAnnotations | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+Return the secret name for the APIKeys.  If we have create true, we will prefix it with the release name.
+*/}}
+{{- define "lakerunner.apiKeysSecretName" -}}
+{{- if .Values.apiKeys.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.apiKeys.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.apiKeys.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the Cardinal API key.
+*/}}
+{{- define "lakerunner.cardinalApiKeySecretName" -}}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) "cardinal-api-key" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "lakerunner.cardinalTelemetryEnv" -}}
+{{- if .Values.global.cardinal.apiKey }}
+- name: cardinalhq-api-key
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "lakerunner.cardinalApiKeySecretName" . }}
+      key: cardinalhq-api-key
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ if eq .Values.global.cardinal.env "test" }}"https://customer-intake-otelhttp.us-east-2.aws.test.cardinalhq.net"{{ else }}"https://otelhttp.intake.us-east-2.aws.cardinalhq.io"{{ end }}
+- name: ENABLE_OTLP_TELEMETRY
+  value: "true"
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "lakerunner.cardinalApiKeySecretName" . }}
+      key: CARDINAL_API_HEADER
+{{- end }}
+{{- end }}
+
+{{/*
+Return the configmap name for the Storage Profiles.  If we have create true, we will prefix it with the release name.
+*/}}
+{{- define "lakerunner.storageProfilesConfigmapName" -}}
+{{- if .Values.storageProfiles.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.storageProfiles.configmapName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.storageProfiles.configmapName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the Database credentials.  If we have create true, we will prefix it with the release name.
+*/}}
+{{- define "lakerunner.databaseSecretName" -}}
+{{- if .Values.database.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the ConfigDB credentials.  If we have create true, we will prefix it with the release name.
+*/}}
+{{- define "lakerunner.configdbSecretName" -}}
+{{- if .Values.configdb.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.configdb.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.configdb.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Return the secret name for cloud provider credentials based on the configured provider.
+*/}}
+{{- define "lakerunner.cloudProviderSecretName" -}}
+{{- if eq .Values.cloudProvider.provider "aws" }}
+{{- if .Values.cloudProvider.aws.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.cloudProvider.aws.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.cloudProvider.aws.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- else if eq .Values.cloudProvider.provider "azure" }}
+{{- if .Values.cloudProvider.azure.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.cloudProvider.azure.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.cloudProvider.azure.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- else if eq .Values.cloudProvider.provider "gcp" }}
+{{- if .Values.cloudProvider.gcp.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.cloudProvider.gcp.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.cloudProvider.gcp.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return whether cloud provider credentials should be injected into pods.
+*/}}
+{{- define "lakerunner.injectCloudProviderCredentials" -}}
+{{- $inject := false -}}
+{{- if eq .Values.cloudProvider.provider "aws" -}}
+{{- $inject = .Values.cloudProvider.aws.inject -}}
+{{- else if eq .Values.cloudProvider.provider "azure" -}}
+{{- $inject = .Values.cloudProvider.azure.inject -}}
+{{- else if eq .Values.cloudProvider.provider "gcp" -}}
+{{- $inject = .Values.cloudProvider.gcp.inject -}}
+{{- end -}}
+{{- $inject -}}
+{{- end }}
+
+{{/*
+Return Spring profile based on cloud provider.
+*/}}
+{{- define "lakerunner.springProfile" -}}
+{{- if eq .Values.cloudProvider.provider "azure" -}}
+azure
+{{- else -}}
+aws
+{{- end -}}
+{{- end }}
+
+{{/*
+Return AWS region from cloudProvider configuration.
+*/}}
+{{- define "lakerunner.awsRegion" -}}
+{{- if and (eq .Values.cloudProvider.provider "aws") .Values.cloudProvider.aws.region }}
+{{- .Values.cloudProvider.aws.region }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Merge two maps; keys in second take precedence.
+Usage: {{ mergeOverwrite $map1 $map2 }}
+*/}}
+{{- define "lakerunner.mergeOverwrite" -}}
+{{- $out := dict -}}
+{{- range $k, $v := index . 0 -}}
+  {{- $_ := set $out $k $v -}}
+{{- end -}}
+{{- range $k, $v := index . 1 -}}
+  {{- $_ := set $out $k $v -}}
+{{- end -}}
+{{- $out -}}
+{{- end -}}
+
+{{/*
+  Merge two maps (global + local), emit nodeSelector: if non-empty.
+  args: [ globalMap, localMap ]
+*/}}
+{{- define "lakerunner.sched.nodeSelector" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default dict -}}
+  {{- $local  := index $args 1 | default dict -}}
+  {{- $m      := merge $local $global -}}
+  {{- if gt (len $m) 0 -}}
+nodeSelector:
+{{ toYaml $m | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+  Merge global and local tolerations, emit tolerations: if non-empty.
+  args: [ globalList, localList ]
+*/}}
+{{- define "lakerunner.sched.tolerations" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default list -}}
+  {{- $local  := index $args 1 | default list -}}
+  {{- $merged := concat $local $global -}}
+  {{- if gt (len $merged) 0 -}}
+tolerations:
+{{ toYaml $merged | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+  Merge two affinity blocks, emit affinity: if non-empty.
+  args: [ globalAffinity, localAffinity ]
+*/}}
+{{- define "lakerunner.sched.affinity" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default dict -}}
+  {{- $local  := index $args 1 | default dict -}}
+  {{- $m      := merge $local $global -}}
+  {{- if gt (len $m) 0 -}}
+affinity:
+{{ toYaml $m | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate the image tag to use.
+Takes two arguments: component image config and root context
+Priority: component.tag > global.image.tag > Chart.appVersion
+Usage: {{ include "lakerunner.image.tag" (list .Values.componentName.image .) }}
+*/}}
+{{- define "lakerunner.image.tag" -}}
+{{- $componentImage := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if and $componentImage.tag (ne $componentImage.tag "") -}}
+{{- $componentImage.tag -}}
+{{- else if and $root.Values.global.image.tag (ne $root.Values.global.image.tag "") -}}
+{{- $root.Values.global.image.tag -}}
+{{- else -}}
+{{- $root.Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the image repository to use.
+Takes two arguments: component image config and root context
+Priority: global.image.repository (if set) > component.repository
+Only applies global override for lakerunner images (contains "lakerunner" in repository)
+Usage: {{ include "lakerunner.image.repository" (list .Values.componentName.image .) }}
+*/}}
+{{- define "lakerunner.image.repository" -}}
+{{- $componentImage := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if and $root.Values.global.image.repository (ne $root.Values.global.image.repository "") (contains "lakerunner" $componentImage.repository) -}}
+{{- $root.Values.global.image.repository -}}
+{{- else -}}
+{{- $componentImage.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the full image name for components.
+Takes two arguments: component image config and root context
+Usage: {{ include "lakerunner.image" (list .Values.componentName.image .) }}
+*/}}
+{{- define "lakerunner.image" -}}
+{{- $componentImage := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $repository := include "lakerunner.image.repository" (list $componentImage $root) -}}
+{{- $tag := include "lakerunner.image.tag" (list $componentImage $root) -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+
+{{/*
+Generate autoscaler environment variables for the monitoring deployment.
+Emits LAKERUNNER_AUTOSCALER_* env vars for all worker services. When a
+signal's processing is disabled, its MIN/MAX replicas are emitted as 0
+so the autoscaler treats it as scaled-to-zero.
+Usage: {{ include "lakerunner.autoscalerEnv" . }}
+*/}}
+{{- define "lakerunner.autoscalerEnv" -}}
+- name: LAKERUNNER_AUTOSCALER_ENABLED
+  value: "true"
+- name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
+  value: {{ .Values.monitoring.autoscaler.observeOnly | quote }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
+  value: {{ include "lakerunner.fullname" . }}-process-logs
+- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
+  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
+  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
+  value: {{ include "lakerunner.fullname" . }}-process-metrics
+- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS
+  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
+  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
+  value: {{ include "lakerunner.fullname" . }}-process-traces
+- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
+  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
+- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
+  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
+{{- end -}}
+
+{{/*
+Emit the LAKERUNNER_SCRATCH_DISK_SIZE_BYTES env var for scratch-using services.
+
+Behavior (issue #783):
+  - global.temporaryStorage.type == "ephemeral" (a real PersistentVolume via
+    volumeClaimTemplate): emit NOTHING. The app falls back to statfs(), which is
+    accurate on a dedicated PV. Setting an explicit size here would only cap the
+    real volume.
+  - otherwise (emptyDir backed by the node disk, with a sizeLimit): emit the
+    sizeLimit converted to bytes so the app treats it as its authoritative scratch
+    slice and stays within it. statfs on an emptyDir reports the whole node disk,
+    not the pod's slice, so the explicit value is required.
+
+The size value is the same one passed to lakerunner.ephemeralVolume, so the env
+var always matches the emptyDir sizeLimit. Emits nothing if no size is set or it
+parses to <= 0.
+
+Takes two args:
+  0: the root chart context
+  1: the component's values block (must have .temporaryStorage.size)
+Usage:
+  {{ include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
+*/}}
+{{- define "lakerunner.scratchDiskSizeEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- if ne $root.Values.global.temporaryStorage.type "ephemeral" -}}
+{{- $size := "" -}}
+{{- if and $comp.temporaryStorage $comp.temporaryStorage.size -}}
+  {{- $size = $comp.temporaryStorage.size -}}
+{{- end -}}
+{{- if $size -}}
+{{- $bytes := include "lakerunner.parseMemoryToBytes" $size | int64 -}}
+{{- if gt $bytes 0 }}
+- name: LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+  value: {{ $bytes | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate ephemeral volume configuration based on global settings.
+Takes three arguments: volume name, storage size, and root context
+Usage: {{ include "lakerunner.ephemeralVolume" (list "scratch" .Values.componentName.temporaryStorage.size .) }}
+*/}}
+{{- define "lakerunner.ephemeralVolume" -}}
+{{- $volumeName := index . 0 -}}
+{{- $storageSize := index . 1 -}}
+{{- $root := index . 2 -}}
+{{- if eq $root.Values.global.temporaryStorage.type "ephemeral" -}}
+- name: {{ $volumeName }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        {{- if $root.Values.global.temporaryStorage.ephemeral.labels }}
+        labels:
+          {{- toYaml $root.Values.global.temporaryStorage.ephemeral.labels | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if $root.Values.global.temporaryStorage.ephemeral.storageClassName }}
+        storageClassName: {{ $root.Values.global.temporaryStorage.ephemeral.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $storageSize | quote }}
+{{- else -}}
+- name: {{ $volumeName }}
+  emptyDir:
+    sizeLimit: {{ $storageSize | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate ephemeral volume configuration without size limit based on global settings.
+Takes two arguments: volume name and root context
+Usage: {{ include "lakerunner.ephemeralVolumeBasic" (list "storage" .) }}
+*/}}
+{{- define "lakerunner.ephemeralVolumeBasic" -}}
+{{- $volumeName := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if eq $root.Values.global.temporaryStorage.type "ephemeral" -}}
+- name: {{ $volumeName }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        {{- if $root.Values.global.temporaryStorage.ephemeral.labels }}
+        labels:
+          {{- toYaml $root.Values.global.temporaryStorage.ephemeral.labels | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if $root.Values.global.temporaryStorage.ephemeral.storageClassName }}
+        storageClassName: {{ $root.Values.global.temporaryStorage.ephemeral.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: "1Gi"
+{{- else -}}
+- name: {{ $volumeName }}
+  emptyDir: {}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate Azure workload identity token volume mount.
+Always included when using Azure workload identity auth type.
+*/}}
+{{- define "lakerunner.azureTokenVolumeMount" -}}
+{{- if and (eq .Values.cloudProvider.provider "azure") (eq .Values.cloudProvider.azure.authType "workload_identity") }}
+- name: azure-identity-token
+  mountPath: /var/run/secrets/azure/tokens
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
+Generate Azure workload identity token volume.
+Always included when using Azure workload identity auth type.
+*/}}
+{{- define "lakerunner.azureTokenVolume" -}}
+{{- if and (eq .Values.cloudProvider.provider "azure") (eq .Values.cloudProvider.azure.authType "workload_identity") }}
+- name: azure-identity-token
+  projected:
+    sources:
+    - serviceAccountToken:
+        path: azure-identity-token
+        audience: api://AzureADTokenExchange
+        expirationSeconds: 3600
+{{- end }}
+{{- end }}
+
+{{/*
+Validate license configuration. Called from license-validation.yaml to fail early.
+*/}}
+{{- define "lakerunner.validateLicense" -}}
+{{- if .Values.license.create }}
+{{- if not .Values.license.data }}
+{{- fail "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName." }}
+{{- end }}
+{{- else }}
+{{- if not .Values.license.secretName }}
+{{- fail "license.secretName is required when license.create is false. Provide the name of an existing Kubernetes secret containing the license." }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the license. If create is true, prefix with release name.
+*/}}
+{{- define "lakerunner.licenseSecretName" -}}
+{{- if .Values.license.create }}
+{{- printf "%s-%s" (include "lakerunner.fullname" .) .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate license volume mount. Always emitted — license is required.
+Usage: {{ include "lakerunner.licenseVolumeMount" . }}
+*/}}
+{{- define "lakerunner.licenseVolumeMount" -}}
+- name: license
+  mountPath: /app/license
+  readOnly: true
+{{- end }}
+
+{{/*
+Generate license volume. Always emitted — license is required.
+Usage: {{ include "lakerunner.licenseVolume" . }}
+*/}}
+{{- define "lakerunner.licenseVolume" -}}
+- name: license
+  secret:
+    secretName: {{ include "lakerunner.licenseSecretName" . }}
+{{- end }}
+
+{{/*
+Health probe configuration helper
+Takes root context and service configuration and returns whether health probes should be enabled
+Usage: {{ include "lakerunner.healthProbesEnabled" (list . .Values.serviceName) }}
+*/}}
+{{- define "lakerunner.healthProbesEnabled" -}}
+{{- $root := index . 0 -}}
+{{- $serviceConfig := index . 1 -}}
+{{- if hasKey $serviceConfig "healthProbes" -}}
+  {{- if not (eq $serviceConfig.healthProbes.enabled nil) -}}
+    {{- $serviceConfig.healthProbes.enabled -}}
+  {{- else -}}
+    {{- $root.Values.global.healthProbes.enabled -}}
+  {{- end -}}
+{{- else -}}
+  {{- $root.Values.global.healthProbes.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Health probe template for lakerunner services
+Generates standard liveness and readiness probes for lakerunner services
+Usage: {{ include "lakerunner.healthProbes" (list . .Values.serviceName) }}
+*/}}
+{{- define "lakerunner.healthProbes" -}}
+{{- $root := index . 0 -}}
+{{- $serviceConfig := index . 1 -}}
+{{- $portName := "healthcheck" -}}
+{{- if gt (len .) 2 -}}{{- $portName = index . 2 -}}{{- end -}}
+{{- if include "lakerunner.healthProbesEnabled" (list $root $serviceConfig) | eq "true" }}
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: {{ $portName }}
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: {{ $portName }}
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+{{- end -}}
+{{- end -}}
+
+{{/*
+Parse Kubernetes memory value to bytes.
+Supports: Ki, Mi, Gi, Ti, K, M, G, T (binary and decimal)
+Usage: {{ include "lakerunner.parseMemoryToBytes" "1Gi" }}
+*/}}
+{{- define "lakerunner.parseMemoryToBytes" -}}
+{{- $mem := . | toString -}}
+{{- $value := 0 -}}
+{{- $multiplier := 1 -}}
+{{- if hasSuffix "Ki" $mem -}}
+  {{- $value = trimSuffix "Ki" $mem | float64 -}}
+  {{- $multiplier = 1024 -}}
+{{- else if hasSuffix "Mi" $mem -}}
+  {{- $value = trimSuffix "Mi" $mem | float64 -}}
+  {{- $multiplier = 1048576 -}}
+{{- else if hasSuffix "Gi" $mem -}}
+  {{- $value = trimSuffix "Gi" $mem | float64 -}}
+  {{- $multiplier = 1073741824 -}}
+{{- else if hasSuffix "Ti" $mem -}}
+  {{- $value = trimSuffix "Ti" $mem | float64 -}}
+  {{- $multiplier = 1099511627776 -}}
+{{- else if hasSuffix "K" $mem -}}
+  {{- $value = trimSuffix "K" $mem | float64 -}}
+  {{- $multiplier = 1000 -}}
+{{- else if hasSuffix "M" $mem -}}
+  {{- $value = trimSuffix "M" $mem | float64 -}}
+  {{- $multiplier = 1000000 -}}
+{{- else if hasSuffix "G" $mem -}}
+  {{- $value = trimSuffix "G" $mem | float64 -}}
+  {{- $multiplier = 1000000000 -}}
+{{- else if hasSuffix "T" $mem -}}
+  {{- $value = trimSuffix "T" $mem | float64 -}}
+  {{- $multiplier = 1000000000000 -}}
+{{- else -}}
+  {{- $value = $mem | float64 -}}
+{{- end -}}
+{{- mulf $value $multiplier | int64 -}}
+{{- end -}}
+
+{{/*
+Calculate GOMEMLIMIT based on memory limit.
+Rules:
+  - If memory > 1GiB: GOMEMLIMIT = total memory - 250MiB
+  - If memory <= 1GiB: GOMEMLIMIT = 75% of memory
+Returns value in MiB format (e.g., "3840MiB").
+Usage: {{ include "lakerunner.calculateGomemlimit" "2Gi" }}
+*/}}
+{{- define "lakerunner.calculateGomemlimit" -}}
+{{- $bytes := include "lakerunner.parseMemoryToBytes" . | int64 -}}
+{{- $oneGiB := 1073741824 -}}
+{{- $reserveMiB := 250 -}}
+{{- $oneMiB := 1048576 -}}
+{{- $totalMiB := divf $bytes $oneMiB | int64 -}}
+{{- if gt $bytes $oneGiB -}}
+  {{- $resultMiB := sub $totalMiB $reserveMiB -}}
+  {{- printf "%dMiB" $resultMiB -}}
+{{- else -}}
+  {{- $resultMiB := mulf $totalMiB 0.75 | int64 -}}
+  {{- printf "%dMiB" $resultMiB -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate GOGC based on memory limit.
+Rules:
+  - If memory <= 1GiB: GOGC = 50
+  - If 1GiB < memory <= 2GiB: GOGC = 100
+  - If memory > 2GiB: GOGC = 200
+Usage: {{ include "lakerunner.calculateGogc" "2Gi" }}
+*/}}
+{{- define "lakerunner.calculateGogc" -}}
+{{- $bytes := include "lakerunner.parseMemoryToBytes" . | int64 -}}
+{{- $oneGiB := 1073741824 -}}
+{{- $twoGiB := 2147483648 -}}
+{{- if le $bytes $oneGiB -}}
+50
+{{- else if le $bytes $twoGiB -}}
+100
+{{- else -}}
+200
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if GOMEMLIMIT is already set in env list.
+Usage: {{ include "lakerunner.hasEnvVar" (list $envList "GOMEMLIMIT") }}
+*/}}
+{{- define "lakerunner.hasEnvVar" -}}
+{{- $envList := index . 0 | default list -}}
+{{- $varName := index . 1 -}}
+{{- $found := false -}}
+{{- range $envList -}}
+  {{- if eq .name $varName -}}
+    {{- $found = true -}}
+  {{- end -}}
+{{- end -}}
+{{- $found -}}
+{{- end -}}
+
+{{/*
+Generate Go runtime environment variables (GOMEMLIMIT, GOGC) based on resource limits.
+Only sets values if not already provided by user in global.env or component.env.
+Takes three args:
+  0: the root chart context
+  1: the component's values block (must have .resources.limits.memory)
+  2: optional component env list
+Usage: {{ include "lakerunner.goRuntimeEnv" (list . .Values.componentName .Values.componentName.env) }}
+*/}}
+{{- define "lakerunner.goRuntimeEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- $compEnv := index . 2 | default list -}}
+{{- $globalEnv := $root.Values.global.env | default list -}}
+{{- $memLimit := "" -}}
+{{- if and $comp.resources $comp.resources.limits $comp.resources.limits.memory -}}
+  {{- $memLimit = $comp.resources.limits.memory -}}
+{{- end -}}
+{{- if $memLimit -}}
+  {{- $hasGomemlimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOMEMLIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOMEMLIMIT")) "true") -}}
+  {{- $hasGogc := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOGC")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOGC")) "true") -}}
+  {{- if not $hasGomemlimit }}
+- name: GOMEMLIMIT
+  value: {{ include "lakerunner.calculateGomemlimit" $memLimit | quote }}
+  {{- end }}
+  {{- if not $hasGogc }}
+- name: GOGC
+  value: {{ include "lakerunner.calculateGogc" $memLimit | quote }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate DuckDB-specific runtime environment variables for ingest/compact/rollup services.
+These services use DuckDB internally and need specific memory tuning.
+
+Memory budget split (worker pods):
+  duckdb_memory_limit  ≈ 40% of container memory
+  go_runtime_budget    ≈ 20% of container memory  (clamped 256–1024 MiB)
+  reserved             ≈ 40% (cgo allocator overhead, DuckDB peak overshoot,
+                              transient allocations not tracked by DuckDB's
+                              memory_limit). Empirically RSS overshoots
+                              memory_limit ~2× under hash builds/sorts.
+
+Settings:
+  - GOMEMLIMIT = clamp(20% of container, 256MiB..1024MiB)
+  - GOGC = 100 (fixed)
+  - LAKERUNNER_DUCKDB_MEMORY_LIMIT = 40% of container, in MB (min 512)
+  - LAKERUNNER_DUCKDB_TEMP_DIRECTORY = /scratch
+  - MALLOC_ARENA_MAX = 2 (collapses glibc per-thread arena fragmentation
+                          for cgo-heavy DuckDB workloads)
+Takes three args:
+  0: the root chart context
+  1: the component's values block (must have .resources.limits.memory)
+  2: optional component env list
+Usage: {{ include "lakerunner.duckdbRuntimeEnv" (list . .Values.componentName .Values.componentName.env) }}
+*/}}
+{{- define "lakerunner.duckdbRuntimeEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- $compEnv := index . 2 | default list -}}
+{{- $globalEnv := $root.Values.global.env | default list -}}
+{{- $memLimit := "" -}}
+{{- if and $comp.resources $comp.resources.limits $comp.resources.limits.memory -}}
+  {{- $memLimit = $comp.resources.limits.memory -}}
+{{- end -}}
+{{- if $memLimit -}}
+  {{- $bytes := include "lakerunner.parseMemoryToBytes" $memLimit | int64 -}}
+  {{- $oneMiB := 1048576 -}}
+  {{- $totalMiB := divf $bytes $oneMiB | int64 -}}
+  {{- $hasGomemlimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOMEMLIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOMEMLIMIT")) "true") -}}
+  {{- $hasGogc := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOGC")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOGC")) "true") -}}
+  {{- $hasDuckdbMemLimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") -}}
+  {{- $hasDuckdbTempDir := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") -}}
+  {{- $hasMallocArenaMax := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "MALLOC_ARENA_MAX")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "MALLOC_ARENA_MAX")) "true") -}}
+{{- if not $hasGomemlimit }}
+{{- /* GOMEMLIMIT = 20% of container, clamped to [256, 1024] MiB */}}
+{{- $gomemlimitMiB := mulf $totalMiB 0.20 | int64 -}}
+{{- if lt $gomemlimitMiB 256 -}}{{- $gomemlimitMiB = 256 -}}{{- end -}}
+{{- if gt $gomemlimitMiB 1024 -}}{{- $gomemlimitMiB = 1024 -}}{{- end }}
+- name: GOMEMLIMIT
+  value: {{ printf "%dMiB" $gomemlimitMiB | quote }}
+{{- end }}
+{{- if not $hasGogc }}
+- name: GOGC
+  value: "100"
+{{- end }}
+{{- if not $hasDuckdbMemLimit }}
+{{- /* DuckDB target = 40% of container, in MB; floor 512 MB */}}
+{{- $duckdbMB := mulf $totalMiB 0.40 | int64 -}}
+{{- if lt $duckdbMB 512 -}}{{- $duckdbMB = 512 -}}{{- end }}
+- name: LAKERUNNER_DUCKDB_MEMORY_LIMIT
+  value: {{ $duckdbMB | quote }}
+{{- end }}
+{{- if not $hasDuckdbTempDir }}
+- name: LAKERUNNER_DUCKDB_TEMP_DIRECTORY
+  value: "/scratch"
+{{- end }}
+{{- if not $hasMallocArenaMax }}
+- name: MALLOC_ARENA_MAX
+  value: "2"
+{{- end }}
+{{- end -}}
+{{- include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
+{{- end -}}
+
+{{/*
+Generate query-worker-specific runtime environment variables.
+Settings:
+  - LAKERUNNER_DUCKDB_MEMORY_LIMIT = 50% of container memory (in MB)
+  - GOMEMLIMIT = 75% of the remaining 50% (37.5% of total)
+  - GOGC = calculated based on total memory
+  - LAKERUNNER_DUCKDB_TEMP_DIRECTORY = /scratch
+  - MALLOC_ARENA_MAX = 2 (cgo-heavy DuckDB workload — collapses glibc
+                          per-thread arena fragmentation)
+Takes three args:
+  0: the root chart context
+  1: the component's values block (must have .resources.limits.memory)
+  2: optional component env list
+Usage: {{ include "lakerunner.queryWorkerRuntimeEnv" (list . .Values.queryWorker .Values.queryWorker.env) }}
+*/}}
+{{- define "lakerunner.queryWorkerRuntimeEnv" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- $compEnv := index . 2 | default list -}}
+{{- $globalEnv := $root.Values.global.env | default list -}}
+{{- $memLimit := "" -}}
+{{- if and $comp.resources $comp.resources.limits $comp.resources.limits.memory -}}
+  {{- $memLimit = $comp.resources.limits.memory -}}
+{{- end -}}
+{{- if $memLimit -}}
+  {{- $bytes := include "lakerunner.parseMemoryToBytes" $memLimit | int64 -}}
+  {{- $oneMiB := 1048576 -}}
+  {{- $totalMiB := divf $bytes $oneMiB | int64 -}}
+  {{- $hasGomemlimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOMEMLIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOMEMLIMIT")) "true") -}}
+  {{- $hasGogc := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "GOGC")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "GOGC")) "true") -}}
+  {{- $hasDuckdbMemLimit := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_MEMORY_LIMIT")) "true") -}}
+  {{- $hasDuckdbTempDir := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "LAKERUNNER_DUCKDB_TEMP_DIRECTORY")) "true") -}}
+  {{- $hasMallocArenaMax := or (eq (include "lakerunner.hasEnvVar" (list $globalEnv "MALLOC_ARENA_MAX")) "true") (eq (include "lakerunner.hasEnvVar" (list $compEnv "MALLOC_ARENA_MAX")) "true") -}}
+{{- if not $hasGomemlimit }}
+{{- /* GOMEMLIMIT = 75% of half the memory = 37.5% of total */}}
+{{- $halfMiB := divf $totalMiB 2 | int64 -}}
+{{- $gomemlimitMiB := mulf $halfMiB 0.75 | int64 }}
+- name: GOMEMLIMIT
+  value: {{ printf "%dMiB" $gomemlimitMiB | quote }}
+{{- end }}
+{{- if not $hasGogc }}
+- name: GOGC
+  value: {{ include "lakerunner.calculateGogc" $memLimit | quote }}
+{{- end }}
+{{- if not $hasDuckdbMemLimit }}
+{{- /* DuckDB memory = 50% of total, in MB */}}
+{{- $duckdbMB := divf $totalMiB 2 | int64 }}
+- name: LAKERUNNER_DUCKDB_MEMORY_LIMIT
+  value: {{ $duckdbMB | quote }}
+{{- end }}
+{{- if not $hasDuckdbTempDir }}
+- name: LAKERUNNER_DUCKDB_TEMP_DIRECTORY
+  value: "/scratch"
+{{- end }}
+{{- if not $hasMallocArenaMax }}
+- name: MALLOC_ARENA_MAX
+  value: "2"
+{{- end }}
+{{- end -}}
+{{- include "lakerunner.scratchDiskSizeEnv" (list $root $comp) }}
+{{- end -}}
+
+{{/*
+Inject common + component-specific env vars for query-worker.
+Query-worker uses DuckDB for queries with specific memory tuning.
+Takes two args:
+  0: the root chart context (so we can call commonEnv with it)
+  1: the component's values block (must have .env as a list)
+Usage:
+  {{ include "lakerunner.injectEnvQueryWorker" (list . .Values.queryWorker) | nindent 10 }}
+*/}}
+{{- define "lakerunner.injectEnvQueryWorker" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- include "lakerunner.commonEnv" $root | nindent 2 -}}
+{{- include "lakerunner.queryWorkerRuntimeEnv" (list $root $comp $comp.env) | nindent 2 -}}
+{{- include "lakerunner.tracesEnv" (list $root $comp) | nindent 2 -}}
+{{- with $root.Values.global.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- with $comp.env -}}
+{{ toYaml . | nindent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Pod-level securityContext for a workload.
+Shallow-merges global.podSecurityContext with an optional per-component override;
+component fields win over global. Uses explicit `set` instead of sprig's `merge`
+to avoid mergo's quirk where falsy zero values (false, 0, "") get overwritten.
+Emits nothing when the resulting map is empty.
+Usage:
+  {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.grafana.podSecurityContext) | nindent 6 }}
+Components without an override can omit the "override" key.
+*/}}
+{{- define "lakerunner.podSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.podSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Container-level securityContext for a container.
+Same shallow-merge semantics as lakerunner.podSecurityContext.
+Usage:
+  {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.grafana.containerSecurityContext) | nindent 8 }}
+*/}}
+{{- define "lakerunner.containerSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.containerSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -1181,3 +1181,30 @@ injected. Override with .Values.serviceAccount.name. Per-component SAs
 {{- .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end }}
+
+{{/* Whether fresh-install bootstrap is active (false when mode=never). */}}
+{{- define "conductor.bootstrapEnabled" -}}
+{{- ne (.Values.bootstrap.mode | default "auto") "never" -}}
+{{- end }}
+
+{{/* Name of the admin-key anchor Secret (operator-supplied or chart-managed). */}}
+{{- define "conductor.adminKeySecretName" -}}
+{{- if .Values.bootstrap.adminKey.existingSecret -}}
+{{- .Values.bootstrap.adminKey.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin-api-key" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{/* Key name within the admin-key Secret. */}}
+{{- define "conductor.adminKeySecretKey" -}}
+{{- .Values.bootstrap.adminKey.existingSecretKey | default "admin-api-key" -}}
+{{- end }}
+
+{{/* In-cluster admin-api / query-api base URLs (release-scoped service names). */}}
+{{- define "conductor.adminApiUrl" -}}
+{{- printf "http://%s-lakerunner-admin-api:9091" .Release.Name -}}
+{{- end }}
+{{- define "conductor.queryApiUrl" -}}
+{{- printf "http://%s-lakerunner-query-api:8080" .Release.Name -}}
+{{- end }}

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -1182,12 +1182,24 @@ injected. Override with .Values.serviceAccount.name. Per-component SAs
 {{- end -}}
 {{- end }}
 
-{{/* Whether fresh-install bootstrap is active. Emits "true" when active and an
-     empty string when mode=never, so callers can use `include` directly in
-     `if`/`and` (a non-empty string is truthy, empty is falsy — unlike the
-     literal string "false", which is truthy). */}}
+{{/* Normalize bootstrap.mode; "never" is a deprecated alias of "adopt". */}}
+{{- define "conductor.bootstrapMode" -}}
+{{- $m := .Values.bootstrap.mode | default "auto" -}}
+{{- if eq $m "never" -}}adopt{{- else -}}{{ $m }}{{- end -}}
+{{- end }}
+
+{{/* Whether fresh-install bootstrap resources render. Emits "true" unless
+     adopting, and an empty string when mode=adopt (alias never), so callers can
+     use `include` directly in `if`/`and` (a non-empty string is truthy, empty is
+     falsy — unlike the literal string "false", which is truthy). */}}
 {{- define "conductor.bootstrapEnabled" -}}
-{{- if ne (.Values.bootstrap.mode | default "auto") "never" -}}true{{- end -}}
+{{- if ne (include "conductor.bootstrapMode" .) "adopt" -}}true{{- end -}}
+{{- end }}
+
+{{/* Whether the pre-install detection Job renders. Emits "true" only in auto
+     mode (force skips the safety net; adopt renders nothing); empty otherwise. */}}
+{{- define "conductor.detectionEnabled" -}}
+{{- if eq (include "conductor.bootstrapMode" .) "auto" -}}true{{- end -}}
 {{- end }}
 
 {{/* Name of the admin-key anchor Secret (operator-supplied or chart-managed). */}}

--- a/conductor/templates/_helpers-maestro.tpl
+++ b/conductor/templates/_helpers-maestro.tpl
@@ -92,11 +92,7 @@ annotations:
 Create the name of the service account to use
 */}}
 {{- define "maestro.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "maestro.fullname" .) .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- .Values.serviceAccount.name }}
-{{- end }}
+{{- include "conductor.serviceAccountName" . -}}
 {{- end }}
 
 {{/*

--- a/conductor/templates/_helpers-maestro.tpl
+++ b/conductor/templates/_helpers-maestro.tpl
@@ -1,0 +1,889 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "maestro.name" -}}
+{{- default "maestro" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Render imagePullSecrets.
+*/}}
+{{- define "maestro.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "maestro.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "maestro" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "maestro.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels, now including .Values.global.labels.
+*/}}
+{{- define "maestro.labels" -}}
+  {{- $global := .Values.global.labels | default dict -}}
+  {{- $labels := merge
+      (dict "helm.sh/chart" (include "maestro.chart" .))
+      (include "maestro.selectorLabels" . | fromYaml)
+  -}}
+  {{- if .Chart.AppVersion -}}
+    {{- $labels = merge $labels (dict "app.kubernetes.io/version" (.Chart.AppVersion)) -}}
+  {{- end -}}
+  {{- $labels = merge $labels (dict "app.kubernetes.io/managed-by" .Release.Service) -}}
+  {{- $labels = merge $labels $global -}}
+  {{- toYaml $labels -}}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "maestro.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "maestro.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return only the indented key: value lines for .Values.global.annotations,
+or nothing if the map is empty.
+*/}}
+{{- define "maestro.annotationPairs" -}}
+{{- $ann := .Values.global.annotations -}}
+{{- if and $ann (gt (len $ann) 0) -}}
+{{ toYaml $ann | indent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+"Smart" annotations helper: emits the header + pairs when non-empty.
+*/}}
+{{- define "maestro.annotations" -}}
+{{- if and .Values.global.annotations (gt (len .Values.global.annotations) 0) -}}
+annotations:
+{{ include "maestro.annotationPairs" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "maestro.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "maestro.fullname" .) .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate the full image name (unified image for all components).
+Priority: image.tag > Chart.appVersion
+Usage: {{ include "maestro.image" . }}
+*/}}
+{{- define "maestro.image" -}}
+{{- $tag := "" -}}
+{{- if and .Values.image.tag (ne .Values.image.tag "") -}}
+{{- $tag = .Values.image.tag -}}
+{{- else -}}
+{{- $tag = .Chart.AppVersion -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+"Unset" detector used by the auto-derive helpers. Treats both null (the
+documented default sentinel) and empty string (operator did `--set
+key=`) as unset, so both produce the auto-derived default.
+*/}}
+{{- define "maestro.isUnset" -}}
+{{- $v := . -}}
+{{- if kindIs "invalid" $v -}}true
+{{- else if and (kindIs "string" $v) (eq $v "") -}}true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Strict bool reader for mode-critical toggles (ha.enabled, githubCache.enabled,
+maestro.persistence.enabled). Returns "true" (string) when the value is the
+YAML/Go bool true, "" when it's bool false or nil. Fails template rendering
+on any other type (e.g. operator typed `--set-string ha.enabled=true` and
+got a string instead of a bool — silently treating "true" as false is the
+dangerous case Codex flagged).
+
+Usage: {{ include "maestro.boolOrFail" (dict "value" $v "path" "ha.enabled") }}
+*/}}
+{{- define "maestro.boolOrFail" -}}
+{{- $v := .value -}}
+{{- $path := .path -}}
+{{- if kindIs "invalid" $v -}}{{/* nil → treat as false; no output */}}
+{{- else if kindIs "bool" $v -}}{{- if $v -}}true{{- end -}}
+{{- else -}}
+{{- fail (printf "%s must be a YAML boolean (true or false), got %v of type %s. Use `--set %s=true` / `=false`, not `--set-string`." $path $v (kindOf $v) $path) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+HA mode toggle — returns "true" (string) when ha.enabled is the bool true,
+"" otherwise. Strictly bool-only via boolOrFail.
+*/}}
+{{- define "maestro.haEnabled" -}}
+{{- include "maestro.boolOrFail" (dict "value" (dig "enabled" false (.Values.ha | default dict)) "path" "ha.enabled") -}}
+{{- end -}}
+
+{{/*
+Effective maestro persistence enablement. Same strict-bool semantics as
+haEnabled. Centralizes the gate so every consumer (PVC, Deployment
+strategy block, env injection, volume mount) reads the same narrowed
+value — and stringly `--set-string maestro.persistence.enabled=false`
+can't accidentally render as truthy in some gates and falsy in others.
+*/}}
+{{- define "maestro.persistenceEnabled" -}}
+{{- $v := dig "enabled" false (dig "persistence" dict (.Values.maestro | default dict)) -}}
+{{- include "maestro.boolOrFail" (dict "value" $v "path" "maestro.persistence.enabled") -}}
+{{- end -}}
+
+{{/*
+Effective github-cache enablement after auto-derivation from ha.enabled.
+  - Explicit operator value (bool true/false) wins.
+  - Unset (null or "") → true when HA, false in POC.
+Returns "true" (string) when enabled, "" otherwise. Pair with the
+maestro.haValidate gate so explicit conflicts surface as failures.
+Strictly bool-only (see maestro.haEnabled rationale).
+*/}}
+{{- define "maestro.githubCacheEnabled" -}}
+{{- $explicit := dig "enabled" nil (.Values.githubCache | default dict) -}}
+{{- if include "maestro.isUnset" $explicit -}}
+  {{- if include "maestro.haEnabled" . -}}true{{- end -}}
+{{- else -}}
+  {{- include "maestro.boolOrFail" (dict "value" $explicit "path" "githubCache.enabled") -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Effective replica count for a workload after auto-derivation from ha.enabled.
+  - Explicit operator value (integer) wins.
+  - Unset (null or "") → `haDefault` when HA, `pocDefault` in POC.
+  - Defaults: haDefault=2, pocDefault=1. mcp-gateway overrides haDefault to 1
+    because its stateful StreamableHTTP drivers (everything except
+    collector-editor) require sticky routing — see conductor issue tracking
+    the gateway-driver-stateless work. Operators can still set the value
+    explicitly to scale past the auto-derived default, knowing the
+    "session not found" risk.
+
+Usage:
+  {{ include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas) }}
+  {{ include "maestro.replicas" (dict "root" . "explicit" .Values.mcpGateway.replicas "haDefault" 1) }}
+*/}}
+{{- define "maestro.replicas" -}}
+{{- $explicit := .explicit -}}
+{{- $haDefault := default 2 .haDefault -}}
+{{- $pocDefault := default 1 .pocDefault -}}
+{{- if include "maestro.isUnset" $explicit -}}
+  {{- if include "maestro.haEnabled" .root -}}{{ $haDefault }}{{- else -}}{{ $pocDefault }}{{- end -}}
+{{- else -}}
+  {{- $explicit -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+mcp-gateway as a native sidecar (initContainer with restartPolicy: Always,
+GA in k8s 1.29). Used by maestro, github-cache (serving), and
+github-cache-provisioner pod templates so each consumer talks to its
+own pod-local gateway over loopback. No Service or cross-pod routing
+involved — sidesteps the "session not found" issue (cardinalhq/conductor#838)
+that affects stateful MCP drivers under round-robin load balancing.
+
+The sidecar uses the unified image dispatched with `mcp-gateway` args.
+Resource block is conservative (CPU request lowered from the standalone
+default since per-pod density goes up); memory keeps the standalone
+default since observed steady-state hovers near it.
+
+Usage (inside a pod template's initContainers list):
+  {{- include "maestro.mcpGatewaySidecar" (dict "root" . "containerSec" $cSec) | nindent 6 }}
+*/}}
+{{- define "maestro.mcpGatewaySidecar" -}}
+- name: mcp-gateway
+  restartPolicy: Always
+  image: {{ include "maestro.image" .root }}
+  imagePullPolicy: {{ .root.Values.image.pullPolicy }}
+  command: ["/app/entrypoint.sh"]
+  args: ["mcp-gateway"]
+  {{- include "maestro.containerSecurityContext" (dict "root" .root "override" (default dict .containerSec)) | nindent 2 }}
+  ports:
+  - containerPort: {{ .root.Values.mcpGateway.port }}
+    name: mcp
+  - containerPort: {{ .root.Values.mcpGateway.debugPort }}
+    name: mcp-debug
+  env:
+    {{ include "maestro.databaseEnv" .root | nindent 4 }}
+    - name: MCP_PORT
+      value: {{ .root.Values.mcpGateway.port | quote }}
+    - name: MCP_DEBUG_PORT
+      value: {{ .root.Values.mcpGateway.debugPort | quote }}
+    {{- if .root.Values.mcpGateway.apiKey }}
+    - name: MCP_API_KEY
+      value: {{ .root.Values.mcpGateway.apiKey | quote }}
+    {{- else if and .root.Values.mcpGateway.apiKeySecret .root.Values.mcpGateway.apiKeySecret.name }}
+    - name: MCP_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ .root.Values.mcpGateway.apiKeySecret.name | quote }}
+          key: {{ .root.Values.mcpGateway.apiKeySecret.key | default "MCP_API_KEY" | quote }}
+    {{- end }}
+    {{- include "maestro.cardinalTelemetryEnv" .root | nindent 4 }}
+    {{- with .root.Values.global.env }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .root.Values.mcpGateway.env }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .root.Values.global.resources.enabled }}
+  resources:
+    {{- toYaml .root.Values.mcpGateway.resources | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+  {{- include "maestro.licenseVolumeMount" .root | nindent 2 }}
+{{- end -}}
+
+{{/*
+HA-mode invariant validator. Called from each Deployment template so an
+invalid combination fails rendering with a clear message no matter which
+file the operator looks at.
+
+The strict-bool narrow on mode-critical toggles runs UNCONDITIONALLY —
+even in POC mode — so a stringly `--set-string ha.enabled=true`,
+`--set-string githubCache.enabled=...`, or `--set-string
+maestro.persistence.enabled=...` fails with a clear message regardless
+of whether the helper is otherwise reached during this particular
+template's render path.
+*/}}
+{{- define "maestro.haValidate" -}}
+{{- /* Force-narrow the mode-critical bools so stringly inputs fail loud. */ -}}
+{{- $_ := include "maestro.haEnabled" . -}}
+{{- $_ = include "maestro.persistenceEnabled" . -}}
+{{- $ghExplicitNarrow := dig "enabled" nil (.Values.githubCache | default dict) -}}
+{{- if not (include "maestro.isUnset" $ghExplicitNarrow) -}}
+  {{- $_ = include "maestro.boolOrFail" (dict "value" $ghExplicitNarrow "path" "githubCache.enabled") -}}
+{{- end -}}
+{{- if include "maestro.haEnabled" . -}}
+  {{- /* HA requires object storage. */ -}}
+  {{- $bucket := dig "bucket" "" (.Values.objectStore | default dict) -}}
+  {{- if not $bucket -}}
+    {{- fail "ha.enabled=true requires objectStore.bucket to be set (artifacts must be durable across pods). See values.yaml for AWS-S3 and Rook-Ceph examples." -}}
+  {{- end -}}
+  {{- /* HA is incompatible with the maestro RWO PVC (Recreate strategy + replicas>1 deadlocks). */ -}}
+  {{- if include "maestro.persistenceEnabled" . -}}
+    {{- fail "ha.enabled=true is incompatible with maestro.persistence.enabled=true (Recreate strategy + RWO PVC deadlocks rolling updates under replicas>1). Use objectStore for artifacts; the github-cache StatefulSet already handles its own per-pod PVCs." -}}
+  {{- end -}}
+  {{- /* HA requires the split github-cache. Explicit bool false fails. */ -}}
+  {{- $ghExplicit := dig "enabled" nil (.Values.githubCache | default dict) -}}
+  {{- if and (not (include "maestro.isUnset" $ghExplicit)) (not (include "maestro.boolOrFail" (dict "value" $ghExplicit "path" "githubCache.enabled"))) -}}
+    {{- fail "ha.enabled=true is incompatible with explicit githubCache.enabled=false (in-process github-cache holds per-pod state and a single PVC, neither of which scales). Remove the override or set ha.enabled=false." -}}
+  {{- end -}}
+  {{- /* HA replica counts must be ≥ 2. */ -}}
+  {{- $mReplicas := dig "replicas" nil (.Values.maestro | default dict) -}}
+  {{- if and (not (include "maestro.isUnset" $mReplicas)) (lt (int $mReplicas) 2) -}}
+    {{- fail (printf "ha.enabled=true requires maestro.replicas >= 2 (got %v). Lower replica counts are POC mode; set ha.enabled=false." $mReplicas) -}}
+  {{- end -}}
+  {{- /* No replica check for mcp-gateway: it stays at 1 even under HA because
+       its non-collector-editor drivers use stateful StreamableHTTP. Scaling
+       past 1 silently is an HA footgun, so we don't auto-derive past 1 — but
+       we DO honor an explicit override so the operator can opt in if they
+       know they only exercise the collector-editor driver (the one HA-safe
+       path). */ -}}
+  {{- $ghServingReplicas := dig "serving" "replicas" nil (.Values.githubCache | default dict) -}}
+  {{- if and (not (include "maestro.isUnset" $ghServingReplicas)) (lt (int $ghServingReplicas) 2) -}}
+    {{- fail (printf "ha.enabled=true requires githubCache.serving.replicas >= 2 (got %v). The serving StatefulSet must be redundant in HA mode." $ghServingReplicas) -}}
+  {{- end -}}
+{{- end -}}
+{{- /* These checks are independent of HA mode — wrong auth keys with an
+    existingSecret will break at runtime in either mode, so fail at template
+    time regardless. */ -}}
+{{- $auth := dig "auth" dict (.Values.objectStore | default dict) -}}
+{{- $existing := dig "existingSecret" "" $auth -}}
+{{- if $existing -}}
+  {{- if not (dig "accessKeyIdKey" "" $auth) -}}
+    {{- fail "objectStore.auth.existingSecret is set but objectStore.auth.accessKeyIdKey is empty. Set the key name the secret uses (commonly AWS_ACCESS_KEY_ID)." -}}
+  {{- end -}}
+  {{- if not (dig "secretAccessKeyKey" "" $auth) -}}
+    {{- fail "objectStore.auth.existingSecret is set but objectStore.auth.secretAccessKeyKey is empty. Set the key name the secret uses (commonly AWS_SECRET_ACCESS_KEY)." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Object-store env vars injected into the maestro container when a bucket
+is configured. Emits MAESTRO_ARTIFACT_STORE=object + bucket/region/
+endpoint/forcePathStyle. Credential env (AWS_*) is emitted separately by
+maestro.objectStoreAuthEnv so the SDK default credential chain still
+works when no existingSecret is configured.
+
+Region defaulting: AWS SDK v3 requires a region. For AWS S3 the operator
+sets `objectStore.region` explicitly. For S3-compatible stores reached
+via a custom `endpoint` (Ceph RGW, MinIO, Rook OBC) the region is
+typically irrelevant but still mandatory at the SDK layer — fall back
+to "us-east-1" so the SDK is satisfied. AWS S3 without an explicit
+region uses no fallback (any wrong default would fail later anyway).
+*/}}
+{{- define "maestro.objectStoreEnv" -}}
+{{- $os := .Values.objectStore | default dict -}}
+{{- $bucket := dig "bucket" "" $os -}}
+{{- if $bucket }}
+{{- $endpoint := dig "endpoint" "" $os -}}
+{{- $region := dig "region" "" $os -}}
+{{- if and (not $region) $endpoint -}}{{- $region = "us-east-1" -}}{{- end }}
+- name: MAESTRO_ARTIFACT_STORE
+  value: "object"
+- name: MAESTRO_ARTIFACT_S3_BUCKET
+  value: {{ $bucket | quote }}
+{{- if $region }}
+- name: MAESTRO_ARTIFACT_S3_REGION
+  value: {{ $region | quote }}
+{{- end }}
+{{- if $endpoint }}
+- name: MAESTRO_ARTIFACT_S3_ENDPOINT
+  value: {{ $endpoint | quote }}
+{{- end }}
+{{- if eq (dig "forcePathStyle" false $os) true }}
+- name: MAESTRO_ARTIFACT_S3_FORCE_PATH_STYLE
+  value: "1"
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Object-store auth env vars sourced from an existing Kubernetes Secret.
+Emits nothing when:
+  - objectStore.bucket is empty (no S3 backend in use → don't inject
+    creds the app won't use, and don't make the pod depend on a secret
+    that may not exist), or
+  - objectStore.auth.existingSecret is empty (rely on the SDK default
+    credential chain — IRSA, instance profile, workload identity).
+*/}}
+{{- define "maestro.objectStoreAuthEnv" -}}
+{{- $os := .Values.objectStore | default dict -}}
+{{- $bucket := dig "bucket" "" $os -}}
+{{- $auth := dig "auth" dict $os -}}
+{{- $secret := dig "existingSecret" "" $auth -}}
+{{- if and $bucket $secret -}}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret | quote }}
+      key: {{ dig "accessKeyIdKey" "AWS_ACCESS_KEY_ID" $auth | quote }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret | quote }}
+      key: {{ dig "secretAccessKeyKey" "AWS_SECRET_ACCESS_KEY" $auth | quote }}
+{{- with dig "sessionTokenKey" "" $auth }}
+- name: AWS_SESSION_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret | quote }}
+      key: {{ . | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret name for the Database credentials. If we have create true, we will prefix it with the release name.
+*/}}
+{{- define "maestro.databaseSecretName" -}}
+{{- if .Values.database.create }}
+{{- printf "%s-%s" (include "maestro.fullname" .) .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database environment variables shared across components.
+*/}}
+{{- define "maestro.databaseEnv" -}}
+- name: MAESTRO_DB_HOST
+  value: {{ .Values.database.host | quote }}
+- name: MAESTRO_DB_PORT
+  value: {{ .Values.database.port | quote }}
+- name: MAESTRO_DB_USER
+  value: {{ .Values.database.username | quote }}
+- name: MAESTRO_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "maestro.databaseSecretName" . }}
+      key: {{ .Values.database.passwordKey }}
+- name: MAESTRO_DB_NAME
+  value: {{ .Values.database.name | quote }}
+- name: MAESTRO_DB_SSLMODE
+  value: {{ .Values.database.sslMode | quote }}
+- name: MAESTRO_DATABASE_URL
+  value: "postgresql://$(MAESTRO_DB_USER):$(MAESTRO_DB_PASSWORD)@$(MAESTRO_DB_HOST):$(MAESTRO_DB_PORT)/$(MAESTRO_DB_NAME)?sslmode=$(MAESTRO_DB_SSLMODE)"
+{{- end }}
+
+{{/*
+github-cache: fully qualified names for the serving StatefulSet + headless
+Service and the provisioner Deployment.
+*/}}
+{{- define "maestro.githubCacheFullname" -}}
+{{- printf "%s-github-cache" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "maestro.githubCacheProvisionerFullname" -}}
+{{- printf "%s-github-cache-provisioner" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+github-cache reads its Postgres DSN from DATABASE_URL (not maestro's
+MAESTRO_DATABASE_URL). Emit it as an alias composed from the same
+MAESTRO_DB_* vars that maestro.databaseEnv defines, so it must follow that
+helper in the env list (the $(VAR) refs resolve against the earlier entries).
+*/}}
+{{- define "maestro.databaseUrlAlias" -}}
+- name: DATABASE_URL
+  value: "postgresql://$(MAESTRO_DB_USER):$(MAESTRO_DB_PASSWORD)@$(MAESTRO_DB_HOST):$(MAESTRO_DB_PORT)/$(MAESTRO_DB_NAME)?sslmode=$(MAESTRO_DB_SSLMODE)"
+{{- end -}}
+
+{{/*
+Return the secret name for the Cardinal API key.
+*/}}
+{{- define "maestro.cardinalApiKeySecretName" -}}
+{{- printf "%s-%s" (include "maestro.fullname" .) "cardinal-api-key" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Validate license configuration. Called from license-validation.yaml to fail early.
+*/}}
+{{- define "maestro.validateLicense" -}}
+{{- if .Values.license.create }}
+{{- if not .Values.license.data }}
+{{- fail "license.data is required when license.create is true. Provide the raw license.json content or set license.create=false and specify an existing secret via license.secretName." }}
+{{- end }}
+{{- else }}
+{{- if not .Values.license.secretName }}
+{{- fail "license.secretName is required when license.create is false. Provide the name of an existing Kubernetes secret containing the license." }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the secret name for the license. If create is true, prefix with release name.
+*/}}
+{{- define "maestro.licenseSecretName" -}}
+{{- if .Values.license.create }}
+{{- printf "%s-%s" (include "maestro.fullname" .) .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.license.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+License volume mount. Always emitted — license is required.
+Usage: {{ include "maestro.licenseVolumeMount" . }}
+*/}}
+{{- define "maestro.licenseVolumeMount" -}}
+- name: license
+  mountPath: /app/license
+  readOnly: true
+{{- end }}
+
+{{/*
+License volume. Always emitted — license is required.
+Usage: {{ include "maestro.licenseVolume" . }}
+*/}}
+{{- define "maestro.licenseVolume" -}}
+- name: license
+  secret:
+    secretName: {{ include "maestro.licenseSecretName" . }}
+{{- end }}
+
+{{/*
+OTLP env vars pointing at CardinalHQ's hosted intake. Emits nothing when
+global.cardinal.apiKey is empty, so existing installs without telemetry
+configuration are unaffected (and chart-test env-index assertions stay
+stable). Both maestro (tracing.ts) and mcp-gateway (telemetry.go) read
+OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS directly; no
+extra gating env var is needed (lakerunner's ENABLE_OTLP_TELEMETRY is
+lakerunner-specific and unused here).
+*/}}
+{{- define "maestro.cardinalTelemetryEnv" -}}
+{{- if .Values.global.cardinal.apiKey }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ if eq .Values.global.cardinal.env "test" }}"https://customer-intake-otelhttp.us-east-2.aws.test.cardinalhq.net"{{ else }}"https://otelhttp.intake.us-east-2.aws.cardinalhq.io"{{ end }}
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "maestro.cardinalApiKeySecretName" . }}
+      key: CARDINAL_API_HEADER
+{{- end }}
+{{- end }}
+
+{{/*
+  Merge two maps (global + local), emit nodeSelector: if non-empty.
+  args: [ globalMap, localMap ]
+*/}}
+{{- define "maestro.sched.nodeSelector" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default dict -}}
+  {{- $local  := index $args 1 | default dict -}}
+  {{- $m      := merge $local $global -}}
+  {{- if gt (len $m) 0 -}}
+nodeSelector:
+{{ toYaml $m | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Merge global and local tolerations, emit tolerations: if non-empty.
+  args: [ globalList, localList ]
+*/}}
+{{- define "maestro.sched.tolerations" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default list -}}
+  {{- $local  := index $args 1 | default list -}}
+  {{- $merged := concat $local $global -}}
+  {{- if gt (len $merged) 0 -}}
+tolerations:
+{{ toYaml $merged | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Merge two affinity blocks, emit affinity: if non-empty.
+  args: [ globalAffinity, localAffinity ]
+*/}}
+{{- define "maestro.sched.affinity" -}}
+  {{- $args   := . -}}
+  {{- $global := index $args 0 | default dict -}}
+  {{- $local  := index $args 1 | default dict -}}
+  {{- $m      := merge $local $global -}}
+  {{- if gt (len $m) 0 -}}
+affinity:
+{{ toYaml $m | indent 2 }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Pod-level securityContext for a workload.
+Shallow-merges global.podSecurityContext with an optional per-component override;
+component fields win over global. Uses explicit `set` instead of sprig's `merge`
+to avoid mergo's quirk where falsy zero values (false, 0, "") get overwritten.
+Emits nothing when the resulting map is empty.
+Usage:
+  {{- include "maestro.podSecurityContext" (dict "root" . "override" .Values.maestro.podSecurityContext) | nindent 6 }}
+*/}}
+{{- define "maestro.podSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.podSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Container-level securityContext for a container.
+Same shallow-merge semantics as maestro.podSecurityContext.
+*/}}
+{{- define "maestro.containerSecurityContext" -}}
+{{- $root := .root -}}
+{{- $override := .override | default dict -}}
+{{- $global := $root.Values.global.containerSecurityContext | default dict -}}
+{{- $merged := dict -}}
+{{- range $k, $v := $global -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- range $k, $v := $override -}}
+{{- $_ := set $merged $k $v -}}
+{{- end -}}
+{{- if $merged }}
+securityContext:
+  {{- toYaml $merged | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the public base URL of the Maestro UI.
+Precedence:
+  1. .Values.maestro.baseUrl (explicit)
+  2. derived from .Values.ingress.host with https when ingress.tls is
+     non-empty, otherwise http
+Returns empty string when neither is available.
+
+Both branches normalize the input host: any leading scheme
+(http://, https://) is stripped and any trailing slash is removed
+before composition, so common operator typos like
+`ingress.host: https://maestro.example.com/` produce a clean
+`https://maestro.example.com` instead of `http://https://...//`.
+*/}}
+{{- define "maestro.baseUrl" -}}
+{{- $explicit := default "" (dig "baseUrl" "" .Values.maestro) -}}
+{{- if $explicit -}}
+{{- $explicit | trimSuffix "/" -}}
+{{- else if .Values.ingress.host -}}
+{{- $scheme := "http" -}}
+{{- if .Values.ingress.tls -}}
+{{- $scheme = "https" -}}
+{{- end -}}
+{{- $host := .Values.ingress.host | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- printf "%s://%s" $scheme $host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Hostname-only view of maestro.baseUrl, with scheme and port stripped.
+Used by the TLS sidecar's cert-init container to put the right CN/SAN
+on its self-signed certificate.
+*/}}
+{{- define "maestro.baseUrlHost" -}}
+{{- $base := include "maestro.baseUrl" . -}}
+{{- $hostport := $base | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- regexReplaceAll ":[0-9]+$" $hostport "" -}}
+{{- end -}}
+
+{{/*
+Validate maestro.tls inputs:
+  * tls.enabled=true requires the resolved baseUrl to use https://, so the
+    OIDC issuer URL the SPA hands to the browser matches the scheme the
+    maestro Service actually serves.
+  * Exactly one of three cert sources must be configured:
+      - cert.autoGenerate=true (default, in-pod self-signed)
+      - secretName (existing kubernetes.io/tls Secret)
+      - cert.crt + cert.key (inline PEM, chart creates the Secret)
+*/}}
+{{- define "maestro.tlsValidate" -}}
+{{- $tls := dig "tls" dict (.Values.maestro | default dict) -}}
+{{- if dig "enabled" false $tls -}}
+  {{- $base := include "maestro.baseUrlOrFail" . -}}
+  {{- if not (hasPrefix "https://" $base) -}}
+    {{- fail (printf "maestro.tls.enabled=true requires maestro.baseUrl to use https:// (got %q). Either set maestro.baseUrl to an https URL or set ingress.tls so the chart derives one." $base) -}}
+  {{- end -}}
+  {{- $autogen := dig "cert" "autoGenerate" true $tls -}}
+  {{- $secret := dig "secretName" "" $tls -}}
+  {{- $crt := dig "cert" "crt" "" $tls -}}
+  {{- $key := dig "cert" "key" "" $tls -}}
+  {{- if or (and $crt (not $key)) (and $key (not $crt)) -}}
+    {{- fail "maestro.tls.cert: set both cert.crt and cert.key, or neither" -}}
+  {{- end -}}
+  {{- $inline := and $crt $key -}}
+  {{- $count := 0 -}}
+  {{- if $autogen -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if $secret -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if $inline -}}{{- $count = add $count 1 -}}{{- end -}}
+  {{- if gt $count 1 -}}
+    {{- fail "maestro.tls: set exactly one cert source — cert.autoGenerate=true, secretName, or cert.crt+cert.key (set cert.autoGenerate=false when using one of the BYO paths)" -}}
+  {{- end -}}
+  {{- if eq $count 0 -}}
+    {{- fail "maestro.tls.enabled=true requires one cert source: cert.autoGenerate=true (default), a non-empty secretName, or cert.crt+cert.key" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the Secret name the TLS sidecar mounts. Returns:
+  * .Values.maestro.tls.secretName when a user-provided Secret is referenced.
+  * "<fullname>-maestro-tls-cert" when inline cert.crt+cert.key are set
+    (the chart creates that Secret via templates/maestro-tls-secret.yaml).
+  * empty string when autoGenerate is in effect (the volume is an emptyDir
+    populated by the tls-init container).
+*/}}
+{{- define "maestro.tlsResolvedSecretName" -}}
+{{- $tls := dig "tls" dict (.Values.maestro | default dict) -}}
+{{- $secret := dig "secretName" "" $tls -}}
+{{- $crt := dig "cert" "crt" "" $tls -}}
+{{- $key := dig "cert" "key" "" $tls -}}
+{{- if $secret -}}
+{{- $secret -}}
+{{- else if and $crt $key -}}
+{{- printf "%s-maestro-tls-cert" (include "maestro.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Same as maestro.baseUrl but fails template rendering when the result is
+empty. Use everywhere a dex-related URL is composed so a missing base
+URL produces an explicit install-time error rather than a silent `/`
+or `/dex` value that breaks at runtime.
+*/}}
+{{- define "maestro.baseUrlOrFail" -}}
+{{- $base := include "maestro.baseUrl" . -}}
+{{- if not $base -}}
+{{- fail "dex.enabled=true requires either maestro.baseUrl to be set or ingress.host to be set so the Dex issuer URL can be derived" -}}
+{{- end -}}
+{{- $base -}}
+{{- end -}}
+
+{{/*
+Fully qualified name of the bundled Dex Deployment / Service.
+*/}}
+{{- define "maestro.dexFullname" -}}
+{{- printf "%s-dex" (include "maestro.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Defaulted view of .Values.dex. Returns a dict with the scalar/image
+fields shared across the dex templates, falling back to documented
+defaults when fields are absent. Per-template fields like staticUsers,
+podSecurityContext, containerSecurityContext, nodeSelector, tolerations,
+affinity, and resources are read directly from .Values.dex via inline
+`dig` in the consuming template.
+
+The point of routing through this helper is to make `--set dex.enabled=true`
+sufficient on its own (every default lives in one place) and to keep
+the values surface light enough that linters don't strip an empty
+`dex:` block on every chart change.
+*/}}
+{{- define "maestro.dexConfig" -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $img := dig "image" dict $d -}}
+enabled: {{ dig "enabled" false $d }}
+replicas: {{ dig "replicas" 1 $d }}
+port: {{ dig "port" 5556 $d }}
+pathPrefix: {{ dig "pathPrefix" "/dex" $d | quote }}
+clientId: {{ dig "clientId" "maestro-ui" $d | quote }}
+superadminGroup: {{ dig "superadminGroup" "maestro-superadmin" $d | quote }}
+image:
+  repository: {{ dig "repository" "ghcr.io/dexidp/dex" $img | quote }}
+  tag: {{ dig "tag" "v2.41.1" $img | quote }}
+  pullPolicy: {{ dig "pullPolicy" "IfNotPresent" $img | quote }}
+{{- end -}}
+
+{{/*
+Validate that dex.enabled=true is paired with the inputs Dex actually
+needs to be useful. Today:
+  - non-empty staticUsers (otherwise Dex starts with no login options)
+  - replicas <= 1 (storage.type=memory is per-pod; multiple replicas
+    diverge on signing keys and session state, so login flows break
+    on any pod that didn't issue the session cookie)
+
+Call this from each dex template (and from maestro.oidcEnv) before
+emitting any dex-dependent output.
+*/}}
+{{- define "maestro.dexValidate" -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $users := dig "staticUsers" list $d -}}
+{{- if not $users -}}
+{{- fail "dex.enabled=true requires dex.staticUsers to be a non-empty list (otherwise the bundled Dex starts with no login options)" -}}
+{{- end -}}
+{{- $replicas := dig "replicas" 1 $d -}}
+{{- if gt (int $replicas) 1 -}}
+{{- fail "dex.replicas > 1 is incompatible with the bundled Dex's in-memory storage; sessions and signing keys diverge across pods. Use a single replica or replace the bundled Dex with an external OIDC provider for HA." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Browser-visible Dex issuer URL (used as OIDC_ISSUER_URL on maestro and as
+the `issuer` field in Dex's own config). Path prefix included.
+Fails template rendering when no base URL is available.
+*/}}
+{{- define "maestro.dexIssuerUrl" -}}
+{{- $base := include "maestro.baseUrlOrFail" . -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- printf "%s%s" $base $cfg.pathPrefix -}}
+{{- end -}}
+
+{{/*
+SPA's redirect URI as Dex must whitelist it. Routed through
+baseUrlOrFail so a misconfigured install fails loudly rather than
+silently registering "/" as an allowed redirect — see auth-provider.tsx
+which uses `redirect_uri: window.location.origin + "/"`.
+*/}}
+{{- define "maestro.dexRedirectUri" -}}
+{{- printf "%s/" (include "maestro.baseUrlOrFail" .) -}}
+{{- end -}}
+
+{{/*
+In-cluster JWKS URL for maestro to verify tokens against, bypassing the
+ingress and any TLS termination. The `/keys` suffix is Dex's well-known
+JWKS endpoint per its discovery doc; if Dex ever moves it, switch to
+discovery-based resolution (fetch /.well-known/openid-configuration and
+read jwks_uri) instead of hardcoding here.
+*/}}
+{{- define "maestro.dexInternalJwksUrl" -}}
+{{- $svc := include "maestro.dexFullname" . -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- printf "http://%s.%s.svc:%v%s/keys" $svc .Release.Namespace $cfg.port $cfg.pathPrefix -}}
+{{- end -}}
+
+{{/*
+In-cluster Dex base URL with path prefix, used as DEX_PROXY_TARGET when
+the maestro container reverse-proxies the Dex flow on behalf of the SPA.
+This makes the install reachable through any path that reaches the
+maestro Service alone — for example a single
+`kubectl port-forward --address 0.0.0.0 svc/<release>-maestro 8080:4200`
+on a bastion host — even when the cluster has no Ingress controller
+doing /dex path-routing. Harmless when an Ingress is also routing /dex
+directly: the Ingress path-match wins and requests never reach the
+in-pod proxy.
+*/}}
+{{- define "maestro.dexInternalProxyTarget" -}}
+{{- $svc := include "maestro.dexFullname" . -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- printf "http://%s.%s.svc:%v%s" $svc .Release.Namespace $cfg.port $cfg.pathPrefix -}}
+{{- end -}}
+
+{{/*
+OIDC + base URL env vars to inject into the maestro container when the
+bundled Dex install is enabled. Emits nothing when dex.enabled is false.
+Built-ins are emitted before the user's `maestro.env` list; Kubernetes
+keeps the first occurrence on duplicate names, so the built-ins win
+(matching the chart's existing convention exercised in env_test.yaml,
+and locked in for OIDC_ISSUER_URL specifically by dex_test.yaml).
+*/}}
+{{- define "maestro.oidcEnv" -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+- name: OIDC_ISSUER_URL
+  value: {{ include "maestro.dexIssuerUrl" . | quote }}
+- name: OIDC_JWKS_URL
+  value: {{ include "maestro.dexInternalJwksUrl" . | quote }}
+- name: OIDC_AUDIENCE
+  value: {{ $cfg.clientId | quote }}
+- name: OIDC_CLIENT_ID
+  value: {{ $cfg.clientId | quote }}
+- name: OIDC_SUPERADMIN_GROUP
+  value: {{ $cfg.superadminGroup | quote }}
+- name: MAESTRO_BASE_URL
+  value: {{ include "maestro.baseUrlOrFail" . | quote }}
+{{- /* Optional in-pod reverse proxy for Dex — see dexInternalProxyTarget. */}}
+{{- if dig "proxyEnabled" true (.Values.dex | default dict) }}
+- name: DEX_PROXY_PATH
+  value: {{ $cfg.pathPrefix | quote }}
+- name: DEX_PROXY_TARGET
+  value: {{ include "maestro.dexInternalProxyTarget" . | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+

--- a/conductor/templates/_helpers-maestro.tpl
+++ b/conductor/templates/_helpers-maestro.tpl
@@ -410,10 +410,10 @@ Emits nothing when:
 Return the secret name for the Database credentials. If we have create true, we will prefix it with the release name.
 */}}
 {{- define "maestro.databaseSecretName" -}}
-{{- if .Values.database.create }}
-{{- printf "%s-%s" (include "maestro.fullname" .) .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- if .Values.maestroDatabase.create }}
+{{- printf "%s-%s" (include "maestro.fullname" .) .Values.maestroDatabase.secretName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- .Values.database.secretName | trunc 63 | trimSuffix "-" }}
+{{- .Values.maestroDatabase.secretName | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -422,20 +422,20 @@ Database environment variables shared across components.
 */}}
 {{- define "maestro.databaseEnv" -}}
 - name: MAESTRO_DB_HOST
-  value: {{ .Values.database.host | quote }}
+  value: {{ .Values.maestroDatabase.host | quote }}
 - name: MAESTRO_DB_PORT
-  value: {{ .Values.database.port | quote }}
+  value: {{ .Values.maestroDatabase.port | quote }}
 - name: MAESTRO_DB_USER
-  value: {{ .Values.database.username | quote }}
+  value: {{ .Values.maestroDatabase.username | quote }}
 - name: MAESTRO_DB_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "maestro.databaseSecretName" . }}
-      key: {{ .Values.database.passwordKey }}
+      key: {{ .Values.maestroDatabase.passwordKey }}
 - name: MAESTRO_DB_NAME
-  value: {{ .Values.database.name | quote }}
+  value: {{ .Values.maestroDatabase.name | quote }}
 - name: MAESTRO_DB_SSLMODE
-  value: {{ .Values.database.sslMode | quote }}
+  value: {{ .Values.maestroDatabase.sslMode | quote }}
 - name: MAESTRO_DATABASE_URL
   value: "postgresql://$(MAESTRO_DB_USER):$(MAESTRO_DB_PASSWORD)@$(MAESTRO_DB_HOST):$(MAESTRO_DB_PORT)/$(MAESTRO_DB_NAME)?sslmode=$(MAESTRO_DB_SSLMODE)"
 {{- end }}

--- a/conductor/templates/bootstrap/admin-key-secret.yaml
+++ b/conductor/templates/bootstrap/admin-key-secret.yaml
@@ -1,0 +1,22 @@
+{{- if and (include "conductor.bootstrapEnabled" .) (not .Values.bootstrap.adminKey.existingSecret) -}}
+{{- $name := include "conductor.adminKeySecretName" . -}}
+{{- $key := include "conductor.adminKeySecretKey" . -}}
+{{- /* Reuse the existing key across upgrades so it never churns; generate only if absent.
+       Pure `helm template` (no cluster) regenerates — GitOps users set bootstrap.adminKey.existingSecret. */ -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- $val := "" -}}
+{{- if and $existing $existing.data (index $existing.data $key) -}}
+{{- $val = index $existing.data $key -}}
+{{- else -}}
+{{- $val = printf "ak_%s" (randAlphaNum 48) | b64enc -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $key }}: {{ $val }}
+{{- end }}

--- a/conductor/templates/bootstrap/detect-job.yaml
+++ b/conductor/templates/bootstrap/detect-job.yaml
@@ -1,0 +1,81 @@
+{{- if include "conductor.detectionEnabled" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-bootstrap-detect
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    # weight 1: after the migrate hooks (weight 0) have brought both schemas up,
+    # before the post-install key-seed (weight 5). A non-zero exit here aborts
+    # the install before maestro can start and create a duplicate shared org.
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  # A classification failure (legacy/foreign or inconsistent DB) must ABORT the
+  # install, not retry — so no backoff.
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: detect
+        image: public.ecr.aws/docker/library/postgres:18-alpine
+        command: ["/bin/sh","-ec"]
+        args:
+          - |
+            set -eu
+            # q QUERY PASSWORD HOST PORT USER DB SSLMODE
+            q() { PGPASSWORD="$2" PGSSLMODE="$7" psql -tA -v ON_ERROR_STOP=1 -h "$3" -p "$4" -U "$5" -d "$6" -c "$1"; }
+            LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;"     "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+            LR_ORGS=$(q    "SELECT count(*) FROM organizations;"            "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+            M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;"    "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+            M_SHARED=$(q   "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+            M_LEGACY=$(q   "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+            echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
+            LR_PROV=0; { [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ]; } && LR_PROV=1
+            if [ "$M_SHARED" -gt 0 ]; then echo "ADOPT_CONDUCTOR: shared deployment present — idempotent, proceeding"; exit 0; fi
+            if [ "$LR_PROV" -eq 0 ] && [ "$M_ORGS" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
+            if [ "$M_LEGACY" -gt 0 ] || [ "$M_ORGS" -gt 0 ]; then
+              echo "ADOPT_LEGACY: existing non-conductor install detected. Re-run with bootstrap.mode=adopt to adopt it without provisioning."; exit 1; fi
+            echo "ERROR: inconsistent state (configdb provisioned but maestro empty, or vice versa). Investigate before proceeding."; exit 1
+        env:
+          # --- configdb (lakerunner) ---
+          - name: CONFIGDB_HOST
+            value: {{ .Values.configdb.lrdb.host | quote }}
+          - name: CONFIGDB_PORT
+            value: {{ .Values.configdb.lrdb.port | quote }}
+          - name: CONFIGDB_NAME
+            value: {{ .Values.configdb.lrdb.name | quote }}
+          - name: CONFIGDB_USER
+            value: {{ .Values.configdb.lrdb.username | quote }}
+          - name: CONFIGDB_SSLMODE
+            value: {{ .Values.configdb.lrdb.sslMode | default "require" | quote }}
+          - name: CONFIGDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "lakerunner.configdbSecretName" . | quote }}
+                key: {{ .Values.configdb.passwordKey | default "CONFIGDB_PASSWORD" | quote }}
+          # --- maestro DB ---
+          - name: MDB_HOST
+            value: {{ .Values.maestroDatabase.host | quote }}
+          - name: MDB_PORT
+            value: {{ .Values.maestroDatabase.port | quote }}
+          - name: MDB_NAME
+            value: {{ .Values.maestroDatabase.name | quote }}
+          - name: MDB_USER
+            value: {{ .Values.maestroDatabase.username | quote }}
+          - name: MDB_SSLMODE
+            value: {{ .Values.maestroDatabase.sslMode | default "require" | quote }}
+          - name: MDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "maestro.databaseSecretName" . }}
+                key: {{ .Values.maestroDatabase.passwordKey }}
+{{- end }}

--- a/conductor/templates/bootstrap/detect-job.yaml
+++ b/conductor/templates/bootstrap/detect-job.yaml
@@ -31,20 +31,21 @@ spec:
         args:
           - |
             set -eu
-            # q QUERY PASSWORD HOST PORT USER DB SSLMODE
             q() { PGPASSWORD="$2" PGSSLMODE="$7" psql -tA -v ON_ERROR_STOP=1 -h "$3" -p "$4" -U "$5" -d "$6" -c "$1"; }
-            LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;"     "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
-            LR_ORGS=$(q    "SELECT count(*) FROM organizations;"            "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
-            M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;"    "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+            LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;" "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+            LR_ORGS=$(q    "SELECT count(*) FROM organizations;"        "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+            LR_KEYS=$(q    "SELECT count(*) FROM admin_api_keys;"       "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+            M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
             M_SHARED=$(q   "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
             M_LEGACY=$(q   "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
-            echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
-            LR_PROV=0; { [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ]; } && LR_PROV=1
+            echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS lr_keys=$LR_KEYS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
+            LR_STATE=0; { [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ] || [ "$LR_KEYS" -gt 0 ]; } && LR_STATE=1
+            M_STATE=0;  { [ "$M_ORGS" -gt 0 ] || [ "$M_LEGACY" -gt 0 ]; } && M_STATE=1
             if [ "$M_SHARED" -gt 0 ]; then echo "ADOPT_CONDUCTOR: shared deployment present — idempotent, proceeding"; exit 0; fi
-            if [ "$LR_PROV" -eq 0 ] && [ "$M_ORGS" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
-            if [ "$M_LEGACY" -gt 0 ] || [ "$M_ORGS" -gt 0 ]; then
+            if [ "$LR_STATE" -eq 0 ] && [ "$M_STATE" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
+            if [ "$LR_STATE" -eq 1 ] && [ "$M_STATE" -eq 1 ]; then
               echo "ADOPT_LEGACY: existing non-conductor install detected. Re-run with bootstrap.mode=adopt to adopt it without provisioning."; exit 1; fi
-            echo "ERROR: inconsistent state (configdb provisioned but maestro empty, or vice versa). Investigate before proceeding."; exit 1
+            echo "ERROR: inconsistent state — only one of lakerunner/configdb or maestro is populated. Investigate; use bootstrap.mode=adopt or force to override."; exit 1
         env:
           # --- configdb (lakerunner) ---
           - name: CONFIGDB_HOST

--- a/conductor/templates/bootstrap/key-seed-job.yaml
+++ b/conductor/templates/bootstrap/key-seed-job.yaml
@@ -27,11 +27,14 @@ spec:
           - |
             HASH=$(printf %s "$ADMIN_KEY" | sha256sum | cut -d' ' -f1)
             echo "seeding admin key hash ${HASH%${HASH#????}}… into admin_api_keys"
+            # The hash is lowercase hex (sha256) — no SQL-injection surface — so we
+            # inline it directly into the -c command string. psql does NOT expand
+            # -v variables (:'hash') inside -c, only in -f/stdin scripts, so the
+            # earlier -v approach failed with a syntax error.
             PGPASSWORD="$CONFIGDB_PASSWORD" psql \
               --set=ON_ERROR_STOP=1 \
               -h "$CONFIGDB_HOST" -p "$CONFIGDB_PORT" -U "$CONFIGDB_USER" -d "$CONFIGDB_NAME" \
-              -v hash="$HASH" \
-              -c "INSERT INTO admin_api_keys (key_hash, name, description) VALUES (:'hash', 'conductor-bootstrap', 'seeded by conductor bootstrap') ON CONFLICT (key_hash) DO NOTHING;"
+              -c "INSERT INTO admin_api_keys (key_hash, name, description) VALUES ('$HASH', 'conductor-bootstrap', 'seeded by conductor bootstrap') ON CONFLICT (key_hash) DO NOTHING;"
             echo "done"
         env:
           - name: ADMIN_KEY

--- a/conductor/templates/bootstrap/key-seed-job.yaml
+++ b/conductor/templates/bootstrap/key-seed-job.yaml
@@ -47,6 +47,8 @@ spec:
             value: {{ .Values.configdb.lrdb.name | quote }}
           - name: CONFIGDB_USER
             value: {{ .Values.configdb.lrdb.username | quote }}
+          - name: PGSSLMODE
+            value: {{ .Values.configdb.lrdb.sslMode | default "require" | quote }}
           - name: CONFIGDB_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/conductor/templates/bootstrap/key-seed-job.yaml
+++ b/conductor/templates/bootstrap/key-seed-job.yaml
@@ -50,6 +50,6 @@ spec:
           - name: CONFIGDB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.configdb.secretName | quote }}
+                name: {{ include "lakerunner.configdbSecretName" . | quote }}
                 key: {{ .Values.configdb.passwordKey | default "CONFIGDB_PASSWORD" | quote }}
 {{- end }}

--- a/conductor/templates/bootstrap/key-seed-job.yaml
+++ b/conductor/templates/bootstrap/key-seed-job.yaml
@@ -1,0 +1,55 @@
+{{- if include "conductor.bootstrapEnabled" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-bootstrap-key-seed
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: key-seed
+        image: public.ecr.aws/docker/library/postgres:18-alpine
+        command: ["/bin/sh","-ec"]
+        args:
+          - |
+            HASH=$(printf %s "$ADMIN_KEY" | sha256sum | cut -d' ' -f1)
+            echo "seeding admin key hash ${HASH%${HASH#????}}… into admin_api_keys"
+            PGPASSWORD="$CONFIGDB_PASSWORD" psql \
+              --set=ON_ERROR_STOP=1 \
+              -h "$CONFIGDB_HOST" -p "$CONFIGDB_PORT" -U "$CONFIGDB_USER" -d "$CONFIGDB_NAME" \
+              -v hash="$HASH" \
+              -c "INSERT INTO admin_api_keys (key_hash, name, description) VALUES (:'hash', 'conductor-bootstrap', 'seeded by conductor bootstrap') ON CONFLICT (key_hash) DO NOTHING;"
+            echo "done"
+        env:
+          - name: ADMIN_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "conductor.adminKeySecretName" . }}
+                key: {{ include "conductor.adminKeySecretKey" . }}
+          - name: CONFIGDB_HOST
+            value: {{ .Values.configdb.lrdb.host | quote }}
+          - name: CONFIGDB_PORT
+            value: {{ .Values.configdb.lrdb.port | quote }}
+          - name: CONFIGDB_NAME
+            value: {{ .Values.configdb.lrdb.name | quote }}
+          - name: CONFIGDB_USER
+            value: {{ .Values.configdb.lrdb.username | quote }}
+          - name: CONFIGDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.configdb.secretName | quote }}
+                key: {{ .Values.configdb.passwordKey | default "CONFIGDB_PASSWORD" | quote }}
+{{- end }}

--- a/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
+++ b/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
@@ -46,10 +46,25 @@ spec:
           {{- toYaml .Values.setup.resources | nindent 10 }}
         {{- end }}
         volumeMounts:
+        {{- /* migrate runs initialize-if-needed which reads STORAGE_PROFILE_FILE
+               (set by injectEnvSetup); mount the (empty) storage-profiles
+               ConfigMap so that step succeeds instead of erroring on a missing
+               file. The ConfigMap is itself a pre-install hook (weight -10). */}}
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
         - name: scratch
           mountPath: /scratch
         {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
       volumes:
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
       {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
       {{- include "lakerunner.licenseVolume" . | nindent 6 }}
   backoffLimit: 3

--- a/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
+++ b/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
@@ -52,5 +52,5 @@ spec:
       volumes:
       {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
       {{- include "lakerunner.licenseVolume" . | nindent 6 }}
-  backoffLimit: 0
+  backoffLimit: 3
 {{- end }}

--- a/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
+++ b/conductor/templates/bootstrap/migrate-lakerunner-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "lakerunner.fullname" . }}-setup
+  name: {{ .Release.Name }}-migrate-lakerunner
   labels:
     {{- include "lakerunner.labelsWithComponent" (list . .Values.setup.labels) | nindent 4 }}
   annotations:
@@ -12,7 +12,8 @@ metadata:
     {{- if gt (len $merged) 0 }}
     {{- toYaml $merged | nindent 4 }}
     {{- end }}
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
@@ -21,7 +22,7 @@ spec:
         {{- include "lakerunner.labelsWithComponent" (list . .Values.setup.labels) | nindent 8 }}
       {{- include "lakerunner.annotationsWithComponent" (list . .Values.setup.annotations) | nindent 6 }}
     spec:
-      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
       restartPolicy: Never
       {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.setup.podSecurityContext) | nindent 6 }}
       {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
@@ -34,10 +35,10 @@ spec:
         image: {{ include "lakerunner.image" (list .Values.setup.image .) }}
         imagePullPolicy: {{ .Values.setup.image.pullPolicy | default .Values.global.image.pullPolicy }}
         command: ["/app/bin/lakerunner"]
-        args: ["setup"]
+        args: ["migrate", "--databases", "lrdb,configdb"]
         env:
           - name: OTEL_SERVICE_NAME
-            value: {{ include "lakerunner.fullname" . }}-setup
+            value: {{ .Release.Name }}-migrate-lakerunner
           {{- include "lakerunner.injectEnvSetup" (list . .Values.setup) | nindent 8 }}
           {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
         {{- if .Values.global.resources.enabled }}
@@ -47,31 +48,9 @@ spec:
         volumeMounts:
         - name: scratch
           mountPath: /scratch
-        {{- if eq .Values.storageProfiles.source "config" }}
-        - name: storage-profiles
-          mountPath: /app/config/storage_profiles.yaml
-          subPath: storage_profiles.yaml
-          readOnly: true
-        {{- end }}
-        {{- if eq .Values.apiKeys.source "config" }}
-        - name: apikeys
-          mountPath: /app/config/apikeys.yaml
-          subPath: apikeys.yaml
-          readOnly: true
-        {{- end }}
         {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
       volumes:
       {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
-      {{- if eq .Values.storageProfiles.source "config" }}
-      - name: storage-profiles
-        configMap:
-          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
-      {{- end }}
-      {{- if eq .Values.apiKeys.source "config" }}
-      - name: apikeys
-        secret:
-          secretName: {{ include "lakerunner.apiKeysSecretName" . }}
-      {{- end }}
       {{- include "lakerunner.licenseVolume" . | nindent 6 }}
   backoffLimit: 0
 {{- end }}

--- a/conductor/templates/bootstrap/migrate-maestro-job.yaml
+++ b/conductor/templates/bootstrap/migrate-maestro-job.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.maestro.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-migrate-maestro
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate-maestro
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate-maestro
+    spec:
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" (.Values.maestro.podSecurityContext | default dict)) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector .Values.maestro.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  .Values.maestro.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.maestro.affinity)     | nindent 6 }}
+      containers:
+      - name: migrate-maestro
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" (.Values.maestro.containerSecurityContext | default dict)) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/app/entrypoint.sh"]
+        args: ["mcp-gateway"]
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          - name: MCP_MIGRATE_ONLY
+            value: "true"
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.mcpGateway.resources | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/conductor/templates/bootstrap/migrate-maestro-job.yaml
+++ b/conductor/templates/bootstrap/migrate-maestro-job.yaml
@@ -40,4 +40,11 @@ spec:
         resources:
           {{- toYaml .Values.mcpGateway.resources | nindent 10 }}
         {{- end }}
+        {{- /* mcp-gateway validates the license at /app/license/license.json
+               before doing ANYTHING (including MCP_MIGRATE_ONLY), so the migrate
+               Job must mount it just like the maestro Deployment does. */}}
+        volumeMounts:
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+      volumes:
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
 {{- end }}

--- a/conductor/templates/bootstrap/migrate-maestro-job.yaml
+++ b/conductor/templates/bootstrap/migrate-maestro-job.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 0
+  backoffLimit: 3
   template:
     metadata:
       labels:

--- a/conductor/templates/lakerunner/admin-api-service.yaml
+++ b/conductor/templates/lakerunner/admin-api-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-admin-api
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+  {{- if .Values.adminApi.service.annotations }}
+  annotations:
+    {{- toYaml .Values.adminApi.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.adminApi.service.type }}
+  {{- if and (eq .Values.adminApi.service.type "LoadBalancer") .Values.adminApi.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.adminApi.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.adminApi.service.type "LoadBalancer") .Values.adminApi.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.adminApi.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.adminApi.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.adminApi.service.type "NodePort") .Values.adminApi.service.nodePort }}
+      nodePort: {{ .Values.adminApi.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "lakerunner.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane

--- a/conductor/templates/lakerunner/apikeys-secret.yaml
+++ b/conductor/templates/lakerunner/apikeys-secret.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.apiKeys.source "config" }}
+{{- if .Values.apiKeys.create -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lakerunner.apiKeysSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  apikeys.yaml: {{ .Values.apiKeys.yaml | toYaml | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/conductor/templates/lakerunner/aws-credentials-secret.yaml
+++ b/conductor/templates/lakerunner/aws-credentials-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and (eq .Values.cloudProvider.provider "aws") .Values.cloudProvider.aws.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.cloudProviderSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  {{- if and .Values.cloudProvider.aws.accessKeyId .Values.cloudProvider.aws.secretAccessKey }}
+  AWS_ACCESS_KEY_ID:     {{ .Values.cloudProvider.aws.accessKeyId | b64enc }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.cloudProvider.aws.secretAccessKey | b64enc }}
+  {{- end }}
+{{- end }}

--- a/conductor/templates/lakerunner/azure-credentials-secret.yaml
+++ b/conductor/templates/lakerunner/azure-credentials-secret.yaml
@@ -1,0 +1,41 @@
+{{- if and (eq .Values.cloudProvider.provider "azure") .Values.cloudProvider.azure.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.cloudProviderSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  {{- $authType := .Values.cloudProvider.azure.authType | default "service_principal" }}
+  # Always include the auth type so applications can determine how to authenticate
+  AZURE_AUTH_TYPE: {{ $authType | b64enc }}
+  
+  {{- if eq $authType "service_principal" }}
+  {{- if and .Values.cloudProvider.azure.clientId .Values.cloudProvider.azure.clientSecret .Values.cloudProvider.azure.tenantId }}
+  AZURE_CLIENT_ID:     {{ .Values.cloudProvider.azure.clientId | b64enc }}
+  AZURE_CLIENT_SECRET: {{ .Values.cloudProvider.azure.clientSecret | b64enc }}
+  AZURE_TENANT_ID:     {{ .Values.cloudProvider.azure.tenantId | b64enc }}
+  {{- end }}
+  
+  {{- else if eq $authType "user_managed_identity" }}
+  {{- if .Values.cloudProvider.azure.clientId }}
+  AZURE_CLIENT_ID:     {{ .Values.cloudProvider.azure.clientId | b64enc }}
+  {{- end }}
+  
+  {{- else if eq $authType "workload_identity" }}
+  {{- if and .Values.cloudProvider.azure.clientId .Values.cloudProvider.azure.tenantId }}
+  AZURE_CLIENT_ID:     {{ .Values.cloudProvider.azure.clientId | b64enc }}
+  AZURE_TENANT_ID:     {{ .Values.cloudProvider.azure.tenantId | b64enc }}
+  AZURE_FEDERATED_TOKEN_FILE: {{ .Values.cloudProvider.azure.federatedTokenFile | default "/var/run/secrets/azure/tokens/azure-identity-token" | b64enc }}
+  {{- end }}
+  
+  {{- else if eq $authType "connection_string" }}
+  {{- if .Values.cloudProvider.azure.connectionString }}
+  AZURE_STORAGE_CONNECTION_STRING: {{ .Values.cloudProvider.azure.connectionString | b64enc }}
+  {{- end }}
+  
+  {{- else if eq $authType "system_managed_identity" }}
+  # No credentials needed for system managed identity
+  {{- end }}
+{{- end }}

--- a/conductor/templates/lakerunner/cardinal-api-key-secret.yaml
+++ b/conductor/templates/lakerunner/cardinal-api-key-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.cardinal.apiKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-cardinal-api-key
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # API key for operator
+  cardinalhq-api-key: {{ .Values.global.cardinal.apiKey | b64enc }}
+  # pre-formatted OTLP header string
+  CARDINAL_API_HEADER: {{ printf "x-cardinalhq-api-key=%s" .Values.global.cardinal.apiKey | b64enc }}
+{{- end }}

--- a/conductor/templates/lakerunner/configdb-secret.yaml
+++ b/conductor/templates/lakerunner/configdb-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.configdb.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.configdbSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  CONFIGDB_PASSWORD: {{ .Values.configdb.lrdb.password | b64enc }}
+{{- end }}

--- a/conductor/templates/lakerunner/configdb-secret.yaml
+++ b/conductor/templates/lakerunner/configdb-secret.yaml
@@ -5,7 +5,13 @@ metadata:
   name: {{ include "lakerunner.configdbSecretName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
-  {{ include "lakerunner.annotations" . | nindent 2 }}
+  annotations:
+    {{- /* pre-install/pre-upgrade hook (weight -10) so the bootstrap migrate +
+           key-seed Jobs can mount it. See postgresql-secret.yaml. */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- include "lakerunner.annotationPairs" . | nindent 4 }}
 data:
   CONFIGDB_PASSWORD: {{ .Values.configdb.lrdb.password | b64enc }}
 {{- end }}

--- a/conductor/templates/lakerunner/control-plane-deployment.yaml
+++ b/conductor/templates/lakerunner/control-plane-deployment.yaml
@@ -1,0 +1,294 @@
+{{/*
+Control-plane Deployment: colocates the four single-replica services
+(admin-api, alert-evaluator, monitoring, sweeper) into one pod. They share the
+same lakerunner image and are natural singletons, so running them as separate
+Deployments wasted a pod (and reserved capacity) per service.
+
+Each container binds a distinct HEALTH_CHECK_PORT (the binary reads this env;
+default 8090) because pod containers share one network namespace and would
+otherwise collide on the health port. Ports are derived from
+global.healthProbes.healthcheckPort + an offset, with matching named ports so
+each container's probes target its own listener.
+*/}}
+{{- $hcBase := .Values.global.healthProbes.healthcheckPort | int -}}
+{{- $hcAdmin := $hcBase -}}
+{{- $hcAlert := add $hcBase 1 -}}
+{{- $hcMon := add $hcBase 2 -}}
+{{- $hcSweep := add $hcBase 3 -}}
+{{/*
+pprof (gated by ENABLE_PPROF in the binary, which may come from the chart flag
+controlPlane.pprof.enabled or from global.env). Each container gets a distinct
+PPROF_PORT = basePort + offset so the four don't collide on the shared pod
+network namespace. PPROF_PORT is always emitted; the binary only honors it when
+pprof is enabled.
+*/}}
+{{- $pprofBase := .Values.controlPlane.pprof.basePort | int -}}
+{{- $pprofAdmin := $pprofBase -}}
+{{- $pprofAlert := add $pprofBase 1 -}}
+{{- $pprofMon := add $pprofBase 2 -}}
+{{- $pprofSweep := add $pprofBase 3 -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-control-plane
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+  {{ include "lakerunner.annotations" . | nindent 2}}
+spec:
+  replicas: {{ .Values.controlPlane.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: control-plane
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: control-plane
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.controlPlane.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.controlPlane.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.controlPlane.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.controlPlane.affinity)     | nindent 6 }}
+      containers:
+      # ---------------------------------------------------------------- admin-api
+      - name: admin-api
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.controlPlane.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.controlPlane.image .) }}
+        imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args:
+          - "admin-api"
+          - "serve"
+          - "--port={{ .Values.adminApi.port }}"
+        ports:
+          - name: http
+            containerPort: {{ .Values.adminApi.port }}
+            protocol: TCP
+          - name: hc-admin
+            containerPort: {{ $hcAdmin }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-admin-api
+          - name: TMPDIR
+            value: /scratch
+          - name: HEALTH_CHECK_PORT
+            value: {{ $hcAdmin | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofAdmin | quote }}
+          {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.adminApi.env | default list) "resources" .Values.controlPlane.resources.adminApi)) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-admin") | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.controlPlane.resources.adminApi | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch-admin
+          mountPath: /scratch
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      # ---------------------------------------------------------- alert-evaluator
+      - name: alert-evaluator
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.controlPlane.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.controlPlane.image .) }}
+        imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["alert-evaluator"]
+        ports:
+          - name: hc-alert
+            containerPort: {{ $hcAlert }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-alert-evaluator
+          - name: TMPDIR
+            value: /scratch
+          - name: HEALTH_CHECK_PORT
+            value: {{ $hcAlert | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofAlert | quote }}
+          - name: ALERT_EVALUATOR_QUERY_API_URL
+            value: {{ .Values.alertEvaluator.queryApiUrl | default (printf "http://%s-query-api:%v" (include "lakerunner.fullname" .) .Values.queryApi.service.port) | quote }}
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.alertEvaluator.env | default list) "resources" .Values.controlPlane.resources.alertEvaluator)) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-alert") | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.controlPlane.resources.alertEvaluator | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch-alert
+          mountPath: /scratch
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      # --------------------------------------------------------------- monitoring
+      - name: monitoring
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.controlPlane.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.controlPlane.image .) }}
+        imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args:
+          - "monitoring"
+          - "serve"
+        ports:
+          - name: hc-mon
+            containerPort: {{ $hcMon }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-monitoring
+          - name: TMPDIR
+            value: /scratch
+          - name: HEALTH_CHECK_PORT
+            value: {{ $hcMon | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofMon | quote }}
+          {{- include "lakerunner.autoscalerEnv" . | nindent 10 }}
+          {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.monitoring.env | default list) "resources" .Values.controlPlane.resources.monitoring)) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-mon") | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.controlPlane.resources.monitoring | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch-mon
+          mountPath: /scratch
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      # ------------------------------------------------------------------ sweeper
+      - name: sweeper
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.controlPlane.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.controlPlane.image .) }}
+        imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["sweeper"]
+        ports:
+          - name: hc-sweep
+            containerPort: {{ $hcSweep }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-sweeper
+          - name: TMPDIR
+            value: /scratch
+          - name: HEALTH_CHECK_PORT
+            value: {{ $hcSweep | quote }}
+          {{- if .Values.controlPlane.pprof.enabled }}
+          - name: ENABLE_PPROF
+            value: "true"
+          {{- end }}
+          - name: PPROF_PORT
+            value: {{ $pprofSweep | quote }}
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.sweeper.env | default list) "resources" .Values.controlPlane.resources.sweeper)) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-sweep") | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.controlPlane.resources.sweeper | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch-sweep
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch-admin" .) | nindent 6 }}
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch-alert" .) | nindent 6 }}
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch-mon" .) | nindent 6 }}
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch-sweep" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}

--- a/conductor/templates/lakerunner/deprecation-warnings.yaml
+++ b/conductor/templates/lakerunner/deprecation-warnings.yaml
@@ -1,0 +1,143 @@
+{{/*
+Deprecation warnings for removed or changed features.
+This template doesn't produce any resources, it only validates configuration.
+*/}}
+
+{{- if .Values.cloudProvider.duckdb }}
+{{- fail `
+================================================================================
+DEPRECATION WARNING: cloudProvider.duckdb has been removed
+
+The cloudProvider.duckdb configuration section has been removed because the
+injected S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY environment variables were
+not actually used by the application.
+
+LakeRunner uses the standard AWS SDK credential chain for S3 access:
+  - IAM roles (recommended for Kubernetes)
+  - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment variables
+  - ~/.aws/credentials file
+
+To fix this error:
+  1. Remove the cloudProvider.duckdb section from your values.yaml
+  2. If you need explicit S3 credentials, use cloudProvider.aws instead:
+
+     cloudProvider:
+       provider: aws
+       aws:
+         inject: true
+         create: true
+         accessKeyId: "your-access-key"
+         secretAccessKey: "your-secret-key"
+
+================================================================================
+` }}
+{{- end }}
+
+{{- if .Values.notificationSender }}
+{{- fail `
+================================================================================
+DEPRECATION WARNING: notificationSender has been removed
+
+The notificationSender component has been removed. Webhook delivery and incident
+garbage collection are now built into the alert-evaluator process.
+
+To fix this error:
+  1. Remove the notificationSender section from your values.yaml
+  2. Ensure alertEvaluator.enabled is true (it handles everything now)
+
+================================================================================
+` }}
+{{- end }}
+
+{{- $cp := list -}}
+{{- range $svc := list "adminApi" "alertEvaluator" "monitoring" "sweeper" -}}
+  {{- $block := index $.Values $svc -}}
+  {{- if $block -}}
+    {{- range $key := list "enabled" "replicas" "image" "resources" "nodeSelector" "tolerations" "affinity" "podSecurityContext" "containerSecurityContext" -}}
+      {{- if hasKey $block $key -}}
+        {{- $cp = append $cp (printf "%s.%s" $svc $key) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $cp }}
+{{- fail (printf `
+================================================================================
+DEPRECATION WARNING: per-service pod settings have moved to controlPlane
+
+admin-api, alert-evaluator, monitoring, and sweeper are now colocated in a
+single pod (Deployment <release>-control-plane). Pod-level settings are no
+longer read from the individual service blocks.
+
+Offending keys found in your values:
+  %s
+
+To fix this error:
+  1. Remove those keys from the adminApi / alertEvaluator / monitoring / sweeper
+     blocks.
+  2. Set pod-level settings under the new controlPlane block instead:
+
+     controlPlane:
+       replicas: 1
+       image:
+         repository: ghcr.io/cardinalhq/lakerunner
+         tag: ""
+       nodeSelector: {}
+       tolerations: []
+       affinity: {}
+       resources:
+         adminApi:       { requests: { cpu: 25m, memory: 64Mi }, limits: { memory: 256Mi } }
+         alertEvaluator: { requests: { cpu: 25m, memory: 64Mi }, limits: { memory: 256Mi } }
+         monitoring:     { requests: { cpu: 25m, memory: 64Mi }, limits: { memory: 256Mi } }
+         sweeper:        { requests: { cpu: 50m, memory: 64Mi }, limits: { memory: 256Mi } }
+
+  Service-specific keys are still read from their own blocks:
+    adminApi.port, adminApi.service, alertEvaluator.queryApiUrl,
+    alertEvaluator.env, monitoring.autoscaler
+
+================================================================================
+` (join ", " $cp)) }}
+{{- end }}
+
+{{- if or .Values.cloudProvider.gcp.accessKeyId .Values.cloudProvider.gcp.secretAccessKey }}
+{{- fail `
+================================================================================
+DEPRECATION WARNING: cloudProvider.gcp HMAC credentials have been removed
+
+The cloudProvider.gcp.accessKeyId and cloudProvider.gcp.secretAccessKey fields
+have been removed. GCP no longer requires AWS-style HMAC credentials.
+
+LakeRunner uses native GCP authentication for GCS access:
+  - Workload Identity (recommended for GKE)
+  - Service Account JSON credentials
+
+To fix this error:
+  1. Remove accessKeyId and secretAccessKey from cloudProvider.gcp
+  2. Use one of these authentication methods:
+
+     # Option 1: Workload Identity (recommended)
+     cloudProvider:
+       provider: gcp
+       gcp:
+         inject: false
+         create: false
+
+     # Option 2: Service Account JSON
+     cloudProvider:
+       provider: gcp
+       gcp:
+         inject: true
+         create: true
+         serviceAccountJson: '{"type":"service_account",...}'
+
+     # Option 3: Existing secret with GOOGLE_APPLICATION_CREDENTIALS
+     cloudProvider:
+       provider: gcp
+       gcp:
+         inject: true
+         create: false
+         secretName: "my-gcp-credentials"
+
+================================================================================
+` }}
+{{- end }}

--- a/conductor/templates/lakerunner/gcp-credentials-secret.yaml
+++ b/conductor/templates/lakerunner/gcp-credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq .Values.cloudProvider.provider "gcp") .Values.cloudProvider.gcp.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.cloudProviderSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  {{- if .Values.cloudProvider.gcp.serviceAccountJson }}
+  GOOGLE_APPLICATION_CREDENTIALS: {{ .Values.cloudProvider.gcp.serviceAccountJson | b64enc }}
+  {{- end }}
+{{- end }}

--- a/conductor/templates/lakerunner/license-secret.yaml
+++ b/conductor/templates/lakerunner/license-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.license.create .Values.license.data -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lakerunner.licenseSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  license.json: {{ .Values.license.data | b64enc | quote }}
+{{- end }}

--- a/conductor/templates/lakerunner/license-validation.yaml
+++ b/conductor/templates/lakerunner/license-validation.yaml
@@ -1,0 +1,5 @@
+{{/*
+License validation — ensures a valid license configuration is provided.
+This template always renders (as a comment) but fails early if the license is misconfigured.
+*/}}
+{{- include "lakerunner.validateLicense" . -}}

--- a/conductor/templates/lakerunner/postgresql-secret.yaml
+++ b/conductor/templates/lakerunner/postgresql-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.database.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lakerunner.databaseSecretName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  LRDB_PASSWORD: {{ .Values.database.lrdb.password | b64enc }}
+{{- end }}

--- a/conductor/templates/lakerunner/postgresql-secret.yaml
+++ b/conductor/templates/lakerunner/postgresql-secret.yaml
@@ -5,7 +5,16 @@ metadata:
   name: {{ include "lakerunner.databaseSecretName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
-  {{ include "lakerunner.annotations" . | nindent 2 }}
+  annotations:
+    {{- /* Created as a pre-install/pre-upgrade hook (weight -10) so the
+           bootstrap migrate Job (weight 0, a pre-install hook) can mount it.
+           Plain resources are created AFTER pre-install hooks, so without this
+           the migrate Job fails with "secret not found". before-hook-creation
+           (NOT hook-succeeded) keeps it for the main release. */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- include "lakerunner.annotationPairs" . | nindent 4 }}
 data:
   LRDB_PASSWORD: {{ .Values.database.lrdb.password | b64enc }}
 {{- end }}

--- a/conductor/templates/lakerunner/process-logs-deployment.yaml
+++ b/conductor/templates/lakerunner/process-logs-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.processLogs.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-process-logs
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list . .Values.processLogs.labels) | nindent 4 }}
+    app.kubernetes.io/component: process-logs
+  {{ include "lakerunner.annotationsWithComponent" (list . .Values.processLogs.annotations) | nindent 2 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: process-logs
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labelsWithComponent" (list . .Values.processLogs.labels) | nindent 8 }}
+        app.kubernetes.io/component: process-logs
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotationsWithComponent" (list . .Values.processLogs.annotations) | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processLogs.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: process-logs
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processLogs.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.processLogs.image .) }}
+        imagePullPolicy: {{ .Values.processLogs.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["process-logs"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-process-logs
+          - name: TMPDIR
+            value: /scratch
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnvDuckdb" (list . .Values.processLogs) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.processLogs) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.processLogs.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        - name: scratch
+          mountPath: /scratch
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.processLogs.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.processLogs.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.processLogs.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolume" (list "scratch" .Values.processLogs.temporaryStorage.size .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/process-metrics-deployment.yaml
+++ b/conductor/templates/lakerunner/process-metrics-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.processMetrics.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-process-metrics
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list . .Values.processMetrics.labels) | nindent 4 }}
+    app.kubernetes.io/component: process-metrics
+  {{ include "lakerunner.annotationsWithComponent" (list . .Values.processMetrics.annotations) | nindent 2 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: process-metrics
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labelsWithComponent" (list . .Values.processMetrics.labels) | nindent 8 }}
+        app.kubernetes.io/component: process-metrics
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotationsWithComponent" (list . .Values.processMetrics.annotations) | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processMetrics.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: process-metrics
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processMetrics.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.processMetrics.image .) }}
+        imagePullPolicy: {{ .Values.processMetrics.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["process-metrics"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-process-metrics
+          - name: TMPDIR
+            value: /scratch
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnvDuckdb" (list . .Values.processMetrics) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.processMetrics) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.processMetrics.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        - name: scratch
+          mountPath: /scratch
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.processMetrics.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.processMetrics.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.processMetrics.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolume" (list "scratch" .Values.processMetrics.temporaryStorage.size .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/process-traces-deployment.yaml
+++ b/conductor/templates/lakerunner/process-traces-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.processTraces.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-process-traces
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list . .Values.processTraces.labels) | nindent 4 }}
+    app.kubernetes.io/component: process-traces
+  {{ include "lakerunner.annotationsWithComponent" (list . .Values.processTraces.annotations) | nindent 2 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: process-traces
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labelsWithComponent" (list . .Values.processTraces.labels) | nindent 8 }}
+        app.kubernetes.io/component: process-traces
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotationsWithComponent" (list . .Values.processTraces.annotations) | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.processTraces.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: process-traces
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.processTraces.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.processTraces.image .) }}
+        imagePullPolicy: {{ .Values.processTraces.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["process-traces"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-process-traces
+          - name: TMPDIR
+            value: /scratch
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnvDuckdb" (list . .Values.processTraces) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.processTraces) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.processTraces.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        - name: scratch
+          mountPath: /scratch
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.processTraces.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.processTraces.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.processTraces.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolume" (list "scratch" .Values.processTraces.temporaryStorage.size .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/pubsub-azure-deployment.yaml
+++ b/conductor/templates/lakerunner/pubsub-azure-deployment.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.pubsub.Azure.enabled -}}
+{{- if not .Values.pubsub.Azure.storageAccount -}}
+{{- fail "pubsub.Azure.storageAccount is required when pubsub.Azure.enabled is true" -}}
+{{- end -}}
+{{- if not .Values.pubsub.Azure.queueName -}}
+{{- fail "pubsub.Azure.queueName is required when pubsub.Azure.enabled is true" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-pubsub-azure
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-azure
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.pubsub.Azure.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pubsub-azure
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: pubsub-azure
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.Azure.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: pubsub
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.Azure.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.pubsub.Azure.image .) }}
+        imagePullPolicy: {{ .Values.pubsub.Azure.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["pubsub", "azure"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-pubsub-azure
+          - name: AZURE_STORAGE_ACCOUNT
+            value: {{ .Values.pubsub.Azure.storageAccount | quote }}
+          - name: AZURE_QUEUE_NAME
+            value: {{ .Values.pubsub.Azure.queueName | quote }}
+          {{- include "lakerunner.injectEnv" (list . .Values.pubsub.Azure) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.pubsub.Azure) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.pubsub.Azure.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.pubsub.Azure.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.pubsub.Azure.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.pubsub.Azure.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/pubsub-gcp-deployment.yaml
+++ b/conductor/templates/lakerunner/pubsub-gcp-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.pubsub.GCP.enabled -}}
+{{- if not .Values.pubsub.GCP.projectID -}}
+{{- fail "pubsub.GCP.projectID is required when pubsub.GCP.enabled is true" -}}
+{{- end -}}
+{{- if not .Values.pubsub.GCP.subscriptionID -}}
+{{- fail "pubsub.GCP.subscriptionID is required when pubsub.GCP.enabled is true" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-pubsub-gcp
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-gcp
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.pubsub.GCP.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pubsub-gcp
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: pubsub-gcp
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.GCP.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: pubsub
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.GCP.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.pubsub.GCP.image .) }}
+        imagePullPolicy: {{ .Values.pubsub.GCP.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["pubsub", "gcp"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-pubsub-gcp
+          - name: GCP_PROJECT_ID
+            value: {{ .Values.pubsub.GCP.projectID | quote }}
+          - name: GCP_SUBSCRIPTION_ID
+            value: {{ .Values.pubsub.GCP.subscriptionID | quote }}
+          {{- include "lakerunner.injectEnv" (list . .Values.pubsub.GCP) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.pubsub.GCP) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.pubsub.GCP.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.pubsub.GCP.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.pubsub.GCP.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.pubsub.GCP.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/pubsub-http-deployment.yaml
+++ b/conductor/templates/lakerunner/pubsub-http-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.pubsub.HTTP.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-pubsub-http
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-http
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.pubsub.HTTP.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pubsub-http
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: pubsub-http
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.HTTP.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: pubsub
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.HTTP.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.pubsub.HTTP.image .) }}
+        imagePullPolicy: {{ .Values.pubsub.HTTP.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["pubsub", "http"]
+        ports:
+        - containerPort: 8080
+          name: http
+        - name: healthcheck
+          containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+          protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-pubsub-http
+          {{- include "lakerunner.injectEnv" (list . .Values.pubsub.HTTP) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- include "lakerunner.healthProbes" (list . .Values.pubsub.HTTP) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.pubsub.HTTP.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.pubsub.HTTP.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.pubsub.HTTP.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.pubsub.HTTP.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/pubsub-http-service.yaml
+++ b/conductor/templates/lakerunner/pubsub-http-service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.pubsub.HTTP.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-pubsub-http
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-http
+  {{- if .Values.pubsub.HTTP.service.annotations }}
+  annotations:
+    {{- toYaml .Values.pubsub.HTTP.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.pubsub.HTTP.service.type }}
+  {{- if and (eq .Values.pubsub.HTTP.service.type "LoadBalancer") .Values.pubsub.HTTP.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.pubsub.HTTP.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.pubsub.HTTP.service.type "LoadBalancer") .Values.pubsub.HTTP.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.pubsub.HTTP.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.pubsub.HTTP.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.pubsub.HTTP.service.type "NodePort") .Values.pubsub.HTTP.service.nodePort }}
+      nodePort: {{ .Values.pubsub.HTTP.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "lakerunner.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-http
+{{- end }}

--- a/conductor/templates/lakerunner/pubsub-sqs-deployment.yaml
+++ b/conductor/templates/lakerunner/pubsub-sqs-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.pubsub.SQS.enabled -}}
+{{- if not .Values.pubsub.SQS.queueURL -}}
+{{- fail "pubsub.SQS.queueURL is required when pubsub.SQS.enabled is true" -}}
+{{- end -}}
+{{- $sqsRegion := .Values.pubsub.SQS.region | default (include "lakerunner.awsRegion" .) -}}
+{{- if or (not $sqsRegion) (eq $sqsRegion "") (eq $sqsRegion "CHANGEME") (eq $sqsRegion "us-test-1") -}}
+{{- fail "pubsub.SQS.region (or aws.region as fallback) must be set to a valid AWS region when pubsub.SQS.enabled is true" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-pubsub-sqs
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pubsub-sqs
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.pubsub.SQS.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pubsub-sqs
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: pubsub-sqs
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.pubsub.SQS.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: pubsub
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.pubsub.SQS.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.pubsub.SQS.image .) }}
+        imagePullPolicy: {{ .Values.pubsub.SQS.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["pubsub", "sqs"]
+        ports:
+          - name: healthcheck
+            containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+            protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-pubsub-sqs
+          - name: SQS_QUEUE_URL
+            value: {{ .Values.pubsub.SQS.queueURL | quote }}
+          - name: SQS_REGION
+            value: {{ .Values.pubsub.SQS.region | default (include "lakerunner.awsRegion" .) | quote }}
+          - name: SQS_ROLE_ARN
+            value: {{ .Values.pubsub.SQS.roleARN | quote }}
+          {{- include "lakerunner.injectEnv" (list . .Values.pubsub.SQS) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.pubsub.SQS) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.pubsub.SQS.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.pubsub.SQS.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.pubsub.SQS.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.pubsub.SQS.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/query-api-deployment.yaml
+++ b/conductor/templates/lakerunner/query-api-deployment.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.queryApi.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-query-api
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-api
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.queryApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query-api
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: query-api
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.queryApi.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: query-api
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.queryApi.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.queryApi.image .) }}
+        imagePullPolicy: {{ .Values.queryApi.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["query-api"]
+        ports:
+        - containerPort: 8080
+          name: http
+        - name: healthcheck
+          containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+          protocol: TCP
+        env:
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-query-api
+          - name: EXECUTION_ENVIRONMENT
+            value: "kubernetes"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: QUERY_WORKER_PORT
+            value: "8081"
+          - name: WORKER_POD_LABEL_SELECTOR
+            value: "app.kubernetes.io/name={{ include "lakerunner.name" . }},app.kubernetes.io/component=query-worker"
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnv" (list . .Values.queryApi) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+        envFrom:
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.queryApi) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.queryApi.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.queryApi.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.queryApi.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.queryApi.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/query-api-service.yaml
+++ b/conductor/templates/lakerunner/query-api-service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.queryApi.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-query-api
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-api
+    lakerunner.cardinalhq.io/component: query-api
+  {{- if .Values.queryApi.service.annotations }}
+  annotations:
+    {{- toYaml .Values.queryApi.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.queryApi.service.type }}
+  {{- if and (eq .Values.queryApi.service.type "LoadBalancer") .Values.queryApi.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.queryApi.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.queryApi.service.type "LoadBalancer") .Values.queryApi.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.queryApi.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.queryApi.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.queryApi.service.type "NodePort") .Values.queryApi.service.nodePort }}
+      nodePort: {{ .Values.queryApi.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "lakerunner.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: query-api
+{{- end }}

--- a/conductor/templates/lakerunner/query-worker-deployment.yaml
+++ b/conductor/templates/lakerunner/query-worker-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.queryWorker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-query-worker
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-worker
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ .Values.queryWorker.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lakerunner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: query-worker
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labels" . | nindent 8 }}
+        app.kubernetes.io/component: query-worker
+        {{- if eq .Values.cloudProvider.azure.authType "workload_identity" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- include "lakerunner.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.queryWorker.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: query-worker
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.queryWorker.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.queryWorker.image .) }}
+        imagePullPolicy: {{ .Values.queryWorker.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["query-worker"]
+        ports:
+        - containerPort: 8081
+          name: http
+        - name: healthcheck
+          containerPort: {{ .Values.global.healthProbes.healthcheckPort }}
+          protocol: TCP
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-query-worker
+          - name: TMPDIR
+            value: /scratch
+          {{- if eq .Values.cloudProvider.provider "azure" }}
+          - name: AZURE_AUTH_TYPE
+            value: {{ .Values.cloudProvider.azure.authType | quote }}
+          {{- end }}
+          {{- include "lakerunner.injectEnvQueryWorker" (list . .Values.queryWorker) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        envFrom:
+        {{- if eq (include "lakerunner.injectCloudProviderCredentials" .) "true" }}
+          - secretRef:
+              name: {{ include "lakerunner.cloudProviderSecretName" . }}
+        {{- end }}
+        {{- include "lakerunner.healthProbes" (list . .Values.queryWorker) | nindent 8 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.queryWorker.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        - name: scratch
+          mountPath: /scratch
+        {{- include "lakerunner.azureTokenVolumeMount" . | nindent 8 }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.queryWorker.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.queryWorker.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.queryWorker.affinity)     | nindent 6 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolume" (list "scratch" .Values.queryWorker.temporaryStorage.size .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- include "lakerunner.azureTokenVolume" . | nindent 6 }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/lakerunner/query-worker-service.yaml
+++ b/conductor/templates/lakerunner/query-worker-service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.queryWorker.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-query-worker
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query-worker
+    lakerunner.cardinalhq.io/component: query-worker
+  {{- if .Values.queryWorker.service.annotations }}
+  annotations:
+    {{- toYaml .Values.queryWorker.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.queryWorker.service.type }}
+  {{- if and (eq .Values.queryWorker.service.type "LoadBalancer") .Values.queryWorker.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.queryWorker.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.queryWorker.service.type "LoadBalancer") .Values.queryWorker.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.queryWorker.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.queryWorker.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.queryWorker.service.type "NodePort") .Values.queryWorker.service.nodePort }}
+      nodePort: {{ .Values.queryWorker.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "lakerunner.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: query-worker
+{{- end }}

--- a/conductor/templates/lakerunner/setup-job.yaml
+++ b/conductor/templates/lakerunner/setup-job.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.setup (hasKey .Values.setup "enabled" | ternary .Values.setup.enabled true) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lakerunner.fullname" . }}-setup
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list . .Values.setup.labels) | nindent 4 }}
+  annotations:
+    {{- $global := .Values.global.annotations | default dict -}}
+    {{- $component := .Values.setup.annotations | default dict -}}
+    {{- $merged := merge $component $global -}}
+    {{- if gt (len $merged) 0 }}
+    {{- toYaml $merged | nindent 4 }}
+    {{- end }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.labelsWithComponent" (list . .Values.setup.labels) | nindent 8 }}
+      {{- include "lakerunner.annotationsWithComponent" (list . .Values.setup.annotations) | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "lakerunner.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- include "lakerunner.podSecurityContext" (dict "root" . "override" .Values.setup.podSecurityContext) | nindent 6 }}
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      {{- include "lakerunner.sched.nodeSelector" (list .Values.global.nodeSelector .Values.setup.nodeSelector) | nindent 6 }}
+      {{- include "lakerunner.sched.tolerations"  (list .Values.global.tolerations  .Values.setup.tolerations)  | nindent 6 }}
+      {{- include "lakerunner.sched.affinity"     (list .Values.global.affinity     .Values.setup.affinity)     | nindent 6 }}
+      containers:
+      - name: run-migrations
+        {{- include "lakerunner.containerSecurityContext" (dict "root" . "override" .Values.setup.containerSecurityContext) | nindent 8 }}
+        image: {{ include "lakerunner.image" (list .Values.setup.image .) }}
+        imagePullPolicy: {{ .Values.setup.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: ["/app/bin/lakerunner"]
+        args: ["setup"]
+        env:
+          - name: OTEL_SERVICE_NAME
+            value: {{ include "lakerunner.fullname" . }}-setup
+          {{- include "lakerunner.injectEnvSetup" (list . .Values.setup) | nindent 8 }}
+          {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.setup.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+        {{- if eq .Values.storageProfiles.source "config" }}
+        - name: storage-profiles
+          mountPath: /app/config/storage_profiles.yaml
+          subPath: storage_profiles.yaml
+          readOnly: true
+        {{- end }}
+        {{- if eq .Values.apiKeys.source "config" }}
+        - name: apikeys
+          mountPath: /app/config/apikeys.yaml
+          subPath: apikeys.yaml
+          readOnly: true
+        {{- end }}
+        {{- include "lakerunner.licenseVolumeMount" . | nindent 8 }}
+      volumes:
+      {{- include "lakerunner.ephemeralVolumeBasic" (list "scratch" .) | nindent 6 }}
+      {{- if eq .Values.storageProfiles.source "config" }}
+      - name: storage-profiles
+        configMap:
+          name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+      {{- end }}
+      {{- if eq .Values.apiKeys.source "config" }}
+      - name: apikeys
+        secret:
+          secretName: {{ include "lakerunner.apiKeysSecretName" . }}
+      {{- end }}
+      {{- include "lakerunner.licenseVolume" . | nindent 6 }}
+  backoffLimit: 0
+{{- end }}

--- a/conductor/templates/lakerunner/storageprofile-configmap.yaml
+++ b/conductor/templates/lakerunner/storageprofile-configmap.yaml
@@ -1,0 +1,12 @@
+{{ if eq .Values.storageProfiles.source "config" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{ include "lakerunner.annotations" . | nindent 2 }}
+data:
+  storage_profiles.yaml: |
+{{ .Values.storageProfiles.yaml | toYaml | indent 6 }}
+{{ end }}

--- a/conductor/templates/lakerunner/storageprofile-configmap.yaml
+++ b/conductor/templates/lakerunner/storageprofile-configmap.yaml
@@ -5,7 +5,16 @@ metadata:
   name: {{ include "lakerunner.storageProfilesConfigmapName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
-  {{ include "lakerunner.annotations" . | nindent 2 }}
+  annotations:
+    {{- /* pre-install/pre-upgrade hook (weight -10) so the bootstrap migrate Job
+           (weight 0) can mount it for `migrate`'s initialize-if-needed step (it
+           reads STORAGE_PROFILE_FILE=/app/config/storage_profiles.yaml). An empty
+           list imports zero profiles — maestro provisions them dynamically.
+           See lakerunner/postgresql-secret.yaml. */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- include "lakerunner.annotationPairs" . | nindent 4 }}
 data:
   storage_profiles.yaml: |
 {{ .Values.storageProfiles.yaml | toYaml | indent 6 }}

--- a/conductor/templates/maestro/cardinal-api-key-secret.yaml
+++ b/conductor/templates/maestro/cardinal-api-key-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.cardinal.apiKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "maestro.cardinalApiKeySecretName" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+type: Opaque
+data:
+  cardinalhq-api-key: {{ .Values.global.cardinal.apiKey | b64enc }}
+  # Pre-formatted OTLP header string consumed by OTEL_EXPORTER_OTLP_HEADERS.
+  CARDINAL_API_HEADER: {{ printf "x-cardinalhq-api-key=%s" .Values.global.cardinal.apiKey | b64enc }}
+{{- end }}

--- a/conductor/templates/maestro/dex-configmap.yaml
+++ b/conductor/templates/maestro/dex-configmap.yaml
@@ -1,0 +1,64 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+{{- $d := .Values.dex | default dict -}}
+{{- $users := dig "staticUsers" list $d -}}
+{{- $extraRedirects := dig "extraRedirectURIs" list $d -}}
+{{- $allowedOrigins := dig "allowedOrigins" list $d -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  config.yaml: |
+    issuer: {{ include "maestro.dexIssuerUrl" . }}
+    # In-memory storage is per-pod. Sessions and signing keys do not
+    # survive pod restart and will diverge across replicas, so this
+    # setup is single-replica POC only — see dex.replicas guard above.
+    storage:
+      type: memory
+    web:
+      http: 0.0.0.0:{{ $cfg.port }}
+      {{- /* CORS allowed origins for Dex's own HTTP endpoints (discovery,
+          token, keys). A browser SPA served from a DIFFERENT origin than the
+          maestro backend — e.g. a local Vite dev server (`ui-vite-dev`) at
+          http://localhost:5173 — fetches /dex/.well-known/openid-configuration
+          and the token endpoint cross-origin; without Dex emitting CORS
+          headers the OIDC PKCE flow fails at discovery. maestro's own CORS
+          middleware covers /api but NOT the /dex reverse-proxy pass-through,
+          so Dex must allow the origin itself. Pairs with extraRedirectURIs
+          (which whitelists the redirect; this whitelists the fetch origin).
+          Empty in prod (SPA is same-origin with maestro, no CORS needed). */}}
+      {{- with $allowedOrigins }}
+      allowedOrigins:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+    oauth2:
+      skipApprovalScreen: true
+    enablePasswordDB: true
+    staticClients:
+      # public:true means PKCE-only (no client secret); matches what
+      # the SPA uses via react-oidc-context. Do NOT switch to a
+      # confidential client without also wiring a client_secret on
+      # the SPA side.
+      - id: {{ $cfg.clientId }}
+        name: "Maestro UI"
+        public: true
+        redirectURIs:
+          - {{ include "maestro.dexRedirectUri" . }}
+          {{- /* Extra dev/CI redirect URIs (e.g. a local Vite dev server at
+              http://localhost:5173/ pointed at this backend). Appended verbatim
+              so non-prod origins can complete the OIDC PKCE flow without
+              hand-patching the live ConfigMap. Leave empty in prod. */}}
+          {{- range $extraRedirects }}
+          - {{ . | quote }}
+          {{- end }}
+    staticPasswords:
+      {{- toYaml $users | nindent 6 }}
+{{- end }}

--- a/conductor/templates/maestro/dex-deployment.yaml
+++ b/conductor/templates/maestro/dex-deployment.yaml
@@ -1,0 +1,85 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+{{- include "maestro.dexValidate" . -}}
+{{- $d := .Values.dex | default dict -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ $cfg.replicas }}
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dex
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: dex
+      annotations:
+        # Roll the pod when the rendered Dex config changes so static
+        # users / clients edits don't require a manual restart.
+        checksum/config: {{ include (print $.Template.BasePath "/dex-configmap.yaml") . | sha256sum }}
+        {{- with .Values.global.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" (dig "podSecurityContext" dict $d)) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: dex
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" (dig "containerSecurityContext" dict $d)) | nindent 8 }}
+        image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+        imagePullPolicy: {{ $cfg.image.pullPolicy }}
+        command: ["/usr/local/bin/dex"]
+        args: ["serve", "/etc/dex/config.yaml"]
+        ports:
+        - containerPort: {{ $cfg.port }}
+          name: http
+        env:
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        # Dex 2.x serves /healthz at the issuer path root (/<pathPrefix>/healthz).
+        # Pin the dex image tag carefully — older or much newer versions may
+        # change this path.
+        readinessProbe:
+          httpGet:
+            path: {{ printf "%s/healthz" $cfg.pathPrefix | quote }}
+            port: http
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: {{ printf "%s/healthz" $cfg.pathPrefix | quote }}
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml (dig "resources" (dict "requests" (dict "cpu" "200m" "memory" "128Mi") "limits" (dict "cpu" "200m" "memory" "128Mi")) $d) | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex
+          readOnly: true
+        # Dex writes templated web assets to /tmp at startup, so it
+        # needs a writable scratch dir under the chart's default
+        # readOnlyRootFilesystem: true container security context.
+        - name: tmp
+          mountPath: /tmp
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector (dig "nodeSelector" dict $d)) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  (dig "tolerations" list $d))  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     (dig "affinity" dict $d))     | nindent 6 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "maestro.dexFullname" . }}
+      - name: tmp
+        emptyDir: {}
+{{- end }}

--- a/conductor/templates/maestro/dex-deployment.yaml
+++ b/conductor/templates/maestro/dex-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Roll the pod when the rendered Dex config changes so static
         # users / clients edits don't require a manual restart.
-        checksum/config: {{ include (print $.Template.BasePath "/dex-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/maestro/dex-configmap.yaml") . | sha256sum }}
         {{- with .Values.global.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/conductor/templates/maestro/dex-service.yaml
+++ b/conductor/templates/maestro/dex-service.yaml
@@ -1,0 +1,20 @@
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+{{- if $cfg.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.dexFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $cfg.port }}
+      targetPort: http
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dex
+{{- end }}

--- a/conductor/templates/maestro/github-cache-provisioner-deployment.yaml
+++ b/conductor/templates/maestro/github-cache-provisioner-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if include "maestro.githubCacheEnabled" . -}}
+{{- $prov := .Values.githubCache.provisioner -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maestro.githubCacheProvisionerFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache-provisioner
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  # Singleton — the ontology poll + dead-row sweeper is guarded by a persisted
+  # lease, but Recreate avoids two overlapping pods during a rollout.
+  replicas: {{ $prov.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: github-cache-provisioner
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache-provisioner
+        {{- with $prov.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- include "maestro.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" $prov.podSecurityContext) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+      # mcp-gateway native sidecar — the provisioner calls it for the
+      # runtime topology overlay. Loopback only; no Service. See conductor#838.
+      {{- include "maestro.mcpGatewaySidecar" (dict "root" . "containerSec" $prov.containerSecurityContext) | nindent 6 }}
+      containers:
+      - name: github-cache-provisioner
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $prov.containerSecurityContext) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/app/entrypoint.sh"]
+        args: ["github-cache-provisioner"]
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          {{- include "maestro.databaseUrlAlias" . | nindent 10 }}
+          # The ontology provisioner (which moves here in remote mode) calls
+          # the mcp-gateway for the runtime topology overlay; without this the
+          # overlay is silently skipped.
+          - name: MCP_GATEWAY_URL
+            value: "http://localhost:{{ .Values.mcpGateway.port }}"
+          # git writes ~/.gitconfig etc.; point HOME at the writable tmp
+          # emptyDir so readOnlyRootFilesystem=true doesn't break it.
+          - name: HOME
+            value: /tmp
+          {{- with .Values.githubCache.diskBudgetBytes }}
+          - name: GITHUB_CACHE_DISK_BUDGET_BYTES
+            value: {{ . | quote }}
+          {{- end }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.githubCache.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml $prov.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector $prov.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  $prov.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     $prov.affinity)     | nindent 6 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
+{{- end }}

--- a/conductor/templates/maestro/github-cache-service.yaml
+++ b/conductor/templates/maestro/github-cache-service.yaml
@@ -1,0 +1,25 @@
+{{- if include "maestro.githubCacheEnabled" . -}}
+# Headless Service: clusterIP None gives each serving pod stable per-pod DNS
+# (github-cache-0.<svc>.<ns>.svc.cluster.local) so the placement directory can
+# address replicas directly. There is no load-balanced VIP — maestro routes to
+# a specific replica chosen from the directory, not to the Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.githubCacheFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.githubCache.serving.port }}
+      targetPort: http
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+{{- end }}

--- a/conductor/templates/maestro/github-cache-statefulset.yaml
+++ b/conductor/templates/maestro/github-cache-statefulset.yaml
@@ -1,0 +1,151 @@
+{{- if include "maestro.githubCacheEnabled" . -}}
+{{- $svc := include "maestro.githubCacheFullname" . -}}
+{{- $serving := .Values.githubCache.serving -}}
+{{- $mountPath := $serving.persistence.mountPath | default "/var/lib/github-cache" -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "maestro.githubCacheFullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-cache
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  serviceName: {{ $svc }}
+  replicas: {{ $serving.replicas }}
+  # RWO volumes attach to one node at a time; parallel pod management avoids a
+  # serial rollout deadlock and lets warm replicas come back independently.
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: github-cache
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache
+        {{- with $serving.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- include "maestro.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- /*
+        Pin SELinux MCS categories so a re-attached PVC's mirror bytes stay
+        readable across pod restarts (same rationale as maestro.persistence).
+        Operators can override seLinuxOptions in serving.podSecurityContext.
+      */}}
+      {{- $podSec := $serving.podSecurityContext | default dict -}}
+      {{- if not (hasKey $podSec "seLinuxOptions") -}}
+        {{- $merged := dict -}}
+        {{- range $k, $v := $podSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
+        {{- $_ := set $merged "seLinuxOptions" (dict "level" $serving.persistence.seLinuxLevel) -}}
+        {{- $podSec = $merged -}}
+      {{- end }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" $podSec) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+      # mcp-gateway native sidecar. The serving container does not call the
+      # gateway today, but co-locating it keeps the topology uniform across
+      # the maestro stack and gives any future cache-side feature a
+      # pod-local gateway over loopback. See conductor#838.
+      {{- include "maestro.mcpGatewaySidecar" (dict "root" . "containerSec" $serving.containerSecurityContext) | nindent 6 }}
+      containers:
+      - name: github-cache
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $serving.containerSecurityContext) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/app/entrypoint.sh"]
+        args: ["github-cache"]
+        ports:
+        - containerPort: {{ $serving.port }}
+          name: http
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          {{- include "maestro.databaseUrlAlias" . | nindent 10 }}
+          - name: GITHUB_CACHE_PORT
+            value: {{ $serving.port | quote }}
+          # Stable per-pod identity: the StatefulSet ordinal hostname.
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: GITHUB_CACHE_REPLICA_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # Endpoint the placement directory advertises to maestro. Code
+          # appends ":<port>", so this is host-only — the stable per-pod DNS
+          # backed by the headless Service.
+          - name: GITHUB_CACHE_ENDPOINT
+            value: "$(POD_NAME).{{ $svc }}.{{ .Release.Namespace }}.svc"
+          - name: MIRROR_ROOT
+            value: {{ printf "%s/mirrors" $mountPath | quote }}
+          # git writes ~/.gitconfig etc.; point HOME at the writable tmp
+          # emptyDir so readOnlyRootFilesystem=true doesn't break it.
+          - name: HOME
+            value: /tmp
+          {{- with .Values.githubCache.diskBudgetBytes }}
+          - name: GITHUB_CACHE_DISK_BUDGET_BYTES
+            value: {{ . | quote }}
+          {{- end }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.githubCache.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml $serving.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: mirrors
+          mountPath: {{ $mountPath | quote }}
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector $serving.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  $serving.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     $serving.affinity)     | nindent 6 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: mirrors
+      # volumeClaimTemplates is IMMUTABLE: use only stable selector labels here.
+      # maestro.labels embeds app.kubernetes.io/version + helm.sh/chart, which
+      # change every release and make the StatefulSet un-updatable (forbidden
+      # immutable-field patch). Stable labels keep future releases syncable.
+      labels:
+        {{- include "maestro.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: github-cache
+    spec:
+      accessModes:
+        - {{ $serving.persistence.accessMode | quote }}
+      resources:
+        requests:
+          storage: {{ $serving.persistence.size | quote }}
+      {{- with $serving.persistence.storageClass }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/conductor/templates/maestro/ingress.yaml
+++ b/conductor/templates/maestro/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $cfg := include "maestro.dexConfig" . | fromYaml -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "maestro.fullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+      {{- if $cfg.enabled }}
+      # NGINX-ingress and Traefik select by longest-prefix match, so
+      # path order here doesn't change which backend serves /dex/*.
+      # Listed first only for readability.
+      - path: {{ $cfg.pathPrefix }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "maestro.dexFullname" . }}
+            port:
+              name: http
+      {{- end }}
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "maestro.fullname" . }}-maestro
+            port:
+              name: http
+{{- end }}

--- a/conductor/templates/maestro/license-secret.yaml
+++ b/conductor/templates/maestro/license-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.license.create .Values.license.data -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "maestro.licenseSecretName" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  license.json: {{ .Values.license.data | b64enc | quote }}
+{{- end }}

--- a/conductor/templates/maestro/license-validation.yaml
+++ b/conductor/templates/maestro/license-validation.yaml
@@ -1,0 +1,5 @@
+{{/*
+License validation — ensures a valid license configuration is provided.
+This template renders nothing but fails early if the license is misconfigured.
+*/}}
+{{- include "maestro.validateLicense" . -}}

--- a/conductor/templates/maestro/maestro-deployment.yaml
+++ b/conductor/templates/maestro/maestro-deployment.yaml
@@ -162,6 +162,41 @@ spec:
           {{- with .Values.maestro.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- if include "conductor.bootstrapEnabled" . }}
+          - name: MAESTRO_BOOTSTRAP_ORG_ID
+            value: {{ required "bootstrap.org.id is required when bootstrap.mode!=never" .Values.bootstrap.org.id | quote }}
+          - name: MAESTRO_BOOTSTRAP_ORG_NAME
+            value: {{ .Values.bootstrap.org.name | default "default" | quote }}
+          - name: MAESTRO_BOOTSTRAP_OWNER_EMAIL
+            value: {{ required "bootstrap.org.ownerEmail is required when bootstrap.mode!=never" .Values.bootstrap.org.ownerEmail | quote }}
+          - name: MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL
+            value: {{ include "conductor.queryApiUrl" . | quote }}
+          - name: MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL
+            value: {{ include "conductor.adminApiUrl" . | quote }}
+          - name: MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "conductor.adminKeySecretName" . }}
+                key: {{ include "conductor.adminKeySecretKey" . }}
+          {{- if .Values.bootstrap.bucket.name }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_NAME
+            value: {{ .Values.bootstrap.bucket.name | quote }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_REGION
+            value: {{ .Values.bootstrap.bucket.region | default "us-east-1" | quote }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER
+            value: {{ .Values.bootstrap.bucket.cloudProvider | default "aws" | quote }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_COLLECTOR_NAME
+            value: {{ .Values.bootstrap.bucket.collectorName | default "default" | quote }}
+          {{- with .Values.bootstrap.bucket.endpoint }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_ENDPOINT
+            value: {{ . | quote }}
+          {{- end }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_USE_PATH_STYLE
+            value: {{ .Values.bootstrap.bucket.usePathStyle | default false | quote }}
+          - name: MAESTRO_BOOTSTRAP_BUCKET_INSECURE_TLS
+            value: {{ .Values.bootstrap.bucket.insecureTls | default false | quote }}
+          {{- end }}
+          {{- end }}
         readinessProbe:
           httpGet:
             path: /api/health

--- a/conductor/templates/maestro/maestro-deployment.yaml
+++ b/conductor/templates/maestro/maestro-deployment.yaml
@@ -1,0 +1,270 @@
+{{- if .Values.maestro.enabled -}}
+{{- include "maestro.haValidate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  replicas: {{ include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas) }}
+  {{- if and (include "maestro.persistenceEnabled" .) (ne .Values.maestro.persistence.accessMode "ReadWriteMany") }}
+  # RWO volumes can only attach to one node at a time. Rolling update would
+  # deadlock the rollout (new pod scheduled to a different node, can't mount
+  # the in-use volume). Recreate forces tear-down → reattach → new pod.
+  strategy:
+    type: Recreate
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: maestro
+  template:
+    metadata:
+      labels:
+        {{- include "maestro.labels" . | nindent 8 }}
+        app.kubernetes.io/component: maestro
+      {{- include "maestro.annotations" . | nindent 6 }}
+    spec:
+      serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      {{- /*
+        When persistence is enabled, pin SELinux MCS categories so the volume
+        is accessible across pod restarts. Default per-pod MCS rotation makes
+        ext4 PVC contents from a previous pod inaccessible to a new one
+        (EACCES on read/write). The user can override seLinuxOptions in
+        maestro.podSecurityContext to change the level or add type/role.
+      */}}
+      {{- $podSec := .Values.maestro.podSecurityContext | default dict -}}
+      {{- if and (include "maestro.persistenceEnabled" .) (not (hasKey $podSec "seLinuxOptions")) -}}
+        {{- $merged := dict -}}
+        {{- range $k, $v := $podSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
+        {{- $_ := set $merged "seLinuxOptions" (dict "level" .Values.maestro.persistence.seLinuxLevel) -}}
+        {{- $podSec = $merged -}}
+      {{- end }}
+      {{- include "maestro.podSecurityContext" (dict "root" . "override" $podSec) | nindent 6 }}
+      {{- include "maestro.imagePullSecrets" . | nindent 6 }}
+      {{- /*
+        With the in-pod TLS sidecar, several paths nginx-unprivileged needs
+        to touch (/tmp/proxy_temp, /etc/nginx/conf.d/default.conf via the
+        ipv6 listen entrypoint hook, /var/cache/nginx) sit on the read-only
+        rootfs. Rather than chase each one with init containers and subPath
+        mounts, drop readOnlyRootFilesystem for the whole pod when TLS is
+        enabled. Operators who need ROFS=true can still set it explicitly
+        in maestro.containerSecurityContext.
+      */}}
+      {{- $containerSec := .Values.maestro.containerSecurityContext | default dict -}}
+      {{- if and (dig "tls" "enabled" false .Values.maestro) (not (hasKey $containerSec "readOnlyRootFilesystem")) -}}
+        {{- $merged := dict -}}
+        {{- range $k, $v := $containerSec }}{{- $_ := set $merged $k $v -}}{{- end -}}
+        {{- $_ := set $merged "readOnlyRootFilesystem" false -}}
+        {{- $containerSec = $merged -}}
+      {{- end }}
+      initContainers:
+      # mcp-gateway as a native sidecar (initContainer + restartPolicy: Always,
+      # GA since k8s 1.29). Starts before the maestro container and stays
+      # running. Maestro talks to it over localhost, so every MCP session lives
+      # entirely within this pod — no Service round-robin, no risk of
+      # "session not found" on stateful drivers. See conductor#838.
+      {{- include "maestro.mcpGatewaySidecar" (dict "root" . "containerSec" $containerSec) | nindent 6 }}
+      {{- if and (dig "tls" "enabled" false .Values.maestro) (dig "tls" "cert" "autoGenerate" true .Values.maestro) (not (dig "tls" "secretName" "" .Values.maestro)) }}
+      # Generates a self-signed cert into the shared `tls` emptyDir at pod
+      # start. Cert regenerates each pod restart — fine for POC, swap to
+      # maestro.tls.secretName for stable certs.
+      - name: tls-init
+        image: "{{ .Values.maestro.tls.cert.image.repository }}:{{ .Values.maestro.tls.cert.image.tag }}"
+        imagePullPolicy: {{ .Values.maestro.tls.cert.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            HOST="${TLS_HOST}"
+            EXTRA_SANS="${TLS_EXTRA_SANS}"
+            SAN="DNS:${HOST}"
+            if [ -n "${EXTRA_SANS}" ]; then SAN="${SAN},${EXTRA_SANS}"; fi
+            cat >/tmp/openssl.cnf <<EOF
+            [req]
+            distinguished_name=req_distinguished_name
+            prompt=no
+            req_extensions=v3
+            [req_distinguished_name]
+            CN=${HOST}
+            [v3]
+            subjectAltName=${SAN}
+            basicConstraints=CA:FALSE
+            keyUsage=digitalSignature,keyEncipherment
+            extendedKeyUsage=serverAuth
+            EOF
+            openssl req -x509 -newkey rsa:2048 -nodes \
+              -keyout /tls/tls.key -out /tls/tls.crt \
+              -days 365 -extensions v3 -config /tmp/openssl.cnf
+            chmod 0644 /tls/tls.key /tls/tls.crt
+        env:
+          - name: TLS_HOST
+            value: {{ include "maestro.baseUrlHost" . | quote }}
+          - name: TLS_EXTRA_SANS
+            value: {{ join "," (default list .Values.maestro.tls.cert.sans) | quote }}
+        volumeMounts:
+          - name: tls
+            mountPath: /tls
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 64Mi
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: maestro
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
+        image: {{ include "maestro.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.maestro.port }}
+          name: http
+        env:
+          {{ include "maestro.databaseEnv" . | nindent 10 }}
+          - name: MCP_GATEWAY_URL
+            value: "http://localhost:{{ .Values.mcpGateway.port }}"
+          - name: PORT
+            value: {{ .Values.maestro.port | quote }}
+          # Maestro writes agent caches under
+          # ${WORKING_DIRECTORY}/<agent>/.cache/<namespace>. Point at the
+          # always-mounted agent-cache emptyDir so writes succeed under
+          # readOnlyRootFilesystem=true.
+          - name: WORKING_DIRECTORY
+            value: "/var/cache/maestro"
+          {{- if include "maestro.githubCacheEnabled" . }}
+          # Split mode: maestro holds no repo bytes. The in-process git client +
+          # ontology poller are disabled and git tool calls route to the
+          # github-cache serving replicas via the placement directory.
+          - name: GITHUB_CACHE_REMOTE
+            value: "1"
+          {{- end }}
+          {{- if (include "maestro.persistenceEnabled" .) }}
+          - name: ONTOLOGY_WORKSPACE_DIR
+            value: {{ printf "%s/git-checkouts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
+          - name: ORCHESTRA_ARTIFACT_DIR
+            value: {{ printf "%s/artifacts" (.Values.maestro.persistence.mountPath | default "/var/lib/maestro") | quote }}
+          {{- end }}
+          {{- include "maestro.objectStoreEnv" . | nindent 10 }}
+          {{- include "maestro.objectStoreAuthEnv" . | nindent 10 }}
+          {{- include "maestro.oidcEnv" . | nindent 10 }}
+          {{- include "maestro.cardinalTelemetryEnv" . | nindent 10 }}
+          {{- with .Values.global.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.maestro.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        # Liveness exists only to catch a *genuinely* stuck process. Maestro
+        # does bursts of CPU-bound work — multi-MB JSON.parse on MCP tool
+        # responses, JSON.stringify for artifact size accounting, the
+        # ontology poller's 60–90s sync — that briefly blocks the event loop.
+        # Tight liveness misreads "busy" as "dead" and SIGKILLs a healthy pod
+        # mid-run. ~10 minutes of consecutive unresponsiveness before we
+        # decide the process is actually wedged.
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 20
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.maestro.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: agent-cache
+          mountPath: /var/cache/maestro
+        {{- if (include "maestro.persistenceEnabled" .) }}
+        - name: data
+          mountPath: {{ .Values.maestro.persistence.mountPath | default "/var/lib/maestro" | quote }}
+        {{- end }}
+        {{- include "maestro.licenseVolumeMount" . | nindent 8 }}
+        {{- with .Values.maestro.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if dig "tls" "enabled" false .Values.maestro }}
+      # TLS-terminating sidecar. Listens on tls.port, proxies plaintext
+      # to the maestro container on localhost. Mounts the cert from the
+      # tls volume (populated by tls-init when autoGenerate=true, or from
+      # maestro.tls.secretName).
+      - name: tls-proxy
+        image: "{{ .Values.maestro.tls.image.repository }}:{{ .Values.maestro.tls.image.tag }}"
+        imagePullPolicy: {{ .Values.maestro.tls.image.pullPolicy }}
+        {{- include "maestro.containerSecurityContext" (dict "root" . "override" $containerSec) | nindent 8 }}
+        ports:
+          - containerPort: {{ .Values.maestro.tls.port }}
+            name: https
+        readinessProbe:
+          tcpSocket:
+            port: https
+          periodSeconds: 5
+          timeoutSeconds: 3
+        livenessProbe:
+          tcpSocket:
+            port: https
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+          - name: tls
+            mountPath: /etc/nginx/tls
+            readOnly: true
+          - name: tls-config
+            mountPath: /etc/nginx/conf.d
+            readOnly: true
+        {{- if .Values.global.resources.enabled }}
+        resources:
+          {{- toYaml .Values.maestro.tls.resources | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- include "maestro.sched.nodeSelector" (list .Values.global.nodeSelector .Values.maestro.nodeSelector) | nindent 6 }}
+      {{- include "maestro.sched.tolerations"  (list .Values.global.tolerations  .Values.maestro.tolerations)  | nindent 6 }}
+      {{- include "maestro.sched.affinity"     (list .Values.global.affinity     .Values.maestro.affinity)     | nindent 6 }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: agent-cache
+        emptyDir: {}
+      {{- if (include "maestro.persistenceEnabled" .) }}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "maestro.fullname" . }}-data
+      {{- end }}
+      {{- include "maestro.licenseVolume" . | nindent 6 }}
+      {{- if dig "tls" "enabled" false .Values.maestro }}
+      - name: tls
+        {{- $tlsSecret := include "maestro.tlsResolvedSecretName" . }}
+        {{- if $tlsSecret }}
+        secret:
+          secretName: {{ $tlsSecret }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: tls-config
+        configMap:
+          name: {{ include "maestro.fullname" . }}-maestro-tls
+      {{- end }}
+      {{- with .Values.maestro.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/conductor/templates/maestro/maestro-deployment.yaml
+++ b/conductor/templates/maestro/maestro-deployment.yaml
@@ -164,11 +164,11 @@ spec:
           {{- end }}
           {{- if include "conductor.bootstrapEnabled" . }}
           - name: MAESTRO_BOOTSTRAP_ORG_ID
-            value: {{ required "bootstrap.org.id is required when bootstrap.mode!=never" .Values.bootstrap.org.id | quote }}
+            value: {{ required "bootstrap.org.id is required when bootstrap is active (mode != adopt)" .Values.bootstrap.org.id | quote }}
           - name: MAESTRO_BOOTSTRAP_ORG_NAME
             value: {{ .Values.bootstrap.org.name | default "default" | quote }}
           - name: MAESTRO_BOOTSTRAP_OWNER_EMAIL
-            value: {{ required "bootstrap.org.ownerEmail is required when bootstrap.mode!=never" .Values.bootstrap.org.ownerEmail | quote }}
+            value: {{ required "bootstrap.org.ownerEmail is required when bootstrap is active (mode != adopt)" .Values.bootstrap.org.ownerEmail | quote }}
           - name: MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL
             value: {{ include "conductor.queryApiUrl" . | quote }}
           - name: MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL

--- a/conductor/templates/maestro/maestro-pvc.yaml
+++ b/conductor/templates/maestro/maestro-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.maestro.enabled (include "maestro.persistenceEnabled" .) -}}
+{{- $effectiveReplicas := int (include "maestro.replicas" (dict "root" . "explicit" .Values.maestro.replicas)) -}}
+{{- if and (gt $effectiveReplicas 1) (ne .Values.maestro.persistence.accessMode "ReadWriteMany") -}}
+{{- fail "maestro.persistence is enabled with replicas > 1, but accessMode is not ReadWriteMany. Set maestro.persistence.accessMode=ReadWriteMany (e.g. EFS) or scale to 1 replica." -}}
+{{- end -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "maestro.fullname" . }}-data
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  accessModes:
+    - {{ .Values.maestro.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.maestro.persistence.size | quote }}
+  {{- with .Values.maestro.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/conductor/templates/maestro/maestro-service.yaml
+++ b/conductor/templates/maestro/maestro-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.maestro.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.maestro.port }}
+      targetPort: http
+      name: http
+    {{- if dig "tls" "enabled" false (.Values.maestro | default dict) }}
+    - port: {{ .Values.maestro.tls.port }}
+      targetPort: https
+      name: https
+    {{- end }}
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+{{- end }}

--- a/conductor/templates/maestro/maestro-tls-config.yaml
+++ b/conductor/templates/maestro/maestro-tls-config.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.maestro.enabled (dig "tls" "enabled" false (.Values.maestro | default dict)) -}}
+{{- include "maestro.tlsValidate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro-tls
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  default.conf: |
+    server {
+      listen {{ .Values.maestro.tls.port }} ssl;
+      http2 on;
+      ssl_certificate     /etc/nginx/tls/tls.crt;
+      ssl_certificate_key /etc/nginx/tls/tls.key;
+      ssl_protocols       TLSv1.2 TLSv1.3;
+      client_max_body_size 50m;
+
+      location / {
+        proxy_pass http://127.0.0.1:{{ .Values.maestro.port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        # OIDC redirect, SSE, and proxied Dex form posts must stream.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout  300s;
+        proxy_send_timeout  300s;
+      }
+    }
+{{- end }}

--- a/conductor/templates/maestro/maestro-tls-secret.yaml
+++ b/conductor/templates/maestro/maestro-tls-secret.yaml
@@ -1,0 +1,24 @@
+{{- /*
+  Validation lives in maestro-tls-config.yaml so the chart raises a single
+  error from a deterministic template. This file only renders when both
+  inline cert fields are set; bad combinations (e.g. inline + autoGenerate)
+  fail rendering elsewhere before this Secret matters.
+*/}}
+{{- if and .Values.maestro.enabled (dig "tls" "enabled" false (.Values.maestro | default dict)) -}}
+{{- $crt := dig "tls" "cert" "crt" "" (.Values.maestro | default dict) -}}
+{{- $key := dig "tls" "cert" "key" "" (.Values.maestro | default dict) -}}
+{{- if and $crt $key -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "maestro.fullname" . }}-maestro-tls-cert
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+  {{ include "maestro.annotations" . | nindent 2 }}
+data:
+  tls.crt: {{ $crt | b64enc | quote }}
+  tls.key: {{ $key | b64enc | quote }}
+{{- end -}}
+{{- end }}

--- a/conductor/templates/maestro/mcp-gateway-service.yaml
+++ b/conductor/templates/maestro/mcp-gateway-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.mcpGateway.service.enabled -}}
+{{/*
+ClusterIP fronting the mcp-gateway sidecar. The sidecar lives inside the
+maestro pod (chart 0.8+), so this Service uses the maestro selector and
+targets the sidecar's named port (`mcp`, default 8080). External traffic
+reaches the gateway via an operator-managed Ingress/IngressRoute pointed
+at this Service; in-cluster maestro continues to use localhost.
+
+Disabled by default to preserve the local-dev / self-hosted contract
+where the gateway is never reachable outside the pod. SaaS operators
+who terminate TLS at Traefik and gate the gateway with an API key flip
+this on.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maestro.fullname" . }}-mcp-gateway
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-gateway
+  {{ include "maestro.annotations" . | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.mcpGateway.port }}
+      targetPort: mcp
+      name: http
+  selector:
+    {{- include "maestro.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: maestro
+{{- end }}

--- a/conductor/templates/maestro/secret.yaml
+++ b/conductor/templates/maestro/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.database.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "maestro.databaseSecretName" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+  {{ include "maestro.annotations" . | nindent 2 }}
+type: Opaque
+data:
+  {{ .Values.database.passwordKey }}: {{ .Values.database.password | b64enc }}
+{{- end }}

--- a/conductor/templates/maestro/secret.yaml
+++ b/conductor/templates/maestro/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.database.create }}
+{{- if .Values.maestroDatabase.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
   {{ include "maestro.annotations" . | nindent 2 }}
 type: Opaque
 data:
-  {{ .Values.database.passwordKey }}: {{ .Values.database.password | b64enc }}
+  {{ .Values.maestroDatabase.passwordKey }}: {{ .Values.maestroDatabase.password | b64enc }}
 {{- end }}

--- a/conductor/templates/maestro/secret.yaml
+++ b/conductor/templates/maestro/secret.yaml
@@ -5,7 +5,13 @@ metadata:
   name: {{ include "maestro.databaseSecretName" . }}
   labels:
     {{- include "maestro.labels" . | nindent 4 }}
-  {{ include "maestro.annotations" . | nindent 2 }}
+  annotations:
+    {{- /* pre-install/pre-upgrade hook (weight -10) so the bootstrap
+           migrate-maestro Job can mount it. See lakerunner/postgresql-secret.yaml. */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- include "maestro.annotationPairs" . | nindent 4 }}
 type: Opaque
 data:
   {{ .Values.maestroDatabase.passwordKey }}: {{ .Values.maestroDatabase.password | b64enc }}

--- a/conductor/templates/shared/rbac.yaml
+++ b/conductor/templates/shared/rbac.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "conductor.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "conductor.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "conductor.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "conductor.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/conductor/templates/shared/rbac.yaml
+++ b/conductor/templates/shared/rbac.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
+  annotations:
+    # Pre-install/pre-upgrade hook (weight -10) so the SA's RBAC exists before
+    # the bootstrap migrate/key-seed Jobs (weight 0) run. See serviceaccount.yaml.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
 rules:
   - apiGroups: [""]
     resources: ["pods", "services"]
@@ -25,6 +31,12 @@ metadata:
   name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
+  annotations:
+    # Pre-install/pre-upgrade hook (weight -10) so the binding exists before
+    # the bootstrap migrate/key-seed Jobs (weight 0) run. See serviceaccount.yaml.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/conductor/templates/shared/serviceaccount.yaml
+++ b/conductor/templates/shared/serviceaccount.yaml
@@ -5,8 +5,16 @@ metadata:
   name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    # Created as a pre-install/pre-upgrade hook (earlier than the migrate/key-seed
+    # bootstrap Jobs at weight 0) so those hook Jobs can mount this ServiceAccount.
+    # Without a hook annotation the SA is created in the main phase, AFTER pre-install
+    # hooks run, and the migrate Jobs fail with "serviceaccount not found".
+    # before-hook-creation (NOT hook-succeeded) keeps it around for the main release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- end }}

--- a/conductor/templates/shared/serviceaccount.yaml
+++ b/conductor/templates/shared/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "conductor.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/conductor/tests/render-parity.sh
+++ b/conductor/tests/render-parity.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Renders legacy lakerunner+maestro and unified conductor with equivalent values,
+# normalizes incidental differences, and compares the resource (kind,name) sets.
+set -euo pipefail
+REL="conductor-test"
+OUT=$(mktemp -d)
+LR_VALUES="${1:?lakerunner test values}"; MS_VALUES="${2:?maestro test values}"; UNI_VALUES="${3:?unified test values}"
+norm() { sed -E 's#helm\.sh/chart: [^ ]+##'; }
+helm template "$REL" lakerunner -f "$LR_VALUES" | norm > "$OUT/legacy-lr.yaml"
+helm template "$REL" maestro    -f "$MS_VALUES" | norm > "$OUT/legacy-ms.yaml"
+helm template "$REL" conductor  -f "$UNI_VALUES" | norm > "$OUT/unified.yaml"
+# Build sorted, filename-free (kind|name) indexes so the diff is readable.
+idx() { grep -hE '^(kind|  name):' "$@" | sed -E 's/^  name: +/  name: /' | sort -u; }
+idx "$OUT/legacy-lr.yaml" "$OUT/legacy-ms.yaml" > "$OUT/legacy-index.txt"
+idx "$OUT/unified.yaml" > "$OUT/unified-index.txt"
+echo "### LEGACY-ONLY (present in legacy, removed in unified):"
+comm -23 "$OUT/legacy-index.txt" "$OUT/unified-index.txt"
+echo "### UNIFIED-ONLY (added in unified):"
+comm -13 "$OUT/legacy-index.txt" "$OUT/unified-index.txt"
+echo "### Expected LEGACY-ONLY: grafana/collector/perch resources + the 2 legacy ServiceAccounts"
+echo "###   (release-named SA 'lakerunner', '<rel>-maestro') + the legacy lakerunner '<rel>-lakerunner-scaler' Role/RoleBinding."
+echo "### Expected UNIFIED-ONLY: one release-named ServiceAccount/Role/RoleBinding ('<rel>')."
+echo "OUT=$OUT"

--- a/conductor/tests/values-lakerunner.yaml
+++ b/conductor/tests/values-lakerunner.yaml
@@ -1,0 +1,5 @@
+# Minimal values to render the legacy lakerunner chart (mirrors lakerunner/tests/test-values.yaml).
+aws:
+  region: us-west-2
+license:
+  data: '{"key":"test"}'

--- a/conductor/tests/values-maestro.yaml
+++ b/conductor/tests/values-maestro.yaml
@@ -1,0 +1,5 @@
+# Minimal values to render the legacy maestro chart.
+database:
+  host: db.example.com
+license:
+  data: '{"key":"test"}'

--- a/conductor/tests/values-unified.yaml
+++ b/conductor/tests/values-unified.yaml
@@ -1,0 +1,10 @@
+# Minimal values to render the unified conductor chart (both families together).
+# Mirrors the values.yaml merge: one license, lakerunner DB under .database.lrdb,
+# maestro DB namespaced under .maestroDatabase.
+aws:
+  region: us-west-2
+license:
+  data: '{"key":"test"}'
+# maestro database (namespaced to avoid colliding with lakerunner's nested database.lrdb)
+maestroDatabase:
+  host: db.example.com

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -1229,18 +1229,26 @@ dex:
   #   - http://localhost:5173
 
 # Fresh-install bootstrap. On a fresh install the chart seeds a shared admin key
-# and Maestro provisions a shared LakeRunner org at boot. On adoption set
-# mode: never (sub-project C adds full auto-detection).
+# and Maestro provisions a shared LakeRunner org at boot.
 bootstrap:
-  # auto = run the fresh-install bootstrap (seed key + render MAESTRO_BOOTSTRAP_*).
-  # never = skip everything (adopt: point at existing external DB/store, no provisioning).
-  # force = same as auto (reserved; C differentiates auto vs force via detection).
+  # Bootstrap mode. One of:
+  #   auto  (default) = run a pre-install detection Job that inspects configdb +
+  #         the maestro DB and classifies the install. Fresh installs bootstrap;
+  #         a conductor-shaped install is adopted idempotently; a legacy/foreign
+  #         or inconsistent DB ABORTS the install (re-run with mode: adopt).
+  #   adopt = skip ALL bootstrap (no detection, key-seed, anchor Secret, or
+  #         MAESTRO_BOOTSTRAP_*). Point at an existing external DB/store and
+  #         provision nothing. Use this to adopt a prior split lakerunner+maestro
+  #         install; keep it set for the life of that adopted release.
+  #   force = bootstrap unconditionally with NO detection safety net
+  #         (recovery/testing only).
+  # "never" is a deprecated alias of "adopt".
   mode: auto
   # The shared org Maestro provisions and that telemetry is attributed to.
   org:
-    id: ""                 # UUID; REQUIRED when mode!=never. e.g. 11111111-1111-1111-1111-111111111111
+    id: ""                 # UUID; REQUIRED when bootstrap is active (mode != adopt). e.g. 11111111-1111-1111-1111-111111111111
     name: "default"
-    ownerEmail: ""         # REQUIRED when mode!=never
+    ownerEmail: ""         # REQUIRED when bootstrap is active (mode != adopt)
   # Admin key shared by admin-api (validated from configdb) and Maestro.
   adminKey:
     # When set, use this existing Secret instead of generating one (sealed-secrets/GitOps).

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -164,16 +164,23 @@ serviceAccount:
   name: ""        # empty → conductor.serviceAccountName uses the release name
   annotations: {}
 
-# License configuration
-# A valid license is required for LakeRunner to operate.
-# The license secret is always mounted to /app/license in all pods.
+# License configuration (single shared CardinalHQ suite license).
+# One license covers BOTH the lakerunner pipeline and maestro; the secret is
+# mounted to /app/license in all pods of both families. Each family prefixes the
+# secret name with its own fullname, so this renders as
+# <release>-lakerunner-cardinal-license and <release>-maestro-cardinal-license.
+# A valid license is required to operate.
+#
+# BYOS (bring your own secret): adopters with an existing license secret should
+# set license.create=false and license.secretName to that secret's name.
 license:
   # Whether to create the license secret from the data below.
   # Set to false to use an existing secret (BYOS).
   create: true
   # Name of the Kubernetes secret containing the license.
-  # Used whether create is true or false.
-  secretName: "lakerunner-license"
+  # Used whether create is true or false. Neutral suite name (not product-specific)
+  # since one license is shared by lakerunner and maestro.
+  secretName: "cardinal-license"
   # Raw license.json content (only used when create: true).
   # The content will be stored under the key "license.json" in the secret.
   data: ""
@@ -1169,11 +1176,11 @@ ingress:
 
 # Bundled Dex OIDC provider. Most fields are kept out of this file on purpose
 # so that `--set dex.enabled=true` is enough to turn it on — defaults live in
-# templates/_helpers.tpl (maestro.dexConfig) and inline `dig` in the dex
+# templates/_helpers-maestro.tpl (maestro.dexConfig) and inline `dig` in the dex
 # templates. `resources` is surfaced here so operators can tune CPU/memory
 # without chasing template internals.
 dex:
-  # Dex container image. Defaults are also defined in templates/_helpers.tpl
+  # Dex container image. Defaults are also defined in templates/_helpers-maestro.tpl
   # (maestro.dexConfig) so `--set dex.enabled=true` keeps working with
   # zero extra fields. Surfaced here so air-gapped/private-registry
   # installs can override without chasing template internals.

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -1246,9 +1246,11 @@ bootstrap:
     # When set, use this existing Secret instead of generating one (sealed-secrets/GitOps).
     existingSecret: ""
     existingSecretKey: "admin-api-key"
-  # Bucket coordinates Maestro provisions for the shared org. Mirror the object store.
+  # Bucket coordinates Maestro provisions for the shared org. Optional: when set,
+  # mirror the object store; when omitted, Maestro creates a bucket-less
+  # deployment and storage is provisioned later in the maestro UI.
   bucket:
-    name: ""               # REQUIRED when mode!=never
+    name: ""               # optional; omit for a bucket-less deployment (provision storage later in the maestro UI)
     region: "us-east-1"
     cloudProvider: "aws"   # aws|gcp|azure
     collectorName: "default"

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -1,0 +1,1222 @@
+# Unified conductor chart values (merged from lakerunner + maestro)
+# === lakerunner ===
+# Default values for lakerunner
+# This is a YAML-formatted file.
+
+# Global settings
+global:
+  # Global resource configuration
+  resources:
+    # Whether to render resource limits and requests in deployments
+    # Set to false to omit resource specifications entirely from rendered templates
+    # Default: true
+    enabled: true
+  # CardinalHQ telemetry configuration
+  cardinal:
+    # API key for CardinalHQ telemetry endpoint
+    # If provided, telemetry will be sent to CardinalHQ's controlled endpoint
+    # If not provided, no telemetry endpoint will be configured
+    apiKey: ""
+    # Set to "test" to route at the test intake endpoint instead of prod.
+    # (Consumed by maestro/mcp-gateway telemetry wiring.)
+    env: ""
+  # The names of image pull secrets to use for all images.
+  # Optional.
+  imagePullSecrets: []
+  # Global image settings
+  image:
+    # Default repository for all lakerunner images
+    # Override this to use a different registry/repository for all images
+    # Example: "public.ecr.aws/cardinalhq.io/lakerunner"
+    repository: ""
+    # Default tag for all lakerunner images.
+    # Pinned explicitly here so lakerunner images do NOT default to the unified
+    # Chart.appVersion (which tracks maestro). Mirrors the legacy lakerunner
+    # chart's appVersion. Per-component image.tag still wins over this.
+    tag: "v1.40.4"
+    # Default pull policy for all images
+    pullPolicy: "IfNotPresent"
+  # Global temporary storage (scratch / DuckDB temp / cache) configuration.
+  # This allows switching between emptyDir and ephemeral volume claim templates.
+  # Storage sizes are configured per-service in their respective temporaryStorage.size settings.
+  #
+  # Scratch-disk-size behavior (LAKERUNNER_SCRATCH_DISK_SIZE_BYTES):
+  #   The scratch-using services (process-logs/metrics/traces, query-worker) tell
+  #   the app how much scratch they may use via LAKERUNNER_SCRATCH_DISK_SIZE_BYTES.
+  #   How that env var is set depends on `type` below:
+  #   - type: "ephemeral" (a dedicated PersistentVolume via volumeClaimTemplate):
+  #       LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is left UNSET. The app probes the
+  #       filesystem with statfs(), which is accurate on a real PV.
+  #   - type: "emptyDir" (node-disk-backed, with a sizeLimit): the env var is set
+  #       to the per-service temporaryStorage.size converted to bytes. statfs on an
+  #       emptyDir reports the whole node disk, not the pod's slice, so the app
+  #       needs the explicit value to stay within its slice.
+  temporaryStorage:
+    # Type of temporary storage: "emptyDir" or "ephemeral"
+    # - emptyDir: Traditional emptyDir volumes (default). The pod's scratch slice
+    #   is bounded by sizeLimit, and LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is set to
+    #   that size so the app stays within it.
+    # - ephemeral: Uses ephemeral volume claim templates for CSI-based storage
+    #   (a real PV). LAKERUNNER_SCRATCH_DISK_SIZE_BYTES is left unset so the app
+    #   uses statfs(), which is accurate for a dedicated PV.
+    type: "emptyDir"
+    # Configuration for ephemeral volume claim templates (only used when type: "ephemeral")
+    ephemeral:
+      # Storage class to use for ephemeral volumes (leave empty for default storage class)
+      storageClassName: ""
+      # Additional labels to apply to ephemeral volume claim templates
+      labels:
+        {}
+        # type: my-frontend-volume
+  # Monitoring and observability configuration
+  monitoring:
+    traces:
+      # OpenTelemetry trace sampler to use
+      sampler: "parentbased_traceidratio"
+      # Sampler argument (e.g., sampling ratio for ratio-based samplers)
+      arg: "0.01"
+  # Global health probe configuration
+  # These defaults can be overridden per service
+  healthProbes:
+    # Global default for health probe enablement
+    enabled: false # Set to true to enable health probes globally
+    # Default health check port name (most services use this)
+    healthcheckPort: 8090
+  # Additional annotations to add to all resources.
+  # This is a key: value map.
+  # Optional.
+  annotations: {}
+  # Additional labels to add to all resources.
+  # This is a key: value map.
+  # Optional.
+  labels: {}
+  # Common environment variables to inject into all containers.
+  # This is a key: value map.
+  # Optional.
+  env: []
+    # - name: ENVAR1
+    #   value: "value1"
+    # - name: ENVAR2
+    #   value: "value2"
+  # Pod-level securityContext applied to every workload by default.
+  # Components may override individual fields via <component>.podSecurityContext
+  # (component fields win, missing fields fall back to these globals).
+  # For OpenShift's restricted-v2 SCC, set this to {runAsNonRoot: true} (or {})
+  # so the SCC can inject runAsUser/runAsGroup/fsGroup from the namespace's
+  # assigned UID range.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  # Container-level securityContext applied to every container by default.
+  # Components may override individual fields via <component>.containerSecurityContext.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # A node selector to apply to all pods.
+  # This is standard Kubernetes node selector syntax.
+  # Optional.
+  nodeSelector:
+    {}
+    # node-role.kubernetes.io/worker: ""
+    # spot-instance: "true"
+  # A set of tolerations to apply to all pods.
+  # This is standard Kubernetes toleration syntax.
+  # Optional.
+  tolerations:
+    []
+    # - key: "spot"
+    #   operator: "Equal"
+    #   value: "true"
+    #   effect: "NoSchedule"
+  # A set of affinity rules to apply to all pods.
+  # This is standard Kubernetes affinity syntax.
+  # Optional.
+  affinity:
+    {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: "node-role.kubernetes.io/worker"
+    #             operator: In
+    #             values:
+    #               - "true"
+  # The default service account to use for all pods.
+  # This service account is assigned some namespaced permissions.
+  # Additional cloud-provider specific permissions can be added
+  # to this service account, either by annotations or through
+  # systems like EKS's IAM roles for service accounts (IRSA).
+  # Required.
+
+# Single shared ServiceAccount for the unified chart. Both the lakerunner.* and
+# maestro.* families delegate to conductor.serviceAccountName, so exactly one SA
+# (+ Role + RoleBinding) renders. With an empty name it is named after the
+# release (the "named install") — the chart name is intentionally NOT injected.
+serviceAccount:
+  create: true
+  name: ""        # empty → conductor.serviceAccountName uses the release name
+  annotations: {}
+
+# License configuration
+# A valid license is required for LakeRunner to operate.
+# The license secret is always mounted to /app/license in all pods.
+license:
+  # Whether to create the license secret from the data below.
+  # Set to false to use an existing secret (BYOS).
+  create: true
+  # Name of the Kubernetes secret containing the license.
+  # Used whether create is true or false.
+  secretName: "lakerunner-license"
+  # Raw license.json content (only used when create: true).
+  # The content will be stored under the key "license.json" in the secret.
+  data: ""
+
+# Cloud provider configuration for storage operations
+# This section configures authentication for the cloud storage backend used by LakeRunner.
+# Choose the primary cloud provider and configure credentials accordingly.
+cloudProvider:
+  # Primary cloud provider for storage operations
+  # Options: "aws", "gcp", "azure"
+  # This determines which credentials are injected into all LakeRunner pods.
+  # Required.
+  provider: "aws" # Change to "azure" or "gcp" based on your storage profiles
+
+  # AWS configuration (used when provider: "aws")
+  aws:
+    # AWS region for the deployment
+    # Required when using AWS provider
+    region: ""
+
+    # Name of the Kubernetes secret that contains AWS credentials
+    # Secret should contain: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    secretName: "aws-credentials"
+
+    # Whether to create the AWS credentials secret
+    create: false
+
+    # Whether to inject AWS credentials into pods
+    # Set to false if using IAM roles (IRSA) or EC2 instance profiles
+    inject: true
+
+    # AWS credentials (only used if create: true)
+    accessKeyId: ""
+    secretAccessKey: ""
+
+  # Azure configuration (used when provider: "azure")
+  azure:
+    # Name of the Kubernetes secret that contains Azure credentials
+    # Secret contents vary based on authType
+    secretName: "azure-credentials"
+
+    # Whether to create the Azure credentials secret
+    create: false
+
+    # Whether to inject Azure credentials into pods
+    # Set to false if using system managed identity without explicit configuration
+    inject: true
+
+    # Azure authentication type
+    # Options: "service_principal", "user_managed_identity", "system_managed_identity",
+    #          "workload_identity", "connection_string"
+    authType: "service_principal"
+
+    # Azure service principal credentials (only used if authType: "service_principal")
+    clientId: ""
+    clientSecret: ""
+    tenantId: ""
+
+    # Connection string (only used if authType: "connection_string")
+    connectionString: ""
+
+    # Federated token file path (only used if authType: "workload_identity")
+    # Default path for Azure Workload Identity webhook
+    federatedTokenFile: "/var/run/secrets/azure/tokens/azure-identity-token"
+
+  # GCP configuration (used when provider: "gcp")
+  gcp:
+    # Name of the Kubernetes secret that contains GCP credentials
+    secretName: "gcp-credentials"
+
+    # Whether to create the GCP credentials secret
+    create: false
+
+    # Whether to inject GCP credentials into pods
+    # Set to false if using Workload Identity or other GCP auth methods
+    inject: true
+
+    # GCP credentials (only used if create: true)
+    # Service account JSON for native GCP API access (e.g., Pub/Sub, GCS)
+    serviceAccountJson: ""
+
+# Storage profile configuration
+# At least one storage profile is required for the LakeRunner to function.
+# Required.
+# If you want to auto create the Cardinal Collector, make sure that your storage profile has the following fields:
+# organization_id, collector_name, cloud_provider, region, bucket
+storageProfiles:
+  source: config # only value for general use.
+  configmapName: "storage-profiles" # Name of the ConfigMap containing storage profiles
+  create: true
+  yaml:
+    []
+    # - organization_id: dddddddd-aaaa-4ff9-ae8f-365873c552f0
+    #   instance_num: 1
+    #   collector_name: "kubepi"
+    #   cloud_provider: "aws"
+    #   region: "us-east-2"
+    #   bucket: "datalake-11ndajkhk"
+    #   endpoint: ""
+    #   use_path_style: true
+
+# API keys are used to control access to the data lake through the data-api service.
+# Each key must be unique, and it associates an API key with an organization ID.
+# An example format is shown below.  If you wish to create the secret outside of the
+# helm chart, follow this format, set `apiKeys.create` to `false`, and create a Kubernetes secret
+# with the content in the secret under a key named `apikeys.yaml`.
+# Required.
+apiKeys:
+  source: config # don't change as no other source is supported.
+  secretName: "apikeys" # will have the format <release-name>-apikeys once deployed
+  create: true
+  yaml:
+    []
+    # - organization_id: dddddddd-aaaa-4ff9-ae8f-365873c552f0
+    #   keys:
+    #     - my-api-key-1
+    #     - my-api-key-2
+
+# Database configuration
+# Required.
+database:
+  secretName: "pg-credentials" # Name of the Kubernetes secret containing database credentials
+  create: true # Whether to create the database credentials secret
+  # Secret key names (only needed if using an existing secret with different key names)
+  passwordKey: "LRDB_PASSWORD" # Key name for password in the secret
+  # LRDB (LakeRunner Database) - PostgreSQL
+  lrdb:
+    # PostgreSQL hostname.
+    # Required.
+    host: ""
+    # PostgreSQL port.  Default is 5432.
+    # Required.
+    port: 5432
+    # PostgreSQL database name.
+    # Required.
+    name: "lakerunner"
+    # PostgreSQL username.
+    # Required.
+    username: "lakerunner"
+    # PostgreSQL password.
+    # Optional, but recommended if not using an existing secret.
+    password: ""
+    # SSL mode for PostgreSQL connection.  Default is "require".
+    # Options are "disable", "allow", "prefer", "require", "verify-ca", and "verify-full".
+    # See https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS for more details.
+    # Optional, but recommended.
+    sslMode: "require"
+
+# Configuration database settings
+configdb:
+  secretName: "configdb-credentials" # Name of the Kubernetes secret containing configdb credentials
+  create: true # Whether to create the configdb credentials secret
+  # Secret key names (only needed if using an existing secret with different key names)
+  passwordKey: "CONFIGDB_PASSWORD" # Key name for password in the secret
+  # CONFIGDB (Configuration Database) - PostgreSQL
+  lrdb:
+    # PostgreSQL hostname.
+    # Required.
+    host: ""
+    # PostgreSQL port.  Default is 5432.
+    # Required.
+    port: 5432
+    # PostgreSQL database name.
+    # Required.
+    name: "config"
+    # PostgreSQL username.
+    # Required.
+    username: "config"
+    # PostgreSQL password.
+    # Optional, but recommended if not using an existing secret.
+    password: ""
+    # SSL mode for PostgreSQL connection.  Default is "require".
+    # Options are "disable", "allow", "prefer", "require", "verify-ca", and "verify-full".
+    # See https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS for more details.
+    # Optional, but recommended.
+    sslMode: "require"
+
+# Setup job configuration (runs before all other services)
+# This job is responsible for running database migrations and initial setup tasks.
+setup:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Override database connection for the setup job.
+  # This is useful when running migrations that require direct PostgreSQL
+  # connections (e.g., advisory locks that don't work through pgbouncer).
+  # Any field not set here falls back to the global database/configdb values.
+  database:
+    lrdb:
+      host: ""
+      port: ""
+      name: ""
+      username: ""
+      sslMode: ""
+  configdb:
+    lrdb:
+      host: ""
+      port: ""
+      name: ""
+      username: ""
+      sslMode: ""
+
+# Process Logs configuration (handles both ingest and compact for logs)
+processLogs:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
+    size: "10Gi"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 10
+  healthProbes:
+    enabled: null # null = inherit from global.healthProbes.enabled
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Process Metrics configuration (handles ingest, compact, and rollup for metrics)
+processMetrics:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
+    size: "10Gi"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 10
+  healthProbes:
+    enabled: null # null = inherit from global.healthProbes.enabled
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Process Traces configuration (handles both ingest and compact for traces)
+processTraces:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
+    size: "10Gi"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 10
+  healthProbes:
+    enabled: null # null = inherit from global.healthProbes.enabled
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Control-plane configuration.
+#
+# admin-api, alert-evaluator, monitoring, and sweeper are single-replica
+# services that share the lakerunner image. They are colocated into one pod
+# (Deployment lakerunner-control-plane) to avoid running four pods for four tiny
+# always-on singletons. Pod-level settings (replicas, image, scheduling,
+# security context, resources) live here; service-specific settings remain in
+# the adminApi / alertEvaluator / monitoring blocks below.
+controlPlane:
+  replicas: 1 # singleton; not intended to scale
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  # pprof debug server. The four containers share the pod network namespace, so
+  # each gets a distinct PPROF_PORT = basePort + offset (admin-api +0,
+  # alert-evaluator +1, monitoring +2, sweeper +3) to avoid colliding on the
+  # default 6060. PPROF_PORT is always set per container; the binary only honors
+  # it when pprof is enabled (via this flag, or globally via global.env
+  # ENABLE_PPROF=true).
+  pprof:
+    enabled: false # sets ENABLE_PPROF=true on each control-plane container
+    basePort: 6060
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Per-container resources, sized to measured prod usage.
+  # CPU: requests only (no limit) so any container can burst into idle
+  # node/sibling capacity instead of being CFS-throttled.
+  # Memory: request + per-container limit so a leak is confined to one container
+  # rather than taking down its podmates.
+  resources:
+    adminApi:
+      requests:
+        cpu: "25m"
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+    alertEvaluator:
+      requests:
+        cpu: "25m"
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+    monitoring:
+      requests:
+        cpu: "25m"
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+    sweeper:
+      requests:
+        cpu: "50m"
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+
+# Sweeper configuration (colocated in the control-plane pod; see controlPlane).
+sweeper:
+  env: []
+
+# Alert Evaluator configuration (colocated in the control-plane pod; see controlPlane).
+alertEvaluator:
+  queryApiUrl: "" # auto-configured to internal query-api if empty
+  env: []
+
+# Monitoring service configuration (colocated in the control-plane pod; see controlPlane).
+monitoring:
+  # PI autoscaler configuration
+  # The autoscaler runs inside the monitoring container and manages worker
+  # deployment replicas. It is always enabled. To disable scaling for a specific
+  # service, set its autoscaling.minReplicas and autoscaling.maxReplicas both to 0.
+  # To pin a service at a fixed replica count, set min == max (e.g., min=5 max=5).
+  autoscaler:
+    # Set to true to log scaling decisions without actually changing replicas.
+    observeOnly: false
+  env: []
+
+adminApi:
+  port: 9091
+  service:
+    type: ClusterIP
+    annotations: {}
+    nodePort: null
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+  env: []
+
+# PubSub configuration
+pubsub:
+  HTTP:
+    enabled: false
+    replicas: 2 # recommend at least 2 in production
+    service:
+      type: ClusterIP
+      port: 8080
+      annotations: {}
+      nodePort: null
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+    image:
+      repository: ghcr.io/cardinalhq/lakerunner
+      tag: ""
+      pullPolicy: ""
+    resources:
+      requests:
+        cpu: "1"
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  SQS:
+    enabled: false
+    replicas: 2
+    # REQUIRED when enabled: Your SQS queue URL
+    # Example: "https://sqs.us-east-2.amazonaws.com/123456789012/my-queue"
+    queueURL: ""
+    # AWS region for the SQS queue - defaults to global aws.region if not specified
+    # Example: "us-east-2"
+    region: ""
+    roleARN: ""
+    image:
+      repository: ghcr.io/cardinalhq/lakerunner
+      tag: ""
+      pullPolicy: ""
+    resources:
+      requests:
+        cpu: "1"
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  GCP:
+    enabled: false
+    replicas: 1
+    # REQUIRED when enabled: Your GCP project ID
+    # Example: "my-project-123456"
+    projectID: ""
+    # REQUIRED when enabled: Your GCP Pub/Sub subscription ID
+    # Example: "my-subscription"
+    subscriptionID: ""
+    image:
+      repository: ghcr.io/cardinalhq/lakerunner
+      tag: ""
+      pullPolicy: ""
+    resources:
+      requests:
+        cpu: "1"
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    env: []
+  Azure:
+    enabled: false
+    replicas: 1
+    # REQUIRED when enabled: Your Azure Storage Account name
+    # Example: "mystorageaccount"
+    storageAccount: ""
+    # REQUIRED when enabled: Your Azure Storage Queue name
+    # Example: "sqs"
+    queueName: ""
+    image:
+      repository: ghcr.io/cardinalhq/lakerunner
+      tag: ""
+      pullPolicy: ""
+    resources:
+      requests:
+        cpu: "1"
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    env: []
+
+# Query API configuration
+queryApi:
+  enabled: true
+  replicas: 2
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+    nodePort: null
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  env: []
+  # Per-component override of global.monitoring.traces. Any keys set here
+  # win over the global values; unset keys fall back to the global config.
+  # Example:
+  #   monitoring:
+  #     traces:
+  #       arg: "1.0"   # 100% sampling for query-api only
+  monitoring: {}
+
+# Query Worker configuration
+queryWorker:
+  enabled: true
+  replicas: 2
+  image:
+    repository: ghcr.io/cardinalhq/lakerunner
+    tag: ""
+    pullPolicy: ""
+  resources:
+    requests:
+      cpu: "2"
+      memory: 4Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+  service:
+    type: ClusterIP
+    port: 8081
+    annotations: {}
+    nodePort: null
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+  temporaryStorage:
+    # Scratch/DuckDB-temp size for this service. Sizes the volume (emptyDir
+    # sizeLimit or ephemeral PVC request). When global.temporaryStorage.type is
+    # "emptyDir", this value is also exported as LAKERUNNER_SCRATCH_DISK_SIZE_BYTES
+    # (in bytes) so the app stays within its node-disk slice; when "ephemeral"
+    # (a real PV) it is left unset and the app uses statfs(). See
+    # global.temporaryStorage above.
+    size: "100Gi"
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Per-component override of global.monitoring.traces. Any keys set here
+  # win over the global values; unset keys fall back to the global config.
+  # Example:
+  #   monitoring:
+  #     traces:
+  #       arg: "0.5"   # 50% sampling for query-worker only
+  monitoring: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Deployment topology.
+#
+# Two modes:
+#   ha.enabled=false (default) — POC: one maestro pod + one mcp-gateway pod,
+#     github-cache rolled into maestro (in-process), no object store required.
+#     Artifacts kept in-memory; ontology git checkouts on the pod's /tmp
+#     emptyDir (re-cloned on restart).
+#   ha.enabled=true — HA: two maestro pods + two mcp-gateway pods (operator
+#     can override higher), github-cache split into its StatefulSet +
+#     singleton provisioner, S3-compat object store REQUIRED for artifacts.
+#     Maestro `persistence.enabled` must be false (RWO PVC + Recreate
+#     strategy deadlocks rolling updates under replicas>1).
+#
+# Defaults for `maestro.replicas` and `githubCache.enabled` auto-derive
+# from this flag when left unset (null). Explicit operator values are
+# honored; conflicting explicit values fail template rendering with a
+# clear message. mcp-gateway is no longer a standalone Deployment — it
+# runs as a native sidecar in every maestro stack pod, so there's no
+# replica count to configure.
+ha:
+  enabled: false
+
+# Object storage for HA-mode artifact bytes. Required when ha.enabled=true.
+# S3 and S3-compatible only (AWS S3, Ceph RGW, MinIO, Rook OBC, ...).
+#
+# Credentials: maestro uses the AWS SDK default credential chain. Set
+# `auth.existingSecret` to inject AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+# from an existing Kubernetes secret (e.g. one created by a Rook
+# ObjectBucketClaim, or one you manage yourself). Leave it empty to rely
+# on ambient credentials — IRSA via `serviceAccount.annotations`, EC2/EKS
+# instance profile, or a workload-identity webhook. The chart does not
+# create the secret; it must already exist when set.
+#
+# Examples:
+#   AWS S3 via IRSA:
+#     ha: { enabled: true }
+#     objectStore:
+#       bucket: maestro-artifacts
+#       region: us-east-2
+#     serviceAccount:
+#       annotations:
+#         eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/maestro-s3
+#
+#   Rook-Ceph ObjectBucketClaim (Ceph RGW):
+#     ha: { enabled: true }
+#     objectStore:
+#       bucket: maestro-artifacts-abc1234       # BUCKET_NAME from the OBC ConfigMap
+#       endpoint: http://rook-ceph-rgw-store.rook-ceph.svc:80
+#       forcePathStyle: true                    # required by Ceph/MinIO
+#       auth:
+#         existingSecret: maestro-artifacts-obc # the OBC-generated secret
+objectStore:
+  bucket: ""
+  # Optional. Set for AWS S3; usually omitted for Ceph/MinIO.
+  region: ""
+  # Optional. Set for S3-compatible stores (Ceph RGW, MinIO).
+  endpoint: ""
+  # Path-style addressing. Required by most S3-compatible stores.
+  forcePathStyle: false
+  auth:
+    # Empty → rely on AWS SDK default credential chain (IRSA, instance
+    # profile, workload identity webhook). Non-empty → inject the named
+    # env vars from this existing Kubernetes Secret. Chart does NOT
+    # create the secret.
+    existingSecret: ""
+    # Secret keys to read AWS credential env vars from. Override only
+    # when the secret uses non-standard key names.
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    # Optional. STS-issued temporary credentials. Empty → not injected.
+    sessionTokenKey: ""
+
+# Unified image for all components (Maestro + MCP Gateway + UI SPA).
+# Entrypoint selects which component to run.
+image:
+  repository: public.ecr.aws/cardinalhq.io/maestro
+  tag: "v1.53.0"   # pinned (mirrors legacy maestro appVersion); do not rely on Chart.appVersion
+  pullPolicy: IfNotPresent
+
+# Maestro API server + UI configuration
+maestro:
+  enabled: true
+  # Replica count. Leave unset (null) to auto-derive from ha.enabled
+  # (1 in POC, 2 in HA). Explicit values are honored; under HA an
+  # explicit value <2 fails template rendering.
+  replicas: ~
+  port: 4200
+  resources:
+    requests:
+      cpu: 1
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 512Mi
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Additional env vars applied to the maestro container. OIDC and
+  # per-integration credentials live here (LLM creds live in the database
+  # and are managed from the admin UI). Commonly-set OIDC claim-mapping
+  # vars — all optional, defaults preserve Keycloak-shaped behavior; see
+  # https://docs.cardinalhq.io/maestro/install/oidc#claim-mapping
+  #
+  # env:
+  #   - name: OIDC_ISSUER_URL
+  #     value: https://auth.example.com/realms/cardinal
+  #   - name: OIDC_AUDIENCE                   # expected `aud` claim on issued tokens
+  #     value: maestro-ui
+  #   - name: OIDC_CLIENT_ID                   # OAuth client_id the SPA sends in authorize
+  #     value: maestro-ui                      # requests; for Okta custom auth servers this
+  #                                            # differs from OIDC_AUDIENCE. Defaults to
+  #                                            # OIDC_AUDIENCE when unset.
+  #   - name: OIDC_SUPERADMIN_EMAILS
+  #     value: admin@example.com
+  #   # Claim mapping (override only when your IdP's token shape differs from
+  #   # Keycloak defaults — e.g. Okta access tokens, Auth0, Azure AD).
+  #   - name: OIDC_EMAIL_CLAIM              # default: email
+  #     value: sub
+  #   - name: OIDC_EMAIL_VERIFIED_CLAIM     # default: email_verified
+  #     value: email_verified
+  #   - name: OIDC_DISPLAY_NAME_CLAIMS      # default: name,preferred_username,email
+  #     value: name,preferred_username,sub
+  #   - name: OIDC_GROUPS_CLAIM             # default: groups
+  #     value: groups
+  #   - name: OIDC_EXTERNAL_ID_CLAIM        # default: sub — persistent account key;
+  #     value: uid                          # changing on a live install is a migration event
+  #   - name: OIDC_TRUST_UNVERIFIED_EMAILS  # default: false — pair carefully with a
+  #     value: "true"                       # remapped OIDC_EMAIL_CLAIM (see docs)
+  env: []
+  extraVolumes: []       # additional volumes
+  extraVolumeMounts: []  # additional volume mounts
+
+  # Optional in-pod TLS termination. When enabled, the chart adds an
+  # nginx-unprivileged sidecar that listens on `tls.port` with a
+  # certificate from one of two sources, and the maestro Service exposes
+  # both the HTTP port (still cluster-internal) and the new HTTPS port.
+  # Use this when the consumer requires HTTPS but no Ingress controller
+  # is doing TLS termination — for example a POC bastion port-forward
+  # against the maestro Service. The maestro container itself keeps
+  # speaking plain HTTP on localhost; the sidecar terminates TLS and
+  # proxies to it.
+  #
+  # The chart fails template rendering when tls.enabled=true unless
+  # `maestro.baseUrl` (or the derived ingress.host+ingress.tls combo)
+  # uses https://, so the OIDC URLs the SPA hands to the browser match
+  # the actual scheme served.
+  tls:
+    enabled: false
+    # Container port the sidecar listens on. The maestro Service exposes
+    # this as `https`. Operators typically port-forward this port.
+    port: 4443
+    # Sidecar image. Overridable for air-gapped registries.
+    image:
+      repository: nginxinc/nginx-unprivileged
+      tag: "1.31-alpine"
+      pullPolicy: IfNotPresent
+    # Additional resources for the sidecar.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    # Certificate source — pick exactly one of three paths. The chart
+    # fails rendering if more than one is configured, or if none is.
+    #   1. cert.autoGenerate=true (default) — in-pod self-signed
+    #   2. secretName — reference an existing kubernetes.io/tls Secret
+    #   3. cert.crt + cert.key — inline PEM, chart creates the Secret
+    cert:
+      # When true and both `secretName` and `cert.crt`/`cert.key` are
+      # empty, an init container generates a self-signed cert into an
+      # emptyDir at pod start. The cert regenerates on every pod
+      # restart, so browsers re-prompt for trust each time — fine for
+      # POC, swap to one of the two BYO paths below for stable certs.
+      autoGenerate: true
+      # Extra Subject Alternative Names beyond the host extracted from
+      # `maestro.baseUrl`. Used only by the autoGenerate path.
+      sans: []
+      # Image used by the cert-init container. openssl CLI is the only
+      # requirement. Pinned to an immutable digest (SP5): the previous
+      # cgr.dev/chainguard/openssl:latest is a mutable floating tag, is not
+      # anonymously pullable, and is distroless (no /bin/sh — but the tls-init
+      # container overrides command: ["/bin/sh","-c"]). alpine/openssl is
+      # publicly pullable, Alpine-based (has /bin/sh), and ships the openssl CLI.
+      # Digest resolved via `crane digest alpine/openssl:3.5.6` (2026-06-06) and
+      # mirrors the server default in
+      # packages/maestro/src/lib/maestro-workload-config.ts.
+      image:
+        repository: alpine/openssl
+        tag: "3.5.6@sha256:87adbe7a8c904b825b9068d5a4060799b1e8280c67a64684f72cef376f627a46"
+        pullPolicy: IfNotPresent
+      # Inline-provided PEM certificate and private key. When both are
+      # non-empty, the chart creates a kubernetes.io/tls Secret named
+      # "<release>-maestro-tls-cert" and the sidecar mounts it. Mutually
+      # exclusive with autoGenerate=true and secretName. Set
+      # `cert.autoGenerate: false` when using this path.
+      #
+      # Generate a matching pair for an IP-only deployment with the
+      # bundled scripts/gen-tls-cert.sh helper, then feed the files
+      # in via `helm --set-file`:
+      #   helm install ... \
+      #     --set maestro.tls.cert.autoGenerate=false \
+      #     --set-file maestro.tls.cert.crt=tls.crt \
+      #     --set-file maestro.tls.cert.key=tls.key
+      crt: ""
+      key: ""
+    # Reference an existing kubernetes.io/tls Secret instead of
+    # generating one or providing inline PEM. Mutually exclusive with
+    # cert.autoGenerate=true and cert.crt/cert.key.
+    # secretName: ""
+
+  # Persistent storage for ephemeral working data: orchestra artifact
+  # payloads (per-run subdirs) and ontology git checkouts. Off by default
+  # — when enabled, mounts a PVC at `mountPath` and sets the env vars
+  # ORCHESTRA_ARTIFACT_DIR and ONTOLOGY_WORKSPACE_DIR so maestro routes
+  # both into the volume. Recommended for SaaS deployments where memory
+  # budgets are tight; not required for small/dev installs (orchestra
+  # falls back to its in-memory artifact store).
+  persistence:
+    enabled: false
+    size: 5Gi
+    accessMode: ReadWriteOnce
+    # storageClass: ""    # leave empty to use the cluster default
+    mountPath: /var/lib/maestro
+    # SELinux MCS level pinned across pod restarts. Without a stable level,
+    # each new pod gets random MCS categories and cannot read files written
+    # by a previous pod (EACCES). The actual values are arbitrary as long as
+    # they're consistent — pick anything two-category and stick with it.
+    # Override only if it conflicts with another workload sharing the
+    # cluster's MCS namespace.
+    seLinuxLevel: "s0:c100,c200"
+
+# MCP Gateway configuration.
+#
+# mcp-gateway runs as a native sidecar (initContainer with restartPolicy:
+# Always, GA in k8s 1.29+) in every maestro stack pod — maestro itself,
+# the github-cache StatefulSet pods, and the github-cache-provisioner.
+# Each pod's main container talks to the gateway over loopback, so every
+# MCP session lives entirely within one pod. This sidesteps the
+# "session not found" error stateful MCP drivers would otherwise hit
+# under round-robin Service routing (conductor#838).
+#
+# Because the sidecar topology eliminates the standalone Deployment,
+# `mcpGateway.replicas` no longer exists.
+mcpGateway:
+  port: 8080
+  debugPort: 9090
+  apiKey: ""
+  # External ClusterIP Service in front of the sidecar. Off by default
+  # so the gateway stays pod-local in self-hosted installs. SaaS
+  # operators who terminate TLS at an Ingress/IngressRoute and gate the
+  # endpoint with an API key flip this on. Maestro itself always reaches
+  # the sidecar via localhost; this Service is only for external traffic.
+  service:
+    enabled: false
+  # Alternative to plaintext `apiKey`: source MCP_API_KEY from an
+  # existing Secret. When `apiKey` is set it wins; otherwise the sidecar
+  # emits a secretKeyRef. Leave both empty for unauthenticated local dev.
+  apiKeySecret:
+    name: ""
+    key: "MCP_API_KEY"
+  # Resources for the sidecar container. CPU is generously over-provisioned
+  # at the default request (1 CPU) given observed steady-state usage of
+  # 1-2 millicores; operators tight on node capacity can drop the request
+  # to ~100m without touching the limit. Memory keeps the standalone default
+  # since steady-state observed ranges 25-110 MiB across deployments.
+  resources:
+    requests:
+      cpu: 1
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 512Mi
+  # Additional env vars applied to every mcp-gateway sidecar.
+  env: []
+
+# GitHub Cache Service (split mode).
+#
+# When enabled, the per-tenant VCS repo mirror cache + git code-search/read
+# tools and the ontology poller/provisioner run as their own pods instead of
+# in-process inside maestro. Maestro then runs as a pure client
+# (GITHUB_CACHE_REMOTE=1): it holds no repo bytes and routes every git tool call
+# to a serving replica via the Postgres placement directory, with failover.
+#
+# Default enablement is auto-derived from ha.enabled (see `enabled:` below).
+#
+# Two roles, both off the unified image:
+#   - serving (`github-cache`): a StatefulSet; each pod owns a stable RWO PVC
+#     holding its bare mirrors and answers MCP-over-HTTP. A headless Service
+#     gives each pod stable per-pod DNS so the directory can address it directly.
+#   - provisioner (`github-cache-provisioner`): a singleton Deployment that runs
+#     the ontology poller + dead-row sweeper (guarded by a persisted lease).
+#     Required whenever split mode is on — in remote mode maestro disables its
+#     in-process poller, so without this pod ontology refresh stops.
+#
+# Leave `enabled` unset (null) to auto-derive from ha.enabled — split mode
+# is the right shape for HA (it's the only multi-pod-safe topology), and
+# in-process is the right shape for POC. Explicitly setting `true` or
+# `false` is honored; pairing `ha.enabled=true` with explicit
+# `githubCache.enabled=false` fails template rendering.
+#
+# NOTE: split mode provisions one RWO PVC per serving replica. The cluster
+# therefore needs a default StorageClass (or serving.persistence.storageClass
+# set) — without dynamic provisioning the serving pods stay Pending.
+githubCache:
+  enabled: ~
+
+  # Serving replicas — the mirror cache + git tool hosts.
+  serving:
+    replicas: 2
+    port: 4300
+    # Per-pod mirror storage. Each StatefulSet pod is the sole writer to its
+    # own RWO volume (volumeClaimTemplate), so a restart re-attaches a warm
+    # disk → delta-fetch instead of a full re-clone.
+    persistence:
+      size: 10Gi
+      accessMode: ReadWriteOnce
+      # storageClass: ""   # leave empty to use the cluster default
+      mountPath: /var/lib/github-cache
+      # SELinux MCS level pinned across pod restarts so a re-attached PVC's
+      # mirror bytes stay readable (same rationale as maestro.persistence).
+      seLinuxLevel: "s0:c100,c200"
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  # Ontology poller + sweeper singleton. Holds no mirror PVC.
+  provisioner:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  # Optional override of the per-replica disk-budget LRU ceiling (bytes).
+  # Leave empty to use the service default (10 GiB), which matches the
+  # serving PVC size above.
+  diskBudgetBytes: ""
+
+  # Additional env vars applied to both the serving and provisioner containers.
+  env: []
+
+# (License configuration is shared — see the single top-level `license:` block
+# above, merged from both charts. The maestro license helpers are repointed at
+# that shared secret so only one license Secret renders.)
+
+# Maestro database configuration.
+# NOTE (unified-chart deviation): the legacy maestro chart used a top-level
+# `database:` with a FLAT shape (host/port/name/...). That collides with the
+# lakerunner `database:` which is nested under `.lrdb`. The two schemas are
+# incompatible (both also read flat secretName/create/passwordKey with different
+# values), so maestro's DB config is namespaced here as `maestroDatabase:` and
+# the maestro.* helpers are repointed at it. Rendered output is unchanged.
+# Required.
+maestroDatabase:
+  secretName: "pg-credentials"
+  # Whether to create the database credentials secret.
+  # Set to false to use an existing secret (BYOS).
+  create: true
+  # Key name for password in the secret
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  # PostgreSQL hostname.
+  # Required.
+  host: ""
+  # PostgreSQL port.
+  port: 5432
+  # PostgreSQL database name.
+  name: "maestro"
+  # PostgreSQL username.
+  username: "maestro"
+  # PostgreSQL password (only used when create: true).
+  password: ""
+  # SSL mode for PostgreSQL connection.
+  sslMode: "require"
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls: []
+
+# Bundled Dex OIDC provider. Most fields are kept out of this file on purpose
+# so that `--set dex.enabled=true` is enough to turn it on — defaults live in
+# templates/_helpers.tpl (maestro.dexConfig) and inline `dig` in the dex
+# templates. `resources` is surfaced here so operators can tune CPU/memory
+# without chasing template internals.
+dex:
+  # Dex container image. Defaults are also defined in templates/_helpers.tpl
+  # (maestro.dexConfig) so `--set dex.enabled=true` keeps working with
+  # zero extra fields. Surfaced here so air-gapped/private-registry
+  # installs can override without chasing template internals.
+  # image:
+  #   repository: ghcr.io/dexidp/dex
+  #   tag: v2.41.1
+  #   pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  # When dex.enabled is true, also have the maestro container expose
+  # /<dex.pathPrefix> as a reverse proxy to the in-cluster Dex Service.
+  # This lets the SPA's OIDC flow complete through any path that reaches
+  # the maestro Service alone — for example a POC bastion port-forward
+  # against svc/<release>-maestro — without an Ingress controller doing
+  # /dex path-routing. Harmless when an Ingress is also routing /dex
+  # directly: the Ingress path-match wins and the in-pod proxy is never
+  # exercised. Set to false to opt out (env vars are not emitted; the
+  # maestro pod returns 404 for /<pathPrefix>/* and an Ingress is
+  # required for the OIDC flow to work).
+  # proxyEnabled: true
+  #
+  # Extra redirect URIs to whitelist on the maestro-ui Dex client, in
+  # addition to the canonical "<baseUrl>/" the chart always registers.
+  # Use this for non-prod origins that complete the same OIDC PKCE flow —
+  # e.g. a local Vite dev server (`ui-vite-dev`) pointed at this backend,
+  # which sends redirect_uri = http://localhost:5173/. Leave empty ([])
+  # in prod so only the real base URL is accepted.
+  # extraRedirectURIs:
+  #   - http://localhost:5173/
+  #
+  # CORS origins Dex allows on its own HTTP endpoints (discovery, token,
+  # keys). Needed when a browser SPA served from a DIFFERENT origin than
+  # the maestro backend completes OIDC against the bundled Dex — e.g. a
+  # local Vite dev server (`ui-vite-dev`) at http://localhost:5173, which
+  # fetches /dex/.well-known/openid-configuration cross-origin. maestro's
+  # CORS middleware covers /api but not the /dex reverse-proxy, so Dex must
+  # allow the origin itself. Values are origins (scheme+host[:port], no
+  # path/trailing slash) — the redirect counterpart is extraRedirectURIs.
+  # Leave empty ([]) in prod (SPA is same-origin with maestro).
+  # allowedOrigins:
+  #   - http://localhost:5173

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -1227,3 +1227,31 @@ dex:
   # Leave empty ([]) in prod (SPA is same-origin with maestro).
   # allowedOrigins:
   #   - http://localhost:5173
+
+# Fresh-install bootstrap. On a fresh install the chart seeds a shared admin key
+# and Maestro provisions a shared LakeRunner org at boot. On adoption set
+# mode: never (sub-project C adds full auto-detection).
+bootstrap:
+  # auto = run the fresh-install bootstrap (seed key + render MAESTRO_BOOTSTRAP_*).
+  # never = skip everything (adopt: point at existing external DB/store, no provisioning).
+  # force = same as auto (reserved; C differentiates auto vs force via detection).
+  mode: auto
+  # The shared org Maestro provisions and that telemetry is attributed to.
+  org:
+    id: ""                 # UUID; REQUIRED when mode!=never. e.g. 11111111-1111-1111-1111-111111111111
+    name: "default"
+    ownerEmail: ""         # REQUIRED when mode!=never
+  # Admin key shared by admin-api (validated from configdb) and Maestro.
+  adminKey:
+    # When set, use this existing Secret instead of generating one (sealed-secrets/GitOps).
+    existingSecret: ""
+    existingSecretKey: "admin-api-key"
+  # Bucket coordinates Maestro provisions for the shared org. Mirror the object store.
+  bucket:
+    name: ""               # REQUIRED when mode!=never
+    region: "us-east-1"
+    cloudProvider: "aws"   # aws|gcp|azure
+    collectorName: "default"
+    endpoint: ""           # S3-compatible endpoint (rustfs/minio)
+    usePathStyle: false
+    insecureTls: false

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -364,7 +364,7 @@ setup:
   enabled: true
   replicas: 1
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:
@@ -403,7 +403,7 @@ processLogs:
   enabled: true
   replicas: 1
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:
@@ -437,7 +437,7 @@ processMetrics:
   enabled: true
   replicas: 1
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:
@@ -471,7 +471,7 @@ processTraces:
   enabled: true
   replicas: 1
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:
@@ -511,7 +511,7 @@ processTraces:
 controlPlane:
   replicas: 1 # singleton; not intended to scale
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   # pprof debug server. The four containers share the pod network namespace, so
@@ -605,7 +605,7 @@ pubsub:
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
     image:
-      repository: ghcr.io/cardinalhq/lakerunner
+      repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
       tag: ""
       pullPolicy: ""
     resources:
@@ -629,7 +629,7 @@ pubsub:
     region: ""
     roleARN: ""
     image:
-      repository: ghcr.io/cardinalhq/lakerunner
+      repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
       tag: ""
       pullPolicy: ""
     resources:
@@ -652,7 +652,7 @@ pubsub:
     # Example: "my-subscription"
     subscriptionID: ""
     image:
-      repository: ghcr.io/cardinalhq/lakerunner
+      repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
       tag: ""
       pullPolicy: ""
     resources:
@@ -676,7 +676,7 @@ pubsub:
     # Example: "sqs"
     queueName: ""
     image:
-      repository: ghcr.io/cardinalhq/lakerunner
+      repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
       tag: ""
       pullPolicy: ""
     resources:
@@ -703,7 +703,7 @@ queryApi:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:
@@ -730,7 +730,7 @@ queryWorker:
   enabled: true
   replicas: 2
   image:
-    repository: ghcr.io/cardinalhq/lakerunner
+    repository: public.ecr.aws/cardinalhq.io/lakerunner # ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate
     tag: ""
     pullPolicy: ""
   resources:

--- a/docs/conductor-migration-guide.md
+++ b/docs/conductor-migration-guide.md
@@ -1,0 +1,192 @@
+# Migrating a split LakeRunner + Maestro install to the unified `conductor` chart
+
+This runbook covers adopting an existing, separately-installed `lakerunner` +
+`maestro` deployment into a single `conductor` release **without provisioning or
+clobbering any existing data**.
+
+`conductor` bundles LakeRunner and Maestro into one chart. When you point a new
+`conductor` release at the **same external Postgres and object store** your split
+install already uses, the data is preserved — only the Kubernetes resource names
+and rebuildable caches change.
+
+> **Golden rule:** adopt with `bootstrap.mode: adopt`. In `adopt` mode conductor
+> renders **no** bootstrap (no detection Job, no admin-key seed Job, no anchor
+> Secret, and **no** `MAESTRO_BOOTSTRAP_*` env on the Maestro deployment). It
+> simply points at the existing external DB/store and provisions nothing.
+
+---
+
+## 1. Prerequisites
+
+1. **Back up Postgres.** Take a logical dump (`pg_dump`) of both the LakeRunner
+   config database and the Maestro database before doing anything. Adoption does
+   not write to these DBs, but a backup is your rollback safety net.
+2. **Back up (or snapshot) the object store.** The S3/MinIO/rustfs bucket holding
+   your lake data is the source of truth for telemetry; it is referenced, not
+   recreated, by conductor.
+3. **Confirm `pgvector` is available on the Maestro database.** Maestro requires
+   the `vector` extension. Verify with:
+   ```sql
+   SELECT extname FROM pg_extension WHERE extname = 'vector';
+   ```
+   If absent, install it (`CREATE EXTENSION vector;`) on the Maestro DB before
+   adopting.
+4. **Have the suite license secret ready.** conductor uses a single license
+   (`cardinal-license`) for both the LakeRunner and Maestro halves. Either supply
+   the raw `license.json` via `license.create: true` + `license.data`, or
+   pre-create the secret and set `license.create: false` +
+   `license.secretName: cardinal-license`.
+5. **Know your current external DB + object-store coordinates** (hosts, ports,
+   database names, users, password secrets, bucket, endpoint).
+
+---
+
+## 2. Values mapping (split charts → conductor)
+
+Most LakeRunner keys carry over unchanged. The biggest change is that the Maestro
+chart's top-level `database:` block becomes conductor's **`maestroDatabase:`** so
+it does not collide with LakeRunner's databases.
+
+| Legacy location | Conductor key | Notes |
+|---|---|---|
+| `lakerunner` `database:` (LRDB) | `database:` | unchanged |
+| `lakerunner` `configdb:` (config DB) | `configdb:` | unchanged |
+| `lakerunner` `storageProfiles:` | `storageProfiles:` | unchanged; keep the same org/bucket rows |
+| `lakerunner` `apiKeys:` | `apiKeys:` | unchanged; keep existing org keys |
+| `lakerunner` object-store keys (bucket / endpoint / region / credentials) | same keys | point at the **same** bucket/endpoint |
+| **`maestro` `database:`** | **`maestroDatabase:`** | **renamed** — host/port/name/username/password/sslMode/secretName/passwordKey |
+| `lakerunner` `cardinalApiKey` / license secret | `license:` (`cardinal-license`) | one license for the whole suite |
+| `maestro` license secret | `license:` (`cardinal-license`) | folded into the same single `license:` |
+
+Maestro-specific feature config (Dex/OIDC, github-cache, mcp-gateway, etc.) maps
+to the corresponding conductor `maestro.*` / top-level keys; see
+`conductor/values.yaml` for the full surface.
+
+### Example `adopt-values.yaml`
+
+```yaml
+bootstrap:
+  mode: adopt            # <-- adopt an existing install; provision nothing
+
+# LakeRunner config DB (same external Postgres as the split install)
+configdb:
+  lrdb:
+    host: postgres.db.svc
+    port: 5432
+    name: config
+    username: config
+    sslMode: require
+  # password via existing secret or configdb.lrdb.password
+
+# LakeRunner LRDB
+database:
+  lrdb:
+    host: postgres.db.svc
+    port: 5432
+    name: lrdb
+    username: lakerunner
+    sslMode: require
+
+# Maestro DB — was the maestro chart's top-level `database:`
+maestroDatabase:
+  host: postgres.db.svc
+  port: 5432
+  name: maestro
+  username: maestro
+  sslMode: require
+  secretName: pg-credentials
+  passwordKey: MAESTRO_DB_PASSWORD
+
+# One license for the whole suite
+license:
+  create: false
+  secretName: cardinal-license
+
+# Object store + org config — keep identical to the split install
+storageProfiles:
+  yaml:
+    - organization_id: 22222222-2222-2222-2222-222222222222
+      instance_num: 1
+      collector_name: "kubepi"
+      cloud_provider: "aws"
+      region: "us-east-2"
+      bucket: "your-existing-bucket"
+      endpoint: ""
+      use_path_style: true
+apiKeys:
+  # keep your existing org API keys
+```
+
+---
+
+## 3. Migration steps
+
+1. **Uninstall the legacy LakeRunner release** (Helm only removes the chart's
+   Kubernetes objects; the external Postgres + object store are untouched):
+   ```bash
+   helm uninstall <lr-release> -n <namespace>
+   ```
+2. **Uninstall the legacy Maestro release:**
+   ```bash
+   helm uninstall <maestro-release> -n <namespace>
+   ```
+3. **Install conductor in `adopt` mode**, pointed at the **same** external
+   Postgres + object store:
+   ```bash
+   helm install conductor ./conductor -n <namespace> -f adopt-values.yaml
+   ```
+   Wait for the rollout (`kubectl -n <namespace> rollout status ...`).
+
+Because `mode: adopt` renders no bootstrap, conductor will not seed an admin key,
+will not create a shared LakeRunner deployment in Maestro, and will not run the
+detection Job — it just attaches to your existing data.
+
+---
+
+## 4. What changes after adoption
+
+- **Resource names get a new prefix.** Objects are renamed to
+  `<release>-lakerunner-*` and `<release>-maestro-*` (the new release name,
+  e.g. `conductor-lakerunner-query-api`). This is expected — Helm tracks the new
+  release; the old per-chart names are gone.
+- **Caches cold-start (no data loss).** The Maestro `github-cache` StatefulSet
+  PVC and the Maestro `-data` PVC are **rebuildable caches**, not your telemetry.
+  Under a new release name they start empty and repopulate (github-cache
+  re-clones). Your actual data lives in the external Postgres + object store and
+  is untouched.
+- **ServiceAccounts / secrets consolidate.** The two legacy per-chart
+  ServiceAccounts and license secrets are replaced by one release-named
+  ServiceAccount and a single `cardinal-license` secret.
+
+---
+
+## 5. Keep `mode: adopt` set for the life of the adopted release
+
+Leave `bootstrap.mode: adopt` in your values for any release that adopted a
+legacy install. If you later switch that release back to `mode: auto`, the
+pre-install detection Job will inspect the DBs, see a legacy-shaped install
+(Maestro orgs / a legacy `maestro_integrations` row with no conductor shared
+deployment) and **deliberately abort the install** with `ADOPT_LEGACY` rather
+than risk creating a duplicate shared deployment. That abort is the safety net,
+not a bug — re-run with `mode: adopt`.
+
+(`mode: force` is for recovery/testing only; it bootstraps unconditionally with
+no detection safety net and can create duplicates against a populated DB. Do not
+use it to adopt.)
+
+---
+
+## 6. Rollback
+
+Adoption does not migrate or rewrite data, so rollback is straightforward:
+
+1. `helm uninstall conductor -n <namespace>` (leaves external DB + object store
+   intact).
+2. Reinstall the original split charts pointed at the **same** external Postgres
+   + object store:
+   ```bash
+   helm install <lr-release> ./lakerunner -n <namespace> -f <old-lr-values>.yaml
+   helm install <maestro-release> ./maestro -n <namespace> -f <old-maestro-values>.yaml
+   ```
+3. If anything looks wrong with the data itself, restore from the `pg_dump` /
+   object-store snapshot taken in step 1 of the Prerequisites.

--- a/docs/conductor-migration-guide.md
+++ b/docs/conductor-migration-guide.md
@@ -38,6 +38,18 @@ and rebuildable caches change.
    `license.secretName: cardinal-license`.
 5. **Know your current external DB + object-store coordinates** (hosts, ports,
    database names, users, password secrets, bucket, endpoint).
+6. **Size Postgres `max_connections` for the full unified stack.** Under one
+   release the entire LakeRunner stack's pgx connection pools run alongside
+   Maestro against the same Postgres. A modestly-sized Postgres can hit *too many
+   clients already* (SQLSTATE `53300`) — most acutely during a rolling **upgrade**,
+   when Helm/Kubernetes briefly runs roughly 2× the pods. Our live test fixture
+   uses `max_connections=400`; size yours for the combined steady-state plus
+   upgrade headroom (or front Postgres with **pgbouncer**, which is already part of
+   the LakeRunner topology). **If you use pgbouncer, the bootstrap migration Jobs
+   still need a *direct*, non-pgbouncer connection** — they take Postgres advisory
+   locks to serialize schema changes, which transaction-pooled pgbouncer does not
+   preserve. Point the migrate Jobs' DB host at Postgres directly even if the
+   workloads go through pgbouncer.
 
 ---
 

--- a/docs/conductor-migration-guide.md
+++ b/docs/conductor-migration-guide.md
@@ -163,12 +163,12 @@ detection Job — it just attaches to your existing data.
 ## 5. Keep `mode: adopt` set for the life of the adopted release
 
 Leave `bootstrap.mode: adopt` in your values for any release that adopted a
-legacy install. If you later switch that release back to `mode: auto`, the
-pre-install detection Job will inspect the DBs, see a legacy-shaped install
-(Maestro orgs / a legacy `maestro_integrations` row with no conductor shared
-deployment) and **deliberately abort the install** with `ADOPT_LEGACY` rather
-than risk creating a duplicate shared deployment. That abort is the safety net,
-not a bug — re-run with `mode: adopt`.
+legacy install. Under `auto`, any populated non-conductor state — lakerunner
+orgs/keys/buckets and/or a maestro org or lakerunner integration, with no
+conductor-owned shared deployment present — causes the pre-install detection Job
+to **abort the install** (`ADOPT_LEGACY`, or `ERROR` if only one side is
+populated) rather than risk creating a duplicate shared deployment. That abort is
+the safety net, not a bug — re-run with `mode: adopt`.
 
 (`mode: force` is for recovery/testing only; it bootstraps unconditionally with
 no detection safety net and can create duplicates against a populated DB. Do not

--- a/docs/superpowers/plans/2026-06-05-unified-chart-skeleton.md
+++ b/docs/superpowers/plans/2026-06-05-unified-chart-skeleton.md
@@ -1,0 +1,493 @@
+# Unified Chart Skeleton (Sub-project A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a single monolithic Helm chart `cardinal/` that renders the same in-scope resources as the legacy `lakerunner` + `maestro` charts combined, minus grafana/collector/perch, with one shared ServiceAccount by default.
+
+**Architecture:** Vendor both charts' templates into one chart under `templates/lakerunner/`, `templates/maestro/`, and `templates/shared/`. Keep the two namespaced helper families (`lakerunner.*`, `maestro.*`) side by side — they don't collide as template names. Decouple each family's `name` from `.Chart.Name` (pin to `"lakerunner"`/`"maestro"`) so existing resource names and selector labels are preserved and pods don't cross-select. Merge `values.yaml` into one document. No bootstrap/adoption logic in this sub-project (that's B/C).
+
+**Tech Stack:** Helm 3, Go templating. "Tests" = `helm lint` + `helm template` render-parity diffs against the legacy charts.
+
+**Chart name decision (FLAGGED):** dir/name = `cardinal`. This changes only the `helm.sh/chart` label (not a selector label) vs the legacy charts. If the user prefers a different name (e.g. eventually reclaiming `lakerunner`), change `meta name`/dir in Task 1 only.
+
+**Reference paths** (legacy charts live at repo root; the unified chart is new):
+- Legacy: `lakerunner/`, `maestro/`
+- New: `cardinal/`
+
+---
+
+## File Structure
+
+```
+cardinal/
+  Chart.yaml
+  values.yaml                       # merged from lakerunner + maestro values (dropped components removed)
+  .helmignore
+  templates/
+    _helpers-lakerunner.tpl         # copy of lakerunner/templates/_helpers.tpl + name pin + SA repoint
+    _helpers-maestro.tpl            # copy of maestro/templates/_helpers.tpl + name pin + SA repoint
+    shared/
+      serviceaccount.yaml           # ONE shared SA (replaces both legacy SAs)
+      rbac.yaml                     # union Role + RoleBinding bound to the effective SA(s)
+    lakerunner/                     # all in-scope lakerunner templates (grafana*/collector/perch* dropped)
+    maestro/                        # all maestro templates (legacy serviceaccount.yaml dropped)
+```
+
+Subdirectories under `templates/` are flattened by Helm; they exist only to avoid filename collisions and aid readability.
+
+---
+
+## Task 1: Scaffold the `cardinal` chart
+
+**Files:**
+- Create: `cardinal/Chart.yaml`
+- Create: `cardinal/.helmignore`
+
+- [ ] **Step 1: Create the chart directory and Chart.yaml**
+
+```bash
+mkdir -p cardinal/templates/shared cardinal/templates/lakerunner cardinal/templates/maestro
+```
+
+Create `cardinal/Chart.yaml`:
+
+```yaml
+apiVersion: v2
+name: cardinal
+description: Unified Helm chart for CardinalHQ LakeRunner + Maestro
+type: application
+version: "0.1.0"
+# appVersion is nominal only — component image tags are pinned per-component in values.yaml
+# (both lakerunner.* and maestro.* image helpers would otherwise default the tag to this).
+appVersion: "v1.52.0"
+keywords:
+  - lakerunner
+  - maestro
+  - logs
+  - metrics
+  - traces
+  - observability
+home: https://docs.cardinalhq.io/lakerunner
+maintainers:
+  - name: Cardinal HQ
+    email: support@cardinalhq.com
+```
+
+- [ ] **Step 2: Create .helmignore**
+
+Copy the legacy one:
+
+```bash
+cp lakerunner/.helmignore cardinal/.helmignore
+```
+
+- [ ] **Step 3: Verify the chart is recognized (empty render)**
+
+Run: `helm lint cardinal 2>&1 | head` — Expected: complains about no templates / empty values, but recognizes `cardinal` as a chart (no "Chart.yaml file is missing").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cardinal/Chart.yaml cardinal/.helmignore
+git commit -m "feat(cardinal): scaffold unified chart skeleton"
+```
+
+---
+
+## Task 2: Vendor and adapt the helper files
+
+**Files:**
+- Create: `cardinal/templates/_helpers-lakerunner.tpl` (from `lakerunner/templates/_helpers.tpl`)
+- Create: `cardinal/templates/_helpers-maestro.tpl` (from `maestro/templates/_helpers.tpl`)
+
+- [ ] **Step 1: Copy both helper files verbatim**
+
+```bash
+cp lakerunner/templates/_helpers.tpl cardinal/templates/_helpers-lakerunner.tpl
+cp maestro/templates/_helpers.tpl    cardinal/templates/_helpers-maestro.tpl
+```
+
+- [ ] **Step 2: Pin `lakerunner.name` to a fixed base (preserve names + selector identity)**
+
+In `cardinal/templates/_helpers-lakerunner.tpl`, replace the body of `lakerunner.name`:
+
+Old:
+```
+{{- define "lakerunner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+```
+New:
+```
+{{- define "lakerunner.name" -}}
+{{- default "lakerunner" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+```
+
+Also update `lakerunner.fullname`'s `$name` default (same file): change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "lakerunner" .Values.nameOverride }}`.
+
+- [ ] **Step 3: Pin `maestro.name` to a fixed base**
+
+In `cardinal/templates/_helpers-maestro.tpl`, replace the body of `maestro.name`:
+
+Old:
+```
+{{- define "maestro.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+```
+New:
+```
+{{- define "maestro.name" -}}
+{{- default "maestro" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+```
+
+Also update `maestro.fullname`'s `$name` default: change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "maestro" .Values.nameOverride }}`.
+
+> Note: `nameOverride`/`fullnameOverride` are now ambiguous across two families. The merged values.yaml (Task 6) sets neither; leaving them unset yields `<release>-lakerunner` / `<release>-maestro`. Per-component renaming, if ever needed, is a follow-up — not in scope for the skeleton.
+
+- [ ] **Step 4: Verify the helper files parse**
+
+Run: `helm template t cardinal --show-only templates/_helpers-lakerunner.tpl 2>&1 | head` — Expected: no parse error (renders nothing, since it's only defines). A "could not find template" message is fine; a YAML/parse error is not.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cardinal/templates/_helpers-lakerunner.tpl cardinal/templates/_helpers-maestro.tpl
+git commit -m "feat(cardinal): vendor helper families, pin name bases to preserve identity"
+```
+
+---
+
+## Task 3: Single shared ServiceAccount + RBAC
+
+**Files:**
+- Create: `cardinal/templates/shared/serviceaccount.yaml`
+- Create: `cardinal/templates/shared/rbac.yaml`
+- Modify: `cardinal/templates/_helpers-lakerunner.tpl` (repoint `lakerunner.serviceAccountName`)
+- Modify: `cardinal/templates/_helpers-maestro.tpl` (repoint `maestro.serviceAccountName`)
+
+- [ ] **Step 1: Add a shared SA-name helper to the lakerunner helper file**
+
+Append to `cardinal/templates/_helpers-lakerunner.tpl`:
+
+```
+{{/*
+Shared ServiceAccount name for the unified chart. Single SA by default;
+override with .Values.serviceAccount.name. Per-component SAs (least-privilege)
+are a future opt-in — for the skeleton, every workload uses this one SA.
+*/}}
+{{- define "cardinal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (printf "%s-cardinal" .Release.Name | trunc 63 | trimSuffix "-") .Values.serviceAccount.name -}}
+{{- else -}}
+{{- .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end }}
+```
+
+- [ ] **Step 2: Repoint both family SA helpers at the shared one**
+
+In `cardinal/templates/_helpers-lakerunner.tpl`, replace the `lakerunner.serviceAccountName` body to delegate:
+```
+{{- define "lakerunner.serviceAccountName" -}}
+{{- include "cardinal.serviceAccountName" . -}}
+{{- end }}
+```
+
+In `cardinal/templates/_helpers-maestro.tpl`, replace the `maestro.serviceAccountName` body to delegate:
+```
+{{- define "maestro.serviceAccountName" -}}
+{{- include "cardinal.serviceAccountName" . -}}
+{{- end }}
+```
+
+- [ ] **Step 3: Create the shared ServiceAccount template**
+
+Create `cardinal/templates/shared/serviceaccount.yaml`:
+```yaml
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cardinal.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+```
+
+- [ ] **Step 4: Create the union Role + RoleBinding**
+
+Inspect the legacy lakerunner Role (`lakerunner/templates/role.yaml`) and any maestro RBAC. Create `cardinal/templates/shared/rbac.yaml` as the union of their rules bound to `cardinal.serviceAccountName`. Use the legacy `lakerunner/templates/role.yaml` rules verbatim as the base (maestro had no Role of its own — confirm with `ls maestro/templates | grep -i role`; if none, the lakerunner rules are the complete union):
+
+```yaml
+{{- if .Values.serviceAccount.create -}}
+{{- /* Base: copy the exact rules block from lakerunner/templates/role.yaml */ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cardinal.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+rules:
+  # <-- paste the rules: list from lakerunner/templates/role.yaml here, verbatim -->
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cardinal.serviceAccountName" . }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cardinal.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cardinal.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+```
+
+(Before writing, run `cat lakerunner/templates/role.yaml` and paste its actual `rules:` content into the placeholder comment — the plan author has not inlined it because the executing engineer must copy the current rules verbatim.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cardinal/templates/_helpers-lakerunner.tpl cardinal/templates/_helpers-maestro.tpl cardinal/templates/shared/
+git commit -m "feat(cardinal): single shared ServiceAccount + union RBAC"
+```
+
+---
+
+## Task 4: Copy in-scope lakerunner templates (drop grafana/collector/perch)
+
+**Files:**
+- Create: `cardinal/templates/lakerunner/*.yaml` (in-scope subset)
+
+- [ ] **Step 1: Copy every lakerunner template except dropped ones, helpers, and the replaced SA/role**
+
+```bash
+for f in lakerunner/templates/*.yaml; do
+  base=$(basename "$f")
+  case "$base" in
+    grafana-*.yaml|collector.yaml|perch-*.yaml|serviceaccount.yaml|role.yaml) ;; # DROP / replaced
+    *) cp "$f" "cardinal/templates/lakerunner/$base" ;;
+  esac
+done
+ls cardinal/templates/lakerunner/
+```
+
+Expected `ls` output excludes: `grafana-datasources-configmap.yaml`, `grafana-deployment.yaml`, `grafana-service.yaml`, `collector.yaml`, `perch-clusterrole.yaml`, `perch-collectors-clusterrole.yaml`, `perch-collectors-role.yaml`, `perch-configmap.yaml`, `perch-deployment.yaml`, `serviceaccount.yaml`, `role.yaml`.
+
+- [ ] **Step 2: Check for references to dropped components**
+
+Run: `grep -rn "perch\|grafana\|collector" cardinal/templates/lakerunner/ | grep -v "#"` — Expected: no functional references (e.g. no `perch.enabled` gating left in copied files that breaks rendering). If a copied template references perch/grafana/collector values, note it; those values still exist in Task 6's values until explicitly removed. Resolve only hard render breaks here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cardinal/templates/lakerunner/
+git commit -m "feat(cardinal): add in-scope lakerunner templates (drop grafana/collector/perch)"
+```
+
+---
+
+## Task 5: Copy maestro templates
+
+**Files:**
+- Create: `cardinal/templates/maestro/*.yaml` and `NOTES.txt`
+
+- [ ] **Step 1: Copy every maestro template except helpers and the replaced SA**
+
+```bash
+for f in maestro/templates/*.yaml; do
+  base=$(basename "$f")
+  case "$base" in
+    serviceaccount.yaml) ;; # replaced by shared SA
+    *) cp "$f" "cardinal/templates/maestro/$base" ;;
+  esac
+done
+cp maestro/templates/NOTES.txt cardinal/templates/NOTES.txt
+ls cardinal/templates/maestro/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cardinal/templates/maestro/ cardinal/templates/NOTES.txt
+git commit -m "feat(cardinal): add maestro templates (drop legacy SA)"
+```
+
+---
+
+## Task 6: Build the merged values.yaml
+
+**Files:**
+- Create: `cardinal/values.yaml`
+
+- [ ] **Step 1: Concatenate the two values files as a starting point**
+
+```bash
+{ echo '# Unified cardinal chart values (merged from lakerunner + maestro)'; \
+  echo '# === lakerunner ==='; cat lakerunner/values.yaml; \
+  echo; echo '# === maestro ==='; cat maestro/values.yaml; } > cardinal/values.yaml
+```
+
+- [ ] **Step 2: Resolve the two `global:` blocks and `serviceAccount:` blocks into one each**
+
+Both charts define top-level `global:` and `serviceAccount:`. YAML last-key-wins would silently drop the first. Manually merge so there is exactly ONE `global:` (union of lakerunner + maestro global keys) and ONE `serviceAccount:` block:
+
+```yaml
+serviceAccount:
+  create: true
+  name: ""        # empty → cardinal.serviceAccountName derives "<release>-cardinal"
+  annotations: {}
+```
+
+Remove the now-duplicate second `global:`/`serviceAccount:`/`nameOverride`/`fullnameOverride` keys. Verify only one of each remains:
+
+Run: `grep -nE '^(global|serviceAccount|nameOverride|fullnameOverride):' cardinal/values.yaml` — Expected: exactly one line per key.
+
+- [ ] **Step 3: Remove values for dropped components**
+
+Delete the `grafana:`, `collector:`, and `perch:` top-level blocks from `cardinal/values.yaml`.
+
+Run: `grep -nE '^(grafana|collector|perch):' cardinal/values.yaml` — Expected: no output.
+
+- [ ] **Step 4: Pin per-component image tags (do not rely on appVersion)**
+
+Set explicit tags so each component image matches its legacy default. Read the legacy effective tags first:
+
+```bash
+helm template lr lakerunner | grep -m1 'image:.*lakerunner'
+helm template ms maestro     | grep -m1 'image:.*maestro'
+```
+
+In `cardinal/values.yaml`, set the lakerunner image tag (e.g. under `global.image.tag` or `setup.image.tag` etc. as the legacy chart expects) and `image.tag` (maestro's top-level image block) to the versions observed above, instead of leaving them empty (empty → defaults to the single `Chart.appVersion`, which is wrong for one of the two).
+
+- [ ] **Step 5: Lint**
+
+Run: `helm lint cardinal` — Expected: `1 chart(s) linted, 0 chart(s) failed`. Fix any template errors surfaced (most likely a stray reference to a removed value).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cardinal/values.yaml
+git commit -m "feat(cardinal): merged values (one global/SA, drop grafana/collector/perch, pin image tags)"
+```
+
+---
+
+## Task 7: Render-parity verification against the legacy charts
+
+**Files:**
+- Create: `cardinal/tests/render-parity.sh`
+
+- [ ] **Step 1: Write the parity script**
+
+Create `cardinal/tests/render-parity.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Renders legacy lakerunner+maestro and the unified cardinal chart with equivalent
+# values, normalizes incidental differences (helm.sh/chart label, release name),
+# and diffs the resulting resource sets. Exit 0 == parity (modulo dropped components).
+set -euo pipefail
+REL="cardinal-test"
+OUT=$(mktemp -d)
+
+# Provide equivalent minimal values for all three renders via these files
+LR_VALUES="${1:?path to lakerunner test values}"
+MS_VALUES="${2:?path to maestro test values}"
+UNIFIED_VALUES="${3:?path to unified test values}"
+
+norm() { sed -E 's/helm\.sh\/chart: [^ ]+//; s/'"$REL"'-(lakerunner|maestro|cardinal)/REL/g'; }
+
+helm template "$REL" lakerunner -f "$LR_VALUES" | norm | yq -P 'sort_keys(..)' > "$OUT/legacy.yaml" 2>/dev/null || \
+  helm template "$REL" lakerunner -f "$LR_VALUES" | norm > "$OUT/legacy-lr.yaml"
+helm template "$REL" maestro    -f "$MS_VALUES" | norm > "$OUT/legacy-ms.yaml"
+helm template "$REL" cardinal   -f "$UNIFIED_VALUES" | norm > "$OUT/unified.yaml"
+
+echo "Rendered into $OUT — compare resource kinds/names:"
+grep -E '^(kind|  name):' "$OUT/legacy-lr.yaml" "$OUT/legacy-ms.yaml" | sort > "$OUT/legacy-index.txt"
+grep -E '^(kind|  name):' "$OUT/unified.yaml" | sort > "$OUT/unified-index.txt"
+diff "$OUT/legacy-index.txt" "$OUT/unified-index.txt" || true
+echo "Dropped-on-purpose (expected only on legacy side): grafana, collector, perch"
+```
+
+```bash
+chmod +x cardinal/tests/render-parity.sh
+```
+
+- [ ] **Step 2: Create minimal test values**
+
+Create `cardinal/tests/values-lakerunner.yaml`, `cardinal/tests/values-maestro.yaml`, and `cardinal/tests/values-unified.yaml` with the minimum required fields for each chart to render (DB host, object store bucket, license, base URL for maestro, etc.). Use the legacy charts' `tests/` fixtures as a reference for required fields:
+
+```bash
+ls lakerunner/tests/ maestro/tests/
+```
+
+Copy the smallest passing fixture from each legacy `tests/` dir as the basis, and build `values-unified.yaml` by merging the two (mirroring the values.yaml merge).
+
+- [ ] **Step 3: Run parity**
+
+Run: `cardinal/tests/render-parity.sh cardinal/tests/values-lakerunner.yaml cardinal/tests/values-maestro.yaml cardinal/tests/values-unified.yaml`
+
+Expected: the diff shows the unified side contains every `kind`/`name` from both legacy renders EXCEPT the dropped grafana/collector/perch resources and the two legacy ServiceAccounts (replaced by one `*-cardinal` SA). No unexpected missing or duplicate resources.
+
+- [ ] **Step 4: Resolve duplicate-resource-name conflicts**
+
+If `helm template cardinal` errors with a duplicate resource name (most likely the shared `license` Secret or `cardinal-api-key` Secret rendered by both families), dedupe: keep one definition and point the other family's `*SecretName` helper / reference at it. Re-run Step 3 until clean.
+
+Run: `helm template cardinal-test cardinal -f cardinal/tests/values-unified.yaml >/dev/null && echo OK` — Expected: `OK` (renders with no duplicate-name error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cardinal/tests/
+git commit -m "test(cardinal): render-parity harness vs legacy charts"
+```
+
+---
+
+## Task 8: Final lint + parity gate
+
+- [ ] **Step 1: Lint clean**
+
+Run: `helm lint cardinal` — Expected: `0 chart(s) failed`.
+
+- [ ] **Step 2: Render clean for both a POC and an HA values set**
+
+Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml --set ha.enabled=true >/dev/null && echo HA-OK`
+Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml >/dev/null && echo POC-OK`
+Expected: `HA-OK` (github-cache StatefulSet appears) and `POC-OK` (github-cache absent).
+
+- [ ] **Step 3: Confirm no selector cross-talk**
+
+Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml | grep -A2 'app.kubernetes.io/name:' | sort -u`
+Expected: both `app.kubernetes.io/name: lakerunner` and `app.kubernetes.io/name: maestro` present and distinct — never a single shared name across both products.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(cardinal): skeleton complete — lint clean, render parity vs legacy (A)"
+```
+
+---
+
+## Self-review notes (spec coverage)
+
+- Monolithic single chart → Tasks 1–6. ✓
+- Single shared SA, splittable later → Task 3 (`cardinal.serviceAccountName`, both families delegate). ✓
+- Drop grafana/collector/perch → Task 4 (templates) + Task 6 (values). ✓
+- Keep mcp-gateway/github-cache/dex → Task 5 (all maestro templates copied) + Task 8 HA check. ✓
+- Render parity exit criterion → Tasks 7–8. ✓
+- No bootstrap/adoption/dex-consolidation here → deferred to B/C/D by design. ✓
+- Flagged for user: chart name `cardinal` (Task 1); per-component image-tag pinning (Task 6 Step 4).

--- a/docs/superpowers/plans/2026-06-05-unified-chart-skeleton.md
+++ b/docs/superpowers/plans/2026-06-05-unified-chart-skeleton.md
@@ -2,24 +2,29 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Produce a single monolithic Helm chart `cardinal/` that renders the same in-scope resources as the legacy `lakerunner` + `maestro` charts combined, minus grafana/collector/perch, with one shared ServiceAccount by default.
+**Goal:** Produce a single monolithic Helm chart `conductor/` that renders the same in-scope resources as the legacy `lakerunner` + `maestro` charts combined, minus grafana/collector/perch, with one shared ServiceAccount by default.
 
 **Architecture:** Vendor both charts' templates into one chart under `templates/lakerunner/`, `templates/maestro/`, and `templates/shared/`. Keep the two namespaced helper families (`lakerunner.*`, `maestro.*`) side by side — they don't collide as template names. Decouple each family's `name` from `.Chart.Name` (pin to `"lakerunner"`/`"maestro"`) so existing resource names and selector labels are preserved and pods don't cross-select. Merge `values.yaml` into one document. No bootstrap/adoption logic in this sub-project (that's B/C).
 
 **Tech Stack:** Helm 3, Go templating. "Tests" = `helm lint` + `helm template` render-parity diffs against the legacy charts.
 
-**Chart name decision (FLAGGED):** dir/name = `cardinal`. This changes only the `helm.sh/chart` label (not a selector label) vs the legacy charts. If the user prefers a different name (e.g. eventually reclaiming `lakerunner`), change `meta name`/dir in Task 1 only.
+**Naming rules (per user):**
+- Chart name / dir = **`conductor`**. The chart name appears ONLY in the `helm.sh/chart` label (not a selector label) — it is deliberately NOT injected into resource names.
+- Workload/Service/etc. names stay `<release>-lakerunner-*` and `<release>-maestro-*` — the release ("named install") is the only prefix; `conductor` never appears in a resource name.
+- The single shared ServiceAccount is named after the release (`.Release.Name`), not the chart, for the same reason.
 
-**Reference paths** (legacy charts live at repo root; the unified chart is new):
-- Legacy: `lakerunner/`, `maestro/`
-- New: `cardinal/`
+**Live-copy note:** Tasks copy the current `lakerunner/` and `maestro/` template + values files verbatim, so recent image bumps (maestro nginx `1.31-alpine`, openssl `3.5.6`, etc.) are inherited automatically — do not hardcode tags.
+
+**Reference paths:**
+- Legacy: `lakerunner/`, `maestro/` (repo root)
+- New: `conductor/`
 
 ---
 
 ## File Structure
 
 ```
-cardinal/
+conductor/
   Chart.yaml
   values.yaml                       # merged from lakerunner + maestro values (dropped components removed)
   .helmignore
@@ -28,7 +33,7 @@ cardinal/
     _helpers-maestro.tpl            # copy of maestro/templates/_helpers.tpl + name pin + SA repoint
     shared/
       serviceaccount.yaml           # ONE shared SA (replaces both legacy SAs)
-      rbac.yaml                     # union Role + RoleBinding bound to the effective SA(s)
+      rbac.yaml                     # union Role + RoleBinding bound to the shared SA
     lakerunner/                     # all in-scope lakerunner templates (grafana*/collector/perch* dropped)
     maestro/                        # all maestro templates (legacy serviceaccount.yaml dropped)
 ```
@@ -37,29 +42,29 @@ Subdirectories under `templates/` are flattened by Helm; they exist only to avoi
 
 ---
 
-## Task 1: Scaffold the `cardinal` chart
+## Task 1: Scaffold the `conductor` chart
 
 **Files:**
-- Create: `cardinal/Chart.yaml`
-- Create: `cardinal/.helmignore`
+- Create: `conductor/Chart.yaml`
+- Create: `conductor/.helmignore`
 
 - [ ] **Step 1: Create the chart directory and Chart.yaml**
 
 ```bash
-mkdir -p cardinal/templates/shared cardinal/templates/lakerunner cardinal/templates/maestro
+mkdir -p conductor/templates/shared conductor/templates/lakerunner conductor/templates/maestro conductor/tests
 ```
 
-Create `cardinal/Chart.yaml`:
+Create `conductor/Chart.yaml`:
 
 ```yaml
 apiVersion: v2
-name: cardinal
+name: conductor
 description: Unified Helm chart for CardinalHQ LakeRunner + Maestro
 type: application
 version: "0.1.0"
 # appVersion is nominal only — component image tags are pinned per-component in values.yaml
 # (both lakerunner.* and maestro.* image helpers would otherwise default the tag to this).
-appVersion: "v1.52.0"
+appVersion: "v1.53.0"
 keywords:
   - lakerunner
   - maestro
@@ -75,21 +80,19 @@ maintainers:
 
 - [ ] **Step 2: Create .helmignore**
 
-Copy the legacy one:
-
 ```bash
-cp lakerunner/.helmignore cardinal/.helmignore
+cp lakerunner/.helmignore conductor/.helmignore
 ```
 
-- [ ] **Step 3: Verify the chart is recognized (empty render)**
+- [ ] **Step 3: Verify the chart is recognized**
 
-Run: `helm lint cardinal 2>&1 | head` — Expected: complains about no templates / empty values, but recognizes `cardinal` as a chart (no "Chart.yaml file is missing").
+Run: `helm lint conductor 2>&1 | head` — Expected: complaints about empty values/templates, but `conductor` is recognized as a chart (no "Chart.yaml file is missing").
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add cardinal/Chart.yaml cardinal/.helmignore
-git commit -m "feat(cardinal): scaffold unified chart skeleton"
+git add conductor/Chart.yaml conductor/.helmignore
+git commit -m "feat(conductor): scaffold unified chart skeleton"
 ```
 
 ---
@@ -97,19 +100,19 @@ git commit -m "feat(cardinal): scaffold unified chart skeleton"
 ## Task 2: Vendor and adapt the helper files
 
 **Files:**
-- Create: `cardinal/templates/_helpers-lakerunner.tpl` (from `lakerunner/templates/_helpers.tpl`)
-- Create: `cardinal/templates/_helpers-maestro.tpl` (from `maestro/templates/_helpers.tpl`)
+- Create: `conductor/templates/_helpers-lakerunner.tpl` (from `lakerunner/templates/_helpers.tpl`)
+- Create: `conductor/templates/_helpers-maestro.tpl` (from `maestro/templates/_helpers.tpl`)
 
 - [ ] **Step 1: Copy both helper files verbatim**
 
 ```bash
-cp lakerunner/templates/_helpers.tpl cardinal/templates/_helpers-lakerunner.tpl
-cp maestro/templates/_helpers.tpl    cardinal/templates/_helpers-maestro.tpl
+cp lakerunner/templates/_helpers.tpl conductor/templates/_helpers-lakerunner.tpl
+cp maestro/templates/_helpers.tpl    conductor/templates/_helpers-maestro.tpl
 ```
 
 - [ ] **Step 2: Pin `lakerunner.name` to a fixed base (preserve names + selector identity)**
 
-In `cardinal/templates/_helpers-lakerunner.tpl`, replace the body of `lakerunner.name`:
+In `conductor/templates/_helpers-lakerunner.tpl`, replace the body of `lakerunner.name`:
 
 Old:
 ```
@@ -124,11 +127,11 @@ New:
 {{- end }}
 ```
 
-Also update `lakerunner.fullname`'s `$name` default (same file): change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "lakerunner" .Values.nameOverride }}`.
+Also in `lakerunner.fullname`, change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "lakerunner" .Values.nameOverride }}`.
 
 - [ ] **Step 3: Pin `maestro.name` to a fixed base**
 
-In `cardinal/templates/_helpers-maestro.tpl`, replace the body of `maestro.name`:
+In `conductor/templates/_helpers-maestro.tpl`, replace the body of `maestro.name`:
 
 Old:
 ```
@@ -143,19 +146,19 @@ New:
 {{- end }}
 ```
 
-Also update `maestro.fullname`'s `$name` default: change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "maestro" .Values.nameOverride }}`.
+Also in `maestro.fullname`, change `{{- $name := default .Chart.Name .Values.nameOverride }}` to `{{- $name := default "maestro" .Values.nameOverride }}`.
 
-> Note: `nameOverride`/`fullnameOverride` are now ambiguous across two families. The merged values.yaml (Task 6) sets neither; leaving them unset yields `<release>-lakerunner` / `<release>-maestro`. Per-component renaming, if ever needed, is a follow-up — not in scope for the skeleton.
+> Note: a single top-level `nameOverride`/`fullnameOverride` is now ambiguous across two families; the merged values.yaml (Task 6) leaves both unset → `<release>-lakerunner` / `<release>-maestro`. Per-component renaming is a future follow-up, not in scope.
 
 - [ ] **Step 4: Verify the helper files parse**
 
-Run: `helm template t cardinal --show-only templates/_helpers-lakerunner.tpl 2>&1 | head` — Expected: no parse error (renders nothing, since it's only defines). A "could not find template" message is fine; a YAML/parse error is not.
+Run: `helm template t conductor 2>&1 | head` — Expected: errors will be about missing required values (DB host, etc.) or no resources yet, NOT a `.tpl` parse/syntax error. A template parse error must be fixed before continuing.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add cardinal/templates/_helpers-lakerunner.tpl cardinal/templates/_helpers-maestro.tpl
-git commit -m "feat(cardinal): vendor helper families, pin name bases to preserve identity"
+git add conductor/templates/_helpers-lakerunner.tpl conductor/templates/_helpers-maestro.tpl
+git commit -m "feat(conductor): vendor helper families, pin name bases to preserve identity"
 ```
 
 ---
@@ -163,24 +166,25 @@ git commit -m "feat(cardinal): vendor helper families, pin name bases to preserv
 ## Task 3: Single shared ServiceAccount + RBAC
 
 **Files:**
-- Create: `cardinal/templates/shared/serviceaccount.yaml`
-- Create: `cardinal/templates/shared/rbac.yaml`
-- Modify: `cardinal/templates/_helpers-lakerunner.tpl` (repoint `lakerunner.serviceAccountName`)
-- Modify: `cardinal/templates/_helpers-maestro.tpl` (repoint `maestro.serviceAccountName`)
+- Create: `conductor/templates/shared/serviceaccount.yaml`
+- Create: `conductor/templates/shared/rbac.yaml`
+- Modify: `conductor/templates/_helpers-lakerunner.tpl` (add shared helper + repoint `lakerunner.serviceAccountName`)
+- Modify: `conductor/templates/_helpers-maestro.tpl` (repoint `maestro.serviceAccountName`)
 
-- [ ] **Step 1: Add a shared SA-name helper to the lakerunner helper file**
+- [ ] **Step 1: Add a shared SA-name helper (release-named, no chart prefix)**
 
-Append to `cardinal/templates/_helpers-lakerunner.tpl`:
+Append to `conductor/templates/_helpers-lakerunner.tpl`:
 
 ```
 {{/*
-Shared ServiceAccount name for the unified chart. Single SA by default;
-override with .Values.serviceAccount.name. Per-component SAs (least-privilege)
-are a future opt-in — for the skeleton, every workload uses this one SA.
+Shared ServiceAccount name for the unified chart. Single SA by default, named
+after the release (the "named install") — the chart name is intentionally NOT
+injected. Override with .Values.serviceAccount.name. Per-component SAs
+(least-privilege) are a future opt-in; for the skeleton every workload uses this one.
 */}}
-{{- define "cardinal.serviceAccountName" -}}
+{{- define "conductor.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-{{- default (printf "%s-cardinal" .Release.Name | trunc 63 | trimSuffix "-") .Values.serviceAccount.name -}}
+{{- default (.Release.Name | trunc 63 | trimSuffix "-") .Values.serviceAccount.name -}}
 {{- else -}}
 {{- .Values.serviceAccount.name -}}
 {{- end -}}
@@ -189,29 +193,29 @@ are a future opt-in — for the skeleton, every workload uses this one SA.
 
 - [ ] **Step 2: Repoint both family SA helpers at the shared one**
 
-In `cardinal/templates/_helpers-lakerunner.tpl`, replace the `lakerunner.serviceAccountName` body to delegate:
+In `conductor/templates/_helpers-lakerunner.tpl`, replace the `lakerunner.serviceAccountName` body:
 ```
 {{- define "lakerunner.serviceAccountName" -}}
-{{- include "cardinal.serviceAccountName" . -}}
+{{- include "conductor.serviceAccountName" . -}}
 {{- end }}
 ```
 
-In `cardinal/templates/_helpers-maestro.tpl`, replace the `maestro.serviceAccountName` body to delegate:
+In `conductor/templates/_helpers-maestro.tpl`, replace the `maestro.serviceAccountName` body:
 ```
 {{- define "maestro.serviceAccountName" -}}
-{{- include "cardinal.serviceAccountName" . -}}
+{{- include "conductor.serviceAccountName" . -}}
 {{- end }}
 ```
 
 - [ ] **Step 3: Create the shared ServiceAccount template**
 
-Create `cardinal/templates/shared/serviceaccount.yaml`:
+Create `conductor/templates/shared/serviceaccount.yaml`:
 ```yaml
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cardinal.serviceAccountName" . }}
+  name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -223,15 +227,20 @@ metadata:
 
 - [ ] **Step 4: Create the union Role + RoleBinding**
 
-Inspect the legacy lakerunner Role (`lakerunner/templates/role.yaml`) and any maestro RBAC. Create `cardinal/templates/shared/rbac.yaml` as the union of their rules bound to `cardinal.serviceAccountName`. Use the legacy `lakerunner/templates/role.yaml` rules verbatim as the base (maestro had no Role of its own — confirm with `ls maestro/templates | grep -i role`; if none, the lakerunner rules are the complete union):
+First read the live lakerunner Role rules (maestro has no Role, so these ARE the full union):
+
+```bash
+cat lakerunner/templates/role.yaml
+```
+
+Create `conductor/templates/shared/rbac.yaml`, pasting the `rules:` content from the command above verbatim into the marked spot:
 
 ```yaml
 {{- if .Values.serviceAccount.create -}}
-{{- /* Base: copy the exact rules block from lakerunner/templates/role.yaml */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "cardinal.serviceAccountName" . }}
+  name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
 rules:
@@ -240,27 +249,27 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "cardinal.serviceAccountName" . }}
+  name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "lakerunner.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "cardinal.serviceAccountName" . }}
+  name: {{ include "conductor.serviceAccountName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "cardinal.serviceAccountName" . }}
+    name: {{ include "conductor.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 ```
 
-(Before writing, run `cat lakerunner/templates/role.yaml` and paste its actual `rules:` content into the placeholder comment — the plan author has not inlined it because the executing engineer must copy the current rules verbatim.)
+(If the legacy `role.yaml` itself wraps rules in conditionals/`if`, preserve those conditionals exactly. The intent is byte-equivalent rules.)
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add cardinal/templates/_helpers-lakerunner.tpl cardinal/templates/_helpers-maestro.tpl cardinal/templates/shared/
-git commit -m "feat(cardinal): single shared ServiceAccount + union RBAC"
+git add conductor/templates/_helpers-lakerunner.tpl conductor/templates/_helpers-maestro.tpl conductor/templates/shared/
+git commit -m "feat(conductor): single shared ServiceAccount + union RBAC (release-named)"
 ```
 
 ---
@@ -268,7 +277,7 @@ git commit -m "feat(cardinal): single shared ServiceAccount + union RBAC"
 ## Task 4: Copy in-scope lakerunner templates (drop grafana/collector/perch)
 
 **Files:**
-- Create: `cardinal/templates/lakerunner/*.yaml` (in-scope subset)
+- Create: `conductor/templates/lakerunner/*.yaml` (in-scope subset)
 
 - [ ] **Step 1: Copy every lakerunner template except dropped ones, helpers, and the replaced SA/role**
 
@@ -277,23 +286,23 @@ for f in lakerunner/templates/*.yaml; do
   base=$(basename "$f")
   case "$base" in
     grafana-*.yaml|collector.yaml|perch-*.yaml|serviceaccount.yaml|role.yaml) ;; # DROP / replaced
-    *) cp "$f" "cardinal/templates/lakerunner/$base" ;;
+    *) cp "$f" "conductor/templates/lakerunner/$base" ;;
   esac
 done
-ls cardinal/templates/lakerunner/
+ls conductor/templates/lakerunner/
 ```
 
-Expected `ls` output excludes: `grafana-datasources-configmap.yaml`, `grafana-deployment.yaml`, `grafana-service.yaml`, `collector.yaml`, `perch-clusterrole.yaml`, `perch-collectors-clusterrole.yaml`, `perch-collectors-role.yaml`, `perch-configmap.yaml`, `perch-deployment.yaml`, `serviceaccount.yaml`, `role.yaml`.
+Expected `ls` to EXCLUDE: `grafana-datasources-configmap.yaml`, `grafana-deployment.yaml`, `grafana-service.yaml`, `collector.yaml`, `perch-clusterrole.yaml`, `perch-collectors-clusterrole.yaml`, `perch-collectors-role.yaml`, `perch-configmap.yaml`, `perch-deployment.yaml`, `serviceaccount.yaml`, `role.yaml`.
 
-- [ ] **Step 2: Check for references to dropped components**
+- [ ] **Step 2: Find any references to dropped components that would break rendering**
 
-Run: `grep -rn "perch\|grafana\|collector" cardinal/templates/lakerunner/ | grep -v "#"` — Expected: no functional references (e.g. no `perch.enabled` gating left in copied files that breaks rendering). If a copied template references perch/grafana/collector values, note it; those values still exist in Task 6's values until explicitly removed. Resolve only hard render breaks here.
+Run: `grep -rln "perch\|grafana\|collector" conductor/templates/lakerunner/` — For each hit, open it and confirm it's only an incidental mention (comment/label), not a hard dependency that breaks `helm template`. Hard breaks get fixed here; dangling values are cleaned in Task 6.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add cardinal/templates/lakerunner/
-git commit -m "feat(cardinal): add in-scope lakerunner templates (drop grafana/collector/perch)"
+git add conductor/templates/lakerunner/
+git commit -m "feat(conductor): in-scope lakerunner templates (drop grafana/collector/perch)"
 ```
 
 ---
@@ -301,7 +310,7 @@ git commit -m "feat(cardinal): add in-scope lakerunner templates (drop grafana/c
 ## Task 5: Copy maestro templates
 
 **Files:**
-- Create: `cardinal/templates/maestro/*.yaml` and `NOTES.txt`
+- Create: `conductor/templates/maestro/*.yaml` and `conductor/templates/NOTES.txt`
 
 - [ ] **Step 1: Copy every maestro template except helpers and the replaced SA**
 
@@ -310,18 +319,18 @@ for f in maestro/templates/*.yaml; do
   base=$(basename "$f")
   case "$base" in
     serviceaccount.yaml) ;; # replaced by shared SA
-    *) cp "$f" "cardinal/templates/maestro/$base" ;;
+    *) cp "$f" "conductor/templates/maestro/$base" ;;
   esac
 done
-cp maestro/templates/NOTES.txt cardinal/templates/NOTES.txt
-ls cardinal/templates/maestro/
+cp maestro/templates/NOTES.txt conductor/templates/NOTES.txt
+ls conductor/templates/maestro/
 ```
 
 - [ ] **Step 2: Commit**
 
 ```bash
-git add cardinal/templates/maestro/ cardinal/templates/NOTES.txt
-git commit -m "feat(cardinal): add maestro templates (drop legacy SA)"
+git add conductor/templates/maestro/ conductor/templates/NOTES.txt
+git commit -m "feat(conductor): add maestro templates (drop legacy SA)"
 ```
 
 ---
@@ -329,57 +338,55 @@ git commit -m "feat(cardinal): add maestro templates (drop legacy SA)"
 ## Task 6: Build the merged values.yaml
 
 **Files:**
-- Create: `cardinal/values.yaml`
+- Create: `conductor/values.yaml`
 
-- [ ] **Step 1: Concatenate the two values files as a starting point**
+- [ ] **Step 1: Concatenate the two live values files as a starting point**
 
 ```bash
-{ echo '# Unified cardinal chart values (merged from lakerunner + maestro)'; \
+{ echo '# Unified conductor chart values (merged from lakerunner + maestro)'; \
   echo '# === lakerunner ==='; cat lakerunner/values.yaml; \
-  echo; echo '# === maestro ==='; cat maestro/values.yaml; } > cardinal/values.yaml
+  echo; echo '# === maestro ==='; cat maestro/values.yaml; } > conductor/values.yaml
 ```
 
-- [ ] **Step 2: Resolve the two `global:` blocks and `serviceAccount:` blocks into one each**
+- [ ] **Step 2: Collapse duplicate top-level keys into one each**
 
-Both charts define top-level `global:` and `serviceAccount:`. YAML last-key-wins would silently drop the first. Manually merge so there is exactly ONE `global:` (union of lakerunner + maestro global keys) and ONE `serviceAccount:` block:
+Both charts define top-level `global:`, `serviceAccount:`, `nameOverride`, `fullnameOverride`. YAML last-wins would silently drop the earlier copy. Manually merge so exactly ONE of each remains: one `global:` (union of both charts' global keys), and this `serviceAccount:` block:
 
 ```yaml
 serviceAccount:
   create: true
-  name: ""        # empty → cardinal.serviceAccountName derives "<release>-cardinal"
+  name: ""        # empty → conductor.serviceAccountName uses the release name
   annotations: {}
+nameOverride: ""
+fullnameOverride: ""
 ```
 
-Remove the now-duplicate second `global:`/`serviceAccount:`/`nameOverride`/`fullnameOverride` keys. Verify only one of each remains:
-
-Run: `grep -nE '^(global|serviceAccount|nameOverride|fullnameOverride):' cardinal/values.yaml` — Expected: exactly one line per key.
+Run: `grep -nE '^(global|serviceAccount|nameOverride|fullnameOverride):' conductor/values.yaml` — Expected: exactly one line per key.
 
 - [ ] **Step 3: Remove values for dropped components**
 
-Delete the `grafana:`, `collector:`, and `perch:` top-level blocks from `cardinal/values.yaml`.
+Delete the `grafana:`, `collector:`, and `perch:` top-level blocks.
 
-Run: `grep -nE '^(grafana|collector|perch):' cardinal/values.yaml` — Expected: no output.
+Run: `grep -nE '^(grafana|collector|perch):' conductor/values.yaml` — Expected: no output.
 
-- [ ] **Step 4: Pin per-component image tags (do not rely on appVersion)**
+- [ ] **Step 4: Pin per-component image tags (don't rely on the single appVersion)**
 
-Set explicit tags so each component image matches its legacy default. Read the legacy effective tags first:
-
+Read the legacy effective image tags:
 ```bash
-helm template lr lakerunner | grep -m1 'image:.*lakerunner'
-helm template ms maestro     | grep -m1 'image:.*maestro'
+helm template lr lakerunner -f lakerunner/tests/$(ls lakerunner/tests | head -1) 2>/dev/null | grep -Eo 'image: [^ ]*lakerunner[^ ]*' | sort -u
+helm template ms maestro -f maestro/tests/$(ls maestro/tests | head -1) 2>/dev/null | grep -Eo 'image: [^ ]*maestro[^ ]*' | sort -u
 ```
-
-In `cardinal/values.yaml`, set the lakerunner image tag (e.g. under `global.image.tag` or `setup.image.tag` etc. as the legacy chart expects) and `image.tag` (maestro's top-level image block) to the versions observed above, instead of leaving them empty (empty → defaults to the single `Chart.appVersion`, which is wrong for one of the two).
+In `conductor/values.yaml`, set the lakerunner component image tag(s) and maestro's top-level `image.tag` to the observed versions explicitly, so neither defaults to the single `Chart.appVersion`.
 
 - [ ] **Step 5: Lint**
 
-Run: `helm lint cardinal` — Expected: `1 chart(s) linted, 0 chart(s) failed`. Fix any template errors surfaced (most likely a stray reference to a removed value).
+Run: `helm lint conductor` — Expected: `1 chart(s) linted, 0 chart(s) failed`. Fix any stray reference to a removed value.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add cardinal/values.yaml
-git commit -m "feat(cardinal): merged values (one global/SA, drop grafana/collector/perch, pin image tags)"
+git add conductor/values.yaml
+git commit -m "feat(conductor): merged values (one global/SA, drop grafana/collector/perch, pin tags)"
 ```
 
 ---
@@ -387,97 +394,87 @@ git commit -m "feat(cardinal): merged values (one global/SA, drop grafana/collec
 ## Task 7: Render-parity verification against the legacy charts
 
 **Files:**
-- Create: `cardinal/tests/render-parity.sh`
+- Create: `conductor/tests/render-parity.sh`
+- Create: `conductor/tests/values-lakerunner.yaml`, `conductor/tests/values-maestro.yaml`, `conductor/tests/values-unified.yaml`
 
-- [ ] **Step 1: Write the parity script**
+- [ ] **Step 1: Create minimal test values**
 
-Create `cardinal/tests/render-parity.sh`:
-
-```bash
-#!/usr/bin/env bash
-# Renders legacy lakerunner+maestro and the unified cardinal chart with equivalent
-# values, normalizes incidental differences (helm.sh/chart label, release name),
-# and diffs the resulting resource sets. Exit 0 == parity (modulo dropped components).
-set -euo pipefail
-REL="cardinal-test"
-OUT=$(mktemp -d)
-
-# Provide equivalent minimal values for all three renders via these files
-LR_VALUES="${1:?path to lakerunner test values}"
-MS_VALUES="${2:?path to maestro test values}"
-UNIFIED_VALUES="${3:?path to unified test values}"
-
-norm() { sed -E 's/helm\.sh\/chart: [^ ]+//; s/'"$REL"'-(lakerunner|maestro|cardinal)/REL/g'; }
-
-helm template "$REL" lakerunner -f "$LR_VALUES" | norm | yq -P 'sort_keys(..)' > "$OUT/legacy.yaml" 2>/dev/null || \
-  helm template "$REL" lakerunner -f "$LR_VALUES" | norm > "$OUT/legacy-lr.yaml"
-helm template "$REL" maestro    -f "$MS_VALUES" | norm > "$OUT/legacy-ms.yaml"
-helm template "$REL" cardinal   -f "$UNIFIED_VALUES" | norm > "$OUT/unified.yaml"
-
-echo "Rendered into $OUT — compare resource kinds/names:"
-grep -E '^(kind|  name):' "$OUT/legacy-lr.yaml" "$OUT/legacy-ms.yaml" | sort > "$OUT/legacy-index.txt"
-grep -E '^(kind|  name):' "$OUT/unified.yaml" | sort > "$OUT/unified-index.txt"
-diff "$OUT/legacy-index.txt" "$OUT/unified-index.txt" || true
-echo "Dropped-on-purpose (expected only on legacy side): grafana, collector, perch"
-```
-
-```bash
-chmod +x cardinal/tests/render-parity.sh
-```
-
-- [ ] **Step 2: Create minimal test values**
-
-Create `cardinal/tests/values-lakerunner.yaml`, `cardinal/tests/values-maestro.yaml`, and `cardinal/tests/values-unified.yaml` with the minimum required fields for each chart to render (DB host, object store bucket, license, base URL for maestro, etc.). Use the legacy charts' `tests/` fixtures as a reference for required fields:
-
+Inspect the legacy fixtures for the minimum required fields:
 ```bash
 ls lakerunner/tests/ maestro/tests/
 ```
+Create `conductor/tests/values-lakerunner.yaml` and `conductor/tests/values-maestro.yaml` from the smallest passing legacy fixtures, and `conductor/tests/values-unified.yaml` by merging the two (mirroring the values.yaml merge: one `global`/`serviceAccount`, both products' required fields).
 
-Copy the smallest passing fixture from each legacy `tests/` dir as the basis, and build `values-unified.yaml` by merging the two (mirroring the values.yaml merge).
+- [ ] **Step 2: Write the parity script**
 
-- [ ] **Step 3: Run parity**
+Create `conductor/tests/render-parity.sh`:
+```bash
+#!/usr/bin/env bash
+# Renders legacy lakerunner+maestro and unified conductor with equivalent values,
+# normalizes incidental differences, and compares the resource (kind,name) sets.
+set -euo pipefail
+REL="conductor-test"
+OUT=$(mktemp -d)
+LR_VALUES="${1:?lakerunner test values}"; MS_VALUES="${2:?maestro test values}"; UNI_VALUES="${3:?unified test values}"
+norm() { sed -E 's#helm\.sh/chart: [^ ]+##'; }
+helm template "$REL" lakerunner -f "$LR_VALUES" | norm > "$OUT/legacy-lr.yaml"
+helm template "$REL" maestro    -f "$MS_VALUES" | norm > "$OUT/legacy-ms.yaml"
+helm template "$REL" conductor  -f "$UNI_VALUES" | norm > "$OUT/unified.yaml"
+idx() { grep -E '^(kind|  name):' "$@" | sort -u; }
+idx "$OUT/legacy-lr.yaml" "$OUT/legacy-ms.yaml" > "$OUT/legacy-index.txt"
+idx "$OUT/unified.yaml" > "$OUT/unified-index.txt"
+echo "### diff (legacy combined vs unified) — '<' only on legacy, '>' only on unified:"
+diff "$OUT/legacy-index.txt" "$OUT/unified-index.txt" || true
+echo "### Expected legacy-only ('<'): grafana, collector, perch resources + the 2 legacy ServiceAccounts."
+echo "### Expected unified-only ('>'): one release-named ServiceAccount/Role/RoleBinding."
+echo "OUT=$OUT"
+```
+```bash
+chmod +x conductor/tests/render-parity.sh
+```
 
-Run: `cardinal/tests/render-parity.sh cardinal/tests/values-lakerunner.yaml cardinal/tests/values-maestro.yaml cardinal/tests/values-unified.yaml`
+- [ ] **Step 3: Run parity and confirm the diff is only the expected deltas**
 
-Expected: the diff shows the unified side contains every `kind`/`name` from both legacy renders EXCEPT the dropped grafana/collector/perch resources and the two legacy ServiceAccounts (replaced by one `*-cardinal` SA). No unexpected missing or duplicate resources.
+Run: `conductor/tests/render-parity.sh conductor/tests/values-lakerunner.yaml conductor/tests/values-maestro.yaml conductor/tests/values-unified.yaml`
+Expected: the only differences are the dropped grafana/collector/perch resources and the SA consolidation (two legacy SAs → one release-named SA + Role/RoleBinding). No other in-scope resource missing.
 
-- [ ] **Step 4: Resolve duplicate-resource-name conflicts**
+- [ ] **Step 4: Resolve any duplicate-resource-name conflicts**
 
-If `helm template cardinal` errors with a duplicate resource name (most likely the shared `license` Secret or `cardinal-api-key` Secret rendered by both families), dedupe: keep one definition and point the other family's `*SecretName` helper / reference at it. Re-run Step 3 until clean.
-
-Run: `helm template cardinal-test cardinal -f cardinal/tests/values-unified.yaml >/dev/null && echo OK` — Expected: `OK` (renders with no duplicate-name error).
+Run: `helm template conductor-test conductor -f conductor/tests/values-unified.yaml >/dev/null && echo OK`
+If it errors on a duplicate resource name (likely the shared `license` Secret or `cardinal-api-key` Secret rendered by both families), dedupe: keep one definition and point the other family's `*SecretName` helper/reference at it. Re-run until `OK`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add cardinal/tests/
-git commit -m "test(cardinal): render-parity harness vs legacy charts"
+git add conductor/tests/
+git commit -m "test(conductor): render-parity harness + fixtures vs legacy charts"
 ```
 
 ---
 
 ## Task 8: Final lint + parity gate
 
-- [ ] **Step 1: Lint clean**
+- [ ] **Step 1: Lint clean** — Run: `helm lint conductor` — Expected: `0 chart(s) failed`.
 
-Run: `helm lint cardinal` — Expected: `0 chart(s) failed`.
+- [ ] **Step 2: Render clean for POC and HA**
 
-- [ ] **Step 2: Render clean for both a POC and an HA values set**
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml >/dev/null && echo POC-OK`
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml --set ha.enabled=true >/dev/null && echo HA-OK`
+Expected: both OK; the HA render includes a github-cache StatefulSet, the POC render does not.
 
-Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml --set ha.enabled=true >/dev/null && echo HA-OK`
-Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml >/dev/null && echo POC-OK`
-Expected: `HA-OK` (github-cache StatefulSet appears) and `POC-OK` (github-cache absent).
+- [ ] **Step 3: Confirm no selector cross-talk and no `conductor` in resource names**
 
-- [ ] **Step 3: Confirm no selector cross-talk**
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml | grep 'app.kubernetes.io/name:' | sort -u`
+Expected: both `lakerunner` and `maestro` present and distinct (never a single shared name).
 
-Run: `helm template c cardinal -f cardinal/tests/values-unified.yaml | grep -A2 'app.kubernetes.io/name:' | sort -u`
-Expected: both `app.kubernetes.io/name: lakerunner` and `app.kubernetes.io/name: maestro` present and distinct — never a single shared name across both products.
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml | grep -E '^  name:' | grep -i conductor || echo "no conductor-prefixed resource names — good"`
+Expected: `no conductor-prefixed resource names — good`.
 
 - [ ] **Step 4: Final commit**
 
 ```bash
 git add -A
-git commit -m "feat(cardinal): skeleton complete — lint clean, render parity vs legacy (A)"
+git commit -m "feat(conductor): skeleton complete — lint clean, render parity vs legacy (A)"
 ```
 
 ---
@@ -485,9 +482,9 @@ git commit -m "feat(cardinal): skeleton complete — lint clean, render parity v
 ## Self-review notes (spec coverage)
 
 - Monolithic single chart → Tasks 1–6. ✓
-- Single shared SA, splittable later → Task 3 (`cardinal.serviceAccountName`, both families delegate). ✓
+- Single shared SA, splittable later → Task 3 (`conductor.serviceAccountName`, both families delegate). ✓
 - Drop grafana/collector/perch → Task 4 (templates) + Task 6 (values). ✓
 - Keep mcp-gateway/github-cache/dex → Task 5 (all maestro templates copied) + Task 8 HA check. ✓
+- No `conductor` in resource names; release-name prefix only → Task 2 (name pins), Task 3 (release-named SA), Task 8 Step 3 guard. ✓
 - Render parity exit criterion → Tasks 7–8. ✓
 - No bootstrap/adoption/dex-consolidation here → deferred to B/C/D by design. ✓
-- Flagged for user: chart name `cardinal` (Task 1); per-component image-tag pinning (Task 6 Step 4).

--- a/docs/superpowers/plans/2026-06-06-adoption-detection.md
+++ b/docs/superpowers/plans/2026-06-06-adoption-detection.md
@@ -1,0 +1,280 @@
+# Adoption Path + Detection State Machine (Sub-project C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `conductor` safely collapse an existing split lakerunner+maestro install into one release — detect fresh vs adopt vs error and never clobber or duplicate existing data — with a migration guide and live adoption + failure-mode tests.
+
+**Architecture:** A `mode=auto` **pre-install detection Job** queries configdb + the maestro DB, classifies the install (fresh / adopt-conductor / adopt-legacy / error), and **exits non-zero to abort the helm install** when it would be unsafe (legacy/foreign state under `auto`, or inconsistent state) — so nothing is ever silently clobbered and maestro never starts to create a duplicate. `mode=adopt` renders **no** bootstrap (no detection, key-seed, anchor Secret, or `MAESTRO_BOOTSTRAP_*`) and simply points at the existing external DB/store. `mode=force` bootstraps unconditionally (recovery). Fresh and conductor's-own-reinstall under `auto` are idempotent.
+
+**Tech Stack:** Helm, Go templates, `psql` (postgres:18-alpine), bash, kubectl; legacy charts `lakerunner@3.13.6` + `maestro@0.8.21` for the adoption test.
+
+**Builds on B:** B shipped `bootstrap.mode` (auto/never/force), the anchor Secret (normal resource), pre-install migrate hooks, post-install key-seed, and `MAESTRO_BOOTSTRAP_*`. C **renames `never`→`adopt`** (keeps `never` as a hidden alias), adds the detection Job, refines render gates, and adds tests.
+
+**Mode semantics (final):**
+| mode | detection job | key-seed + anchor + MAESTRO_BOOTSTRAP_* | meaning |
+|---|---|---|---|
+| `auto` (default) | yes (pre-install) | rendered | detect; fresh→bootstrap, adopt-conductor→idempotent skip, legacy/error→ABORT |
+| `adopt` (alias `never`) | no | NOT rendered | point at existing external DB/store; no provisioning |
+| `force` | no | rendered | bootstrap unconditionally (recovery/testing) |
+
+**Detection signals (verified):**
+- configdb (lakerunner): `SELECT count(*) FROM organizations`, `... admin_api_keys`, `... organization_buckets`.
+- maestro: `SELECT count(*) FROM maestro_organizations`; legacy lakerunner integration `SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL`; conductor's shared deployment (must match maestro's `listSharedAutoAddEnabled`): `SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>''`.
+
+**Classifier (the core logic):**
+```
+LR_PROVISIONED   = configdb.organization_buckets > 0  OR configdb.organizations > 0
+MAESTRO_SHARED   = maestro_lakerunner_deployments(shared_cardinal eligible) > 0
+MAESTRO_LEGACY   = maestro_integrations(lakerunner, deployment_id IS NULL) > 0
+MAESTRO_ORGS     = maestro_organizations > 0
+
+classify:
+  if MAESTRO_SHARED                         -> ADOPT_CONDUCTOR   (idempotent: proceed; key-seed no-ops; maestro skips)
+  elif not LR_PROVISIONED and not MAESTRO_ORGS -> FRESH          (proceed: seed + provision)
+  elif MAESTRO_LEGACY or (MAESTRO_ORGS and not MAESTRO_SHARED)  -> ADOPT_LEGACY (ABORT under auto: "set bootstrap.mode=adopt")
+  else                                       -> ERROR            (ABORT: inconsistent — e.g. configdb provisioned but maestro empty, or vice versa)
+```
+
+---
+
+## File Structure
+
+```
+conductor/
+  values.yaml                                  # mode enum doc: auto|adopt|force (never=alias)
+  templates/_helpers-lakerunner.tpl            # conductor.bootstrapMode (normalize never->adopt), conductor.bootstrapEnabled, conductor.detectionEnabled
+  templates/bootstrap/detect-job.yaml          # NEW: pre-install/pre-upgrade detection+classify (mode=auto only)
+docs/
+  conductor-migration-guide.md                 # NEW: split→single adoption runbook + values mapping
+test/adoption/                                 # NEW: live kubepi adoption + auto-abort tests
+  00-run.sh  10-legacy-install.sh  20-populate-legacy.sh  30-uninstall-legacy.sh
+  40-adopt-install.sh  50-assert-adopt.sh  60-assert-auto-aborts.sh  99-teardown.sh
+test/failure-modes/                            # NEW: §8.3 acceptance tests
+  run.sh  (crash-mid-seed, secret/db-mismatch, concurrent, rollback, wiped-configdb, pvc-cold-start)
+```
+
+---
+
+## Part 1 — Mode refinement + detection job
+
+### Task 1: Normalize the mode enum (auto|adopt|force; never=alias)
+
+**Files:** Modify `conductor/values.yaml`, `conductor/templates/_helpers-lakerunner.tpl`
+
+- [ ] **Step 1: Update the values doc**
+
+In `conductor/values.yaml` `bootstrap.mode`, change the comment to enumerate `auto` (default; detect), `adopt` (skip all bootstrap; point at existing external DB/store), `force` (bootstrap unconditionally). Note `never` is a deprecated alias of `adopt`.
+
+- [ ] **Step 2: Add a normalizing helper**
+
+Append to `conductor/templates/_helpers-lakerunner.tpl`:
+```
+{{/* Normalize bootstrap.mode; "never" is a deprecated alias of "adopt". */}}
+{{- define "conductor.bootstrapMode" -}}
+{{- $m := .Values.bootstrap.mode | default "auto" -}}
+{{- if eq $m "never" -}}adopt{{- else -}}{{ $m }}{{- end -}}
+{{- end }}
+
+{{/* Bootstrap resources render unless adopting. */}}
+{{- define "conductor.bootstrapEnabled" -}}
+{{- if ne (include "conductor.bootstrapMode" .) "adopt" -}}true{{- end -}}
+{{- end }}
+
+{{/* Detection job renders only in auto mode (force skips the safety net; adopt renders nothing). */}}
+{{- define "conductor.detectionEnabled" -}}
+{{- if eq (include "conductor.bootstrapMode" .) "auto" -}}true{{- end -}}
+{{- end }}
+```
+Then DELETE the old `conductor.bootstrapEnabled` define from B (the one that branched on `!= "never"`) so only this one remains.
+
+- [ ] **Step 3: Verify the three modes gate correctly**
+
+Run for each of `auto`,`adopt`,`force`,`never`:
+`helm template c conductor -f conductor/tests/values-unified.yaml --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 --set bootstrap.org.ownerEmail=a@b.c --set bootstrap.bucket.name=b --set bootstrap.mode=MODE | yq 'select(.kind=="Job") | .metadata.name' | sort`
+Expected: `auto` → migrate jobs + detect + key-seed; `force` → migrate + key-seed (no detect); `adopt`/`never` → migrate jobs only (no detect, no key-seed); and `MAESTRO_BOOTSTRAP_*`/anchor Secret present for auto/force, absent for adopt/never.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conductor/values.yaml conductor/templates/_helpers-lakerunner.tpl
+git commit -m "feat(conductor): mode auto|adopt|force (never alias) + detection/bootstrap gates"
+```
+
+### Task 2: Pre-install detection + classify Job
+
+**Files:** Create `conductor/templates/bootstrap/detect-job.yaml`
+
+- [ ] **Step 1: Create the detection Job (mode=auto only)**
+
+Create `conductor/templates/bootstrap/detect-job.yaml`: a `pre-install,pre-upgrade` hook, `helm.sh/hook-weight: "1"` (after migrations at 0, before key-seed which is post-install), delete-policy `before-hook-creation,hook-succeeded`, gated `{{- if include "conductor.detectionEnabled" . }}`. Image `public.ecr.aws/docker/library/postgres:18-alpine`. It connects to BOTH configdb (`.Values.configdb.lrdb.*` + secret) and the maestro DB (`.Values.maestroDatabase.*` + secret), runs the classifier, prints the classification, and `exit 1` on ADOPT_LEGACY or ERROR. Use this script body:
+
+```sh
+set -eu
+q() { PGPASSWORD="$2" psql -tA -v ON_ERROR_STOP=1 -h "$3" -p "$4" -U "$5" -d "$6" -c "$1"; }
+LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;"     "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME")
+LR_ORGS=$(q    "SELECT count(*) FROM organizations;"            "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME")
+M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;"    "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
+M_SHARED=$(q   "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
+M_LEGACY=$(q   "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
+echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
+LR_PROV=0; [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ] && LR_PROV=1
+if [ "$M_SHARED" -gt 0 ]; then echo "ADOPT_CONDUCTOR: shared deployment present — idempotent, proceeding"; exit 0; fi
+if [ "$LR_PROV" -eq 0 ] && [ "$M_ORGS" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
+if [ "$M_LEGACY" -gt 0 ] || [ "$M_ORGS" -gt 0 ]; then
+  echo "ADOPT_LEGACY: existing non-conductor install detected. Re-run with bootstrap.mode=adopt to adopt it without provisioning."; exit 1; fi
+echo "ERROR: inconsistent state (configdb provisioned but maestro empty, or vice versa). Investigate before proceeding."; exit 1
+```
+
+Env: `CONFIGDB_*` from `.Values.configdb` (mirror the key-seed Job's env, incl. `PGSSLMODE` from `.Values.configdb.lrdb.sslMode`); `MDB_*` from `.Values.maestroDatabase` (host/port/name/user + password via `secretKeyRef` to `include "maestro.databaseSecretName" .`, plus `PGSSLMODE` from `.Values.maestroDatabase.sslMode`). Use `serviceAccountName: {{ include "conductor.serviceAccountName" . }}`, `restartPolicy: Never`, `backoffLimit: 0` (a classification failure must abort, not retry).
+
+> Confirm the maestro DB env helper names first: `grep -n 'maestro.databaseSecretName\|maestro.databaseEnv' conductor/templates/_helpers-maestro.tpl` and reuse the exact secret name + password key.
+
+- [ ] **Step 2: Verify it renders only under auto and queries both DBs**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 --set bootstrap.org.ownerEmail=a@b.c --set bootstrap.bucket.name=b --set bootstrap.mode=auto | yq 'select(.metadata.name=="c-bootstrap-detect") | .spec.template.spec.containers[0].args[0]'`
+Expected: the classifier script. With `--set bootstrap.mode=adopt` and `=force`: no `c-bootstrap-detect` Job.
+
+- [ ] **Step 3: Lint + commit**
+
+```bash
+helm lint conductor
+git add conductor/templates/bootstrap/detect-job.yaml
+git commit -m "feat(conductor): pre-install detection job (fresh/adopt/error classifier, aborts on unsafe)"
+```
+
+---
+
+## Part 2 — Migration guide
+
+### Task 3: Write the split→single migration guide
+
+**Files:** Create `docs/conductor-migration-guide.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/conductor-migration-guide.md` covering, concretely: (1) prerequisites — back up Postgres + object store; confirm maestro DB has `pgvector`; have the suite license secret; (2) the values mapping table — legacy `lakerunner` values → conductor keys (unchanged `database:`/`configdb:`), legacy `maestro` `database:` → conductor **`maestroDatabase:`**, both licenses → one `license:` (`cardinal-license`), object store keys; (3) the steps: `helm uninstall <lr>`; `helm uninstall <maestro>`; `helm install conductor conductor -f adopt-values.yaml` with **`bootstrap.mode: adopt`** pointed at the SAME external Postgres + object store; (4) what changes — resource names become `<release>-lakerunner-*`/`<release>-maestro-*` (new release name), github-cache + maestro `-data` PVCs **cold-start** (rebuildable caches; data is external), legacy SAs/secrets replaced by one release-named SA + `cardinal-license`; (5) note that `mode=adopt` should remain set for an adopted legacy install (under `auto`, detection will deliberately abort a legacy-shaped DB to avoid creating a duplicate shared deployment); (6) rollback — reinstall the split charts pointed at the same external DB/store.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/conductor-migration-guide.md
+git commit -m "docs(conductor): split→single migration guide + values mapping"
+```
+
+---
+
+## Part 3 — Live adoption test (kubepi)
+
+> Namespace `conductor-adopt`, context-pinned `--context kubepi`. Reuses B's Postgres/rustfs fixtures (`test/fresh-install/10-postgres.yaml`, `20-rustfs.yaml`) and license-mint approach.
+
+### Task 4: Install + populate the legacy split stack
+
+**Files:** Create `test/adoption/10-legacy-install.sh`, `test/adoption/20-populate-legacy.sh`
+
+- [ ] **Step 1: Legacy install script**
+
+`10-legacy-install.sh`: create ns `conductor-adopt`; apply the shared Postgres 18 (pgvector) + rustfs fixtures; `helm install lr ./lakerunner --version-pin 3.13.6` and `helm install ms ./maestro` (legacy charts at repo root) with minimal external-DB values (DB host `postgres`, the lr/config/maestro DBs, rustfs object store + a `storageProfiles`/`apiKeys` entry for org `22222222-2222-2222-2222-222222222222`, the suite license). Wait for the legacy `lr-lakerunner-setup` job + rollouts.
+
+- [ ] **Step 2: Populate maestro the legacy (UI) way via direct DB insert**
+
+`20-populate-legacy.sh`: since the legacy maestro↔lakerunner integration is a pure UI step, simulate it with psql into the maestro DB — insert a `maestro_organizations` row and a `maestro_integrations` row `(type='lakerunner', deployment_id NULL, credentials jsonb with the lakerunner api key, org_id=...)`. This produces the ADOPT_LEGACY signal shape.
+
+Run both; verify: `kubectl --context kubepi -n conductor-adopt exec deploy/postgres -- psql -U postgres -d maestro -c "SELECT type,deployment_id FROM maestro_integrations;"` shows the legacy lakerunner integration; configdb has `organizations`/`organization_buckets` rows.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/adoption/10-legacy-install.sh test/adoption/20-populate-legacy.sh
+git commit -m "test(adopt): legacy split install + legacy maestro integration fixture"
+```
+
+### Task 5: Uninstall legacy, adopt with conductor, assert no duplication
+
+**Files:** Create `test/adoption/30-uninstall-legacy.sh`, `40-adopt-install.sh`, `50-assert-adopt.sh`
+
+- [ ] **Step 1: Uninstall legacy**
+
+`30-uninstall-legacy.sh`: `helm uninstall lr ms -n conductor-adopt`; wait for pods gone; (external Postgres + rustfs remain).
+
+- [ ] **Step 2: Adopt-install conductor**
+
+`40-adopt-install.sh`: `helm install conductor ./conductor -n conductor-adopt -f <adopt-values>` with `bootstrap.mode=adopt`, DB/store pointed at the SAME `postgres`/`rustfs`, `maestroDatabase` → the maestro DB, `license` → cardinal-license. Wait for rollout.
+
+- [ ] **Step 3: Assert adoption correctness**
+
+`50-assert-adopt.sh`: assert (a) all conductor pods Ready; (b) **no new bootstrap occurred** — `SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal';` is still 0 (adopt didn't create one), and the legacy `maestro_integrations` row is intact and singular (no duplicate); (c) configdb org/bucket counts unchanged from pre-adoption; (d) existing data still queryable via query-api with the legacy org key. Exit non-zero on any mismatch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/adoption/30-uninstall-legacy.sh test/adoption/40-adopt-install.sh test/adoption/50-assert-adopt.sh
+git commit -m "test(adopt): uninstall legacy + adopt-install conductor + assert no duplication"
+```
+
+### Task 6: Assert `auto` aborts on the legacy DB (safety net)
+
+**Files:** Create `test/adoption/60-assert-auto-aborts.sh`, `00-run.sh`, `99-teardown.sh`
+
+- [ ] **Step 1: Auto-abort assertion**
+
+`60-assert-auto-aborts.sh`: against the SAME legacy-populated DBs, attempt `helm install conductor-auto ./conductor -n conductor-adopt -f <values> --set bootstrap.mode=auto` and assert it **fails** and the detect Job logs `ADOPT_LEGACY`. (Clean up the failed release.) This proves the safety net prevents accidental duplication when the operator forgets `mode=adopt`.
+
+- [ ] **Step 2: Orchestrator + teardown**
+
+`00-run.sh`: ns setup → 10 → 20 → (snapshot counts) → 30 → 40 → 50 → 60 → print `ADOPTION PASS`/exit code. `99-teardown.sh`: `kubectl delete ns conductor-adopt`.
+
+- [ ] **Step 3: Full run on kubepi**
+
+Run: `bash test/adoption/00-run.sh`
+Expected: `ADOPTION PASS` — conductor adopts the legacy install with no duplication, AND `auto` correctly aborts on the legacy-shaped DB.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/adoption/
+git commit -m "test(adopt): auto-abort safety-net assertion + orchestrator; passes on kubepi"
+```
+
+---
+
+## Part 4 — Failure-mode acceptance tests (§8.3)
+
+### Task 7: Failure-mode tests
+
+**Files:** Create `test/failure-modes/run.sh`
+
+- [ ] **Step 1: Implement the cases**
+
+`test/failure-modes/run.sh` (kubepi, throwaway ns `conductor-fail`), each asserting the expected safe behavior:
+1. **wiped-configdb / split-brain:** maestro populated (orgs) but configdb empty → `auto` detect classifies ERROR/ADOPT_LEGACY and aborts (no partial bootstrap).
+2. **secret/DB mismatch:** anchor Secret holds key X but configdb has a different hash → maestro can't auth; assert maestro's retry surfaces a clear auth error (does not crashloop the whole release) and re-running key-seed reconciles.
+3. **concurrent bootstrap:** apply two key-seed Jobs concurrently → `ON CONFLICT DO NOTHING` keeps exactly one row (no error).
+4. **helm rollback:** upgrade then `helm rollback` → migrations are not re-run destructively; release stays healthy.
+5. **PVC cold-start:** after adoption, github-cache StatefulSet re-clones (no data loss; eventually Ready).
+Each case prints PASS/FAIL; script exits non-zero if any fail.
+
+- [ ] **Step 2: Run on kubepi**
+
+Run: `bash test/failure-modes/run.sh`
+Expected: all cases PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/failure-modes/
+git commit -m "test(failure-modes): split-brain/mismatch/concurrent/rollback/pvc-coldstart acceptance"
+```
+
+---
+
+## Self-review notes (spec coverage)
+
+- Detection state machine fresh/adopt/error → Tasks 1–2 (spec §7). ✓
+- Adopt-time gating of MAESTRO_BOOTSTRAP_* (mode=adopt renders nothing; auto aborts on legacy) → Tasks 1,2,6. ✓
+- Migration guide + values mapping → Task 3 (spec §5.4a, §7). ✓
+- kubepi split→single adoption test → Tasks 4–6 (spec §8.1). ✓
+- §8.3 failure-mode tests → Task 7. ✓
+- "Set adopt once, fail-safe, never clobber" (user requirement) → detection ABORTS rather than clobbers; documented that adopt stays set for legacy installs (Task 3 step 5). ✓
+- Reuses B fixtures (Postgres18/rustfs/license-mint) rather than duplicating. ✓
+- Open verification for the implementer: exact `maestro.databaseSecretName`/password key (Task 2 Step 1); legacy chart install values against external DB (Task 4 — crib from `install-scripts/generated/`).
+```

--- a/docs/superpowers/plans/2026-06-06-adoption-detection.md
+++ b/docs/superpowers/plans/2026-06-06-adoption-detection.md
@@ -21,19 +21,29 @@
 - configdb (lakerunner): `SELECT count(*) FROM organizations`, `... admin_api_keys`, `... organization_buckets`.
 - maestro: `SELECT count(*) FROM maestro_organizations`; legacy lakerunner integration `SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL`; conductor's shared deployment (must match maestro's `listSharedAutoAddEnabled`): `SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>''`.
 
-**Classifier (the core logic):**
+**Classifier (the core logic).** Safe rule: under `auto`, bootstrap ONLY when conductor
+already owns the shared deployment (idempotent) OR everything is truly empty (fresh);
+**abort on any other populated/partial state** (operator must choose `adopt` or `force`).
+This guarantees "never clobber/duplicate; fail loudly."
 ```
-LR_PROVISIONED   = configdb.organization_buckets > 0  OR configdb.organizations > 0
-MAESTRO_SHARED   = maestro_lakerunner_deployments(shared_cardinal eligible) > 0
-MAESTRO_LEGACY   = maestro_integrations(lakerunner, deployment_id IS NULL) > 0
-MAESTRO_ORGS     = maestro_organizations > 0
+# configdb (lakerunner)
+LR_BUCKETS   = count(organization_buckets); LR_ORGS = count(organizations); LR_KEYS = count(admin_api_keys)
+# maestro
+M_SHARED = count(maestro_lakerunner_deployments WHERE shared_cardinal eligible)   # == maestro listSharedAutoAddEnabled
+M_ORGS   = count(maestro_organizations); M_LEGACY = count(maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL)
+
+LR_STATE = (LR_BUCKETS>0 OR LR_ORGS>0 OR LR_KEYS>0)
+M_STATE  = (M_ORGS>0 OR M_LEGACY>0)
 
 classify:
-  if MAESTRO_SHARED                         -> ADOPT_CONDUCTOR   (idempotent: proceed; key-seed no-ops; maestro skips)
-  elif not LR_PROVISIONED and not MAESTRO_ORGS -> FRESH          (proceed: seed + provision)
-  elif MAESTRO_LEGACY or (MAESTRO_ORGS and not MAESTRO_SHARED)  -> ADOPT_LEGACY (ABORT under auto: "set bootstrap.mode=adopt")
-  else                                       -> ERROR            (ABORT: inconsistent — e.g. configdb provisioned but maestro empty, or vice versa)
+  if M_SHARED>0                      -> ADOPT_CONDUCTOR  (exit 0: idempotent; key-seed no-ops; maestro skips)
+  elif not LR_STATE and not M_STATE  -> FRESH            (exit 0: seed + provision)
+  elif LR_STATE and M_STATE          -> ADOPT_LEGACY     (exit 1 abort: "set bootstrap.mode=adopt")
+  else                               -> ERROR            (exit 1 abort: only one side populated — inconsistent)
 ```
+Note: `admin_api_keys` and `maestro_integrations`-alone are now part of the populated
+signals, so legacy/partial states never slip through as FRESH. The FRESH branch requires
+BOTH sides empty.
 
 ---
 
@@ -110,20 +120,23 @@ Create `conductor/templates/bootstrap/detect-job.yaml`: a `pre-install,pre-upgra
 
 ```sh
 set -eu
-q() { PGPASSWORD="$2" psql -tA -v ON_ERROR_STOP=1 -h "$3" -p "$4" -U "$5" -d "$6" -c "$1"; }
-LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;"     "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME")
-LR_ORGS=$(q    "SELECT count(*) FROM organizations;"            "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME")
-M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;"    "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
-M_SHARED=$(q   "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
-M_LEGACY=$(q   "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME")
-echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
-LR_PROV=0; [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ] && LR_PROV=1
+q() { PGPASSWORD="$2" PGSSLMODE="$7" psql -tA -v ON_ERROR_STOP=1 -h "$3" -p "$4" -U "$5" -d "$6" -c "$1"; }
+LR_BUCKETS=$(q "SELECT count(*) FROM organization_buckets;" "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+LR_ORGS=$(q    "SELECT count(*) FROM organizations;"        "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+LR_KEYS=$(q    "SELECT count(*) FROM admin_api_keys;"       "$CONFIGDB_PASSWORD" "$CONFIGDB_HOST" "$CONFIGDB_PORT" "$CONFIGDB_USER" "$CONFIGDB_NAME" "$CONFIGDB_SSLMODE")
+M_ORGS=$(q     "SELECT count(*) FROM maestro_organizations;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+M_SHARED=$(q   "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+M_LEGACY=$(q   "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner' AND deployment_id IS NULL;" "$MDB_PASSWORD" "$MDB_HOST" "$MDB_PORT" "$MDB_USER" "$MDB_NAME" "$MDB_SSLMODE")
+echo "signals: lr_buckets=$LR_BUCKETS lr_orgs=$LR_ORGS lr_keys=$LR_KEYS m_orgs=$M_ORGS m_shared=$M_SHARED m_legacy=$M_LEGACY"
+LR_STATE=0; { [ "$LR_BUCKETS" -gt 0 ] || [ "$LR_ORGS" -gt 0 ] || [ "$LR_KEYS" -gt 0 ]; } && LR_STATE=1
+M_STATE=0;  { [ "$M_ORGS" -gt 0 ] || [ "$M_LEGACY" -gt 0 ]; } && M_STATE=1
 if [ "$M_SHARED" -gt 0 ]; then echo "ADOPT_CONDUCTOR: shared deployment present — idempotent, proceeding"; exit 0; fi
-if [ "$LR_PROV" -eq 0 ] && [ "$M_ORGS" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
-if [ "$M_LEGACY" -gt 0 ] || [ "$M_ORGS" -gt 0 ]; then
+if [ "$LR_STATE" -eq 0 ] && [ "$M_STATE" -eq 0 ]; then echo "FRESH: proceeding with bootstrap"; exit 0; fi
+if [ "$LR_STATE" -eq 1 ] && [ "$M_STATE" -eq 1 ]; then
   echo "ADOPT_LEGACY: existing non-conductor install detected. Re-run with bootstrap.mode=adopt to adopt it without provisioning."; exit 1; fi
-echo "ERROR: inconsistent state (configdb provisioned but maestro empty, or vice versa). Investigate before proceeding."; exit 1
+echo "ERROR: inconsistent state — only one of lakerunner/configdb or maestro is populated. Investigate; use bootstrap.mode=adopt or force to override."; exit 1
 ```
+(Env also provides `CONFIGDB_SSLMODE`/`MDB_SSLMODE` from each DB's `.sslMode | default "require"`.)
 
 Env: `CONFIGDB_*` from `.Values.configdb` (mirror the key-seed Job's env, incl. `PGSSLMODE` from `.Values.configdb.lrdb.sslMode`); `MDB_*` from `.Values.maestroDatabase` (host/port/name/user + password via `secretKeyRef` to `include "maestro.databaseSecretName" .`, plus `PGSSLMODE` from `.Values.maestroDatabase.sslMode`). Use `serviceAccountName: {{ include "conductor.serviceAccountName" . }}`, `restartPolicy: Never`, `backoffLimit: 0` (a classification failure must abort, not retry).
 

--- a/docs/superpowers/plans/2026-06-06-fresh-install-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-06-fresh-install-bootstrap.md
@@ -1,0 +1,589 @@
+# Fresh-Install Bootstrap (Sub-project B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a fresh `conductor` install stand up a working LakeRunner+Maestro from empty DBs — phased migrations, a self-seeded shared admin key, and Maestro auto-provisioning the shared LakeRunner — and prove it end-to-end with a scripted test.
+
+**Architecture:** Two pre-install/pre-upgrade hook Jobs run migrations (lakerunner; maestro-via-mcp-gateway). A persistent, lookup-stable Secret anchors the admin key (or an operator `existingSecret`). A post-install/post-upgrade hook Job seeds that key's SHA-256 hash directly into LakeRunner's `configdb.admin_api_keys` (idempotent). The Maestro deployment gets `MAESTRO_BOOTSTRAP_*` env (admin key from the anchor Secret) and provisions the shared org at boot using its own resilient async-retry worker. A scripted test deploys Postgres 18 + rustfs + a cardinalhq-otel-collector fixture, sends telemetry, and validates it via `query-api` directly and via the Maestro proxy.
+
+**Tech Stack:** Helm 3/4, Go-templated Kubernetes manifests, `psql` (postgres:18-alpine), bash, curl, the `cardinalhq-otel-collector` image.
+
+**Scope boundary:** B implements the **fresh** path with idempotent guards (`ON CONFLICT DO NOTHING`, "skip if admin key exists"). The full **fresh/adopt/error detection state machine** and the adopt-time gating of `MAESTRO_BOOTSTRAP_*` are **sub-project C** — do NOT build them here. B's bootstrap must be structured so C can layer detection on top (see Task 5 note).
+
+**Key verified facts (cite when implementing):**
+- Admin-key table (current name, post-rename migration `1755713265`): `admin_api_keys (id UUID default gen_random_uuid() PK, key_hash TEXT NOT NULL UNIQUE, name TEXT NOT NULL, description TEXT, created_at timestamptz default now())`. Hash = lowercase hex `sha256(plaintext)`; `admin-api` `ValidateAPIKey` hashes any presented key the same way and looks it up — **no key-format requirement**.
+- Migrations: `lakerunner migrate --databases lrdb,configdb` (golang-migrate self-locks). Maestro migrations: the mcp-gateway binary with `MCP_MIGRATE_ONLY=true` runs them and exits 0 (table `gomigrate_maestro`).
+- Ports: query-api `8080`, admin-api `9091`, pubsub-http `8080`.
+- Ingest path: object lands in bucket → S3-event JSON POSTed to `pubsub-http:8080` (`{"Records":[{"s3":{"bucket":{"name":...},"object":{"key":...,"size":...}}}]}`) → worklane → process-*. The `cardinalhq-otel-collector` `awss3` exporter can POST these via `s3uploader.notifications.endpoint`.
+- `MAESTRO_BOOTSTRAP_*` contract: CORE (required, all 3) `ORG_ID,ORG_NAME,OWNER_EMAIL`; LAKERUNNER (required, all 3) `LAKERUNNER_QUERY_API_URL,LAKERUNNER_ADMIN_API_URL,LAKERUNNER_ADMIN_API_KEY`; BUCKET (optional, all 4 together) `BUCKET_NAME,BUCKET_REGION,BUCKET_CLOUD_PROVIDER,BUCKET_COLLECTOR_NAME`; refinements (optional) `BUCKET_ENDPOINT,BUCKET_ROLE,BUCKET_USE_PATH_STYLE,BUCKET_INSECURE_TLS`. Maestro bootstrap is resilient: it writes a DB row and an async worker retries admin-api with backoff — so admin-api/seed ordering races are tolerated.
+- Maestro proxy: `POST /api/lakerunner/{instanceId}/{query|alert}/{subpath}` (mounted at `/api/lakerunner`), needs `X-Org-Id` + user auth (`X-CardinalHQ-API-Key` per-user key or OIDC session); maestro stamps the integration's `x-cardinalhq-api-key` upstream.
+- Reference rig to adapt: `../conductor/dev/trial-testenv/` (rustfs + bundled pg + intake collector + scripts) and `base-collector-manifests/gateway/configmap.yaml` (awss3 exporter + notifications).
+
+---
+
+## File Structure
+
+```
+conductor/
+  values.yaml                                   # + bootstrap: block; lakerunner image → ecr-public
+  templates/bootstrap/
+    admin-key-secret.yaml                        # persistent lookup-stable anchor Secret (or existingSecret)
+    migrate-lakerunner-job.yaml                  # pre-install/upgrade hook: lakerunner migrate
+    migrate-maestro-job.yaml                     # pre-install/upgrade hook: mcp-gateway MCP_MIGRATE_ONLY
+    key-seed-job.yaml                            # post-install/upgrade hook: psql upsert into admin_api_keys
+  templates/maestro/maestro-deployment.yaml      # + MAESTRO_BOOTSTRAP_* env block
+  templates/_helpers-lakerunner.tpl              # + conductor.adminKeySecretName, conductor.bootstrapEnabled helpers
+test/fresh-install/                              # scripted test rig (NOT part of the chart)
+  00-run.sh            # orchestrator
+  10-postgres.yaml     # Postgres 18
+  20-rustfs.yaml       # rustfs S3 store + bucket create
+  30-values.yaml       # conductor fresh-install values
+  40-collector.yaml    # cardinalhq-otel-collector fixture (awss3 → rustfs + notify pubsub-http)
+  50-send-telemetry.sh # emit logs/metrics/traces
+  60-validate.sh       # curl query-api direct + via maestro proxy
+  99-teardown.sh
+```
+
+Legacy `lakerunner/templates/setup-job.yaml` was copied into `conductor/templates/lakerunner/` by sub-project A; Task 4 repurposes/replaces it (migrations move to the dedicated hook).
+
+---
+
+## Part 1 — Chart bootstrap
+
+### Task 1: Default the lakerunner image to ecr-public
+
+**Files:** Modify `conductor/values.yaml`
+
+- [ ] **Step 1: Find the lakerunner image repository default**
+
+Run: `grep -n 'ghcr.io/cardinalhq/lakerunner' conductor/values.yaml`
+Expected: one or more lines (e.g. `global.image.repository` and/or per-component `image.repository`).
+
+- [ ] **Step 2: Change every lakerunner default repo to ecr-public**
+
+For each match, change `ghcr.io/cardinalhq/lakerunner` → `public.ecr.aws/cardinalhq.io/lakerunner`. Add/keep a comment: `# ecr-public default; ghcr.io/cardinalhq/lakerunner is a supported alternate`.
+
+- [ ] **Step 3: Verify render uses ecr-public for lakerunner and ecr-public for maestro**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml | grep -Eo 'image: [^ ]*(lakerunner|maestro)[^ ]*' | sort -u`
+Expected: lakerunner image shows `public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4`; maestro shows `public.ecr.aws/cardinalhq.io/maestro:v1.53.0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conductor/values.yaml
+git commit -m "feat(conductor): default lakerunner image to ecr-public (ghcr.io as alternate)"
+```
+
+### Task 2: Add the `bootstrap:` values block + helpers
+
+**Files:** Modify `conductor/values.yaml`, `conductor/templates/_helpers-lakerunner.tpl`
+
+- [ ] **Step 1: Add the bootstrap values block**
+
+Append to `conductor/values.yaml`:
+
+```yaml
+# Fresh-install bootstrap. On a fresh install the chart seeds a shared admin key
+# and Maestro provisions a shared LakeRunner org at boot. On adoption set
+# mode: never (sub-project C adds full auto-detection).
+bootstrap:
+  # auto = run the fresh-install bootstrap (seed key + render MAESTRO_BOOTSTRAP_*).
+  # never = skip everything (adopt: point at existing external DB/store, no provisioning).
+  # force = same as auto (reserved; C differentiates auto vs force via detection).
+  mode: auto
+  # The shared org Maestro provisions and that telemetry is attributed to.
+  org:
+    id: ""                 # UUID; REQUIRED when mode!=never. e.g. 11111111-1111-1111-1111-111111111111
+    name: "default"
+    ownerEmail: ""         # REQUIRED when mode!=never
+  # Admin key shared by admin-api (validated from configdb) and Maestro.
+  adminKey:
+    # When set, use this existing Secret instead of generating one (sealed-secrets/GitOps).
+    existingSecret: ""
+    existingSecretKey: "admin-api-key"
+  # Bucket coordinates Maestro provisions for the shared org. Mirror the object store.
+  bucket:
+    name: ""               # REQUIRED when mode!=never
+    region: "us-east-1"
+    cloudProvider: "aws"   # aws|gcp|azure
+    collectorName: "default"
+    endpoint: ""           # S3-compatible endpoint (rustfs/minio)
+    usePathStyle: false
+    insecureTls: false
+```
+
+- [ ] **Step 2: Add helpers**
+
+Append to `conductor/templates/_helpers-lakerunner.tpl`:
+
+```
+{{/* Whether fresh-install bootstrap is active (false when mode=never). */}}
+{{- define "conductor.bootstrapEnabled" -}}
+{{- ne (.Values.bootstrap.mode | default "auto") "never" -}}
+{{- end }}
+
+{{/* Name of the admin-key anchor Secret (operator-supplied or chart-managed). */}}
+{{- define "conductor.adminKeySecretName" -}}
+{{- if .Values.bootstrap.adminKey.existingSecret -}}
+{{- .Values.bootstrap.adminKey.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin-api-key" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{/* Key name within the admin-key Secret. */}}
+{{- define "conductor.adminKeySecretKey" -}}
+{{- .Values.bootstrap.adminKey.existingSecretKey | default "admin-api-key" -}}
+{{- end }}
+
+{{/* In-cluster admin-api / query-api base URLs (release-scoped service names). */}}
+{{- define "conductor.adminApiUrl" -}}
+{{- printf "http://%s-lakerunner-admin-api:9091" .Release.Name -}}
+{{- end }}
+{{- define "conductor.queryApiUrl" -}}
+{{- printf "http://%s-lakerunner-query-api:8080" .Release.Name -}}
+{{- end }}
+```
+
+> **Verify the service names** before relying on them: run
+> `helm template c conductor -f conductor/tests/values-unified.yaml | yq 'select(.kind=="Service") | .metadata.name'`
+> and confirm `c-lakerunner-admin-api` and `c-lakerunner-query-api` exist with ports 9091/8080. If the admin-api Service name differs (it is colocated in control-plane — see `admin-api-service.yaml`), correct `conductor.adminApiUrl` to the actual name.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add conductor/values.yaml conductor/templates/_helpers-lakerunner.tpl
+git commit -m "feat(conductor): bootstrap values block + URL/secret helpers"
+```
+
+### Task 3: Persistent anchor admin-key Secret
+
+**Files:** Create `conductor/templates/bootstrap/admin-key-secret.yaml`
+
+- [ ] **Step 1: Create the Secret template (lookup-stable; skipped when existingSecret set)**
+
+```yaml
+{{- if and (include "conductor.bootstrapEnabled" .) (not .Values.bootstrap.adminKey.existingSecret) -}}
+{{- $name := include "conductor.adminKeySecretName" . -}}
+{{- $key := include "conductor.adminKeySecretKey" . -}}
+{{- /* Reuse the existing key across upgrades so it never churns; generate only if absent.
+       Pure `helm template` (no cluster) regenerates — GitOps users set bootstrap.adminKey.existingSecret. */ -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- $val := "" -}}
+{{- if and $existing $existing.data (index $existing.data $key) -}}
+{{- $val = index $existing.data $key -}}
+{{- else -}}
+{{- $val = printf "ak_%s" (randAlphaNum 48) | b64enc -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $key }}: {{ $val }}
+{{- end }}
+```
+
+- [ ] **Step 2: Verify it renders a stable-shaped secret**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 --set bootstrap.org.ownerEmail=a@b.c --set bootstrap.bucket.name=b | yq 'select(.kind=="Secret" and (.metadata.name|test("admin-api-key")))'`
+Expected: a Secret `c-admin-api-key` with a base64 `admin-api-key` value.
+
+Run again with `--set bootstrap.adminKey.existingSecret=my-sec` and confirm the Secret is NOT rendered (operator-supplied).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add conductor/templates/bootstrap/admin-key-secret.yaml
+git commit -m "feat(conductor): persistent anchor admin-key Secret (lookup-stable, existingSecret override)"
+```
+
+### Task 4: migrate-lakerunner pre-install hook
+
+**Files:** Create `conductor/templates/bootstrap/migrate-lakerunner-job.yaml`; modify the copied `conductor/templates/lakerunner/setup-job.yaml`
+
+- [ ] **Step 1: Inspect the legacy setup-job to reuse its env/volumes**
+
+Run: `sed -n '1,120p' conductor/templates/lakerunner/setup-job.yaml`
+Note how it builds DB env (the `lakerunner.injectEnvSetup` / `lakerunner.setupEnv` helpers), service account, security contexts, and image. Reuse those helpers verbatim.
+
+- [ ] **Step 2: Create the migration Job as a pre-install/pre-upgrade hook**
+
+Create `conductor/templates/bootstrap/migrate-lakerunner-job.yaml` modeled on `setup-job.yaml`, but: name `{{ .Release.Name }}-migrate-lakerunner`; `helm.sh/hook: pre-install,pre-upgrade`; `helm.sh/hook-weight: "0"`; `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`; command `["/app/bin/lakerunner"]`, args `["migrate","--databases","lrdb,configdb"]`. Keep the same `serviceAccountName`, security contexts, image (`lakerunner.image`), and the setup DB env injection helper used by the legacy setup-job. Render only when `include "conductor.bootstrapEnabled" .` OR always (migrations are safe/idempotent on every install) — gate with `{{- if .Values.setup.enabled | default true }}` to preserve the legacy toggle.
+
+- [ ] **Step 3: Neutralize the legacy setup-job's migration role**
+
+The copied `conductor/templates/lakerunner/setup-job.yaml` also runs `setup` (migrations). To avoid double-migration, change its args from `["setup"]` to a no-op OR disable it. Simplest: delete `conductor/templates/lakerunner/setup-job.yaml` (migrations now live in the dedicated hook). Confirm nothing else references the setup job name.
+
+Run: `grep -rn "fullname.*-setup\|run-migrations" conductor/templates/ || echo "no refs"`
+
+- [ ] **Step 4: Verify render**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml | yq 'select(.kind=="Job") | .metadata.name'`
+Expected includes `c-migrate-lakerunner`; the old `c-lakerunner-setup` is gone.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add conductor/templates/bootstrap/migrate-lakerunner-job.yaml conductor/templates/lakerunner/
+git commit -m "feat(conductor): migrate-lakerunner pre-install hook (replaces setup-job migrations)"
+```
+
+### Task 5: migrate-maestro pre-install hook
+
+**Files:** Create `conductor/templates/bootstrap/migrate-maestro-job.yaml`
+
+- [ ] **Step 1: Find how mcp-gateway is invoked**
+
+Run: `grep -n -A20 'define "maestro.mcpGatewaySidecar"' conductor/templates/_helpers-maestro.tpl`
+Note the image, command/args, and the DB env it injects (`maestro.databaseEnv` reads `.Values.maestroDatabase`). Reuse that exact image + DB env.
+
+- [ ] **Step 2: Create the maestro migration Job (pre-install/pre-upgrade hook)**
+
+Create `conductor/templates/bootstrap/migrate-maestro-job.yaml`: name `{{ .Release.Name }}-migrate-maestro`; hook `pre-install,pre-upgrade`; weight `"0"`; delete-policy `before-hook-creation,hook-succeeded`; `serviceAccountName {{ include "conductor.serviceAccountName" . }}`; one container using the mcp-gateway image/command from Step 1, with env: the maestro DB env (`include "maestro.databaseEnv" .`) plus `- name: MCP_MIGRATE_ONLY` / `value: "true"`. Gate with `{{- if .Values.maestro.enabled }}`.
+
+- [ ] **Step 3: Verify render**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml | yq 'select(.kind=="Job" and .metadata.name=="c-migrate-maestro") | .spec.template.spec.containers[0].env[] | select(.name=="MCP_MIGRATE_ONLY")'`
+Expected: `{name: MCP_MIGRATE_ONLY, value: "true"}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conductor/templates/bootstrap/migrate-maestro-job.yaml
+git commit -m "feat(conductor): migrate-maestro pre-install hook (mcp-gateway MCP_MIGRATE_ONLY)"
+```
+
+### Task 6: key-seed post-install hook (configdb admin_api_keys upsert)
+
+**Files:** Create `conductor/templates/bootstrap/key-seed-job.yaml`
+
+- [ ] **Step 1: Determine configdb connection env**
+
+Run: `grep -n -A20 'define "lakerunner.setupEnv"\|configdb' conductor/templates/_helpers-lakerunner.tpl | head -40`
+Identify how configdb host/port/db/user/password are exposed (values `configdb.lrdb.*` + secret `configdb.secretName` key `CONFIGDB_PASSWORD`). The seed Job will build a libpq connection from these.
+
+- [ ] **Step 2: Create the seed Job**
+
+Create `conductor/templates/bootstrap/key-seed-job.yaml`:
+
+```yaml
+{{- if include "conductor.bootstrapEnabled" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-bootstrap-key-seed
+  labels:
+    {{- include "lakerunner.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "lakerunner.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- include "lakerunner.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: key-seed
+        image: public.ecr.aws/docker/library/postgres:18-alpine
+        command: ["/bin/sh","-ec"]
+        args:
+          - |
+            HASH=$(printf %s "$ADMIN_KEY" | sha256sum | cut -d' ' -f1)
+            echo "seeding admin key hash ${HASH%${HASH#????}}… into admin_api_keys"
+            PGPASSWORD="$CONFIGDB_PASSWORD" psql \
+              --set=ON_ERROR_STOP=1 \
+              -h "$CONFIGDB_HOST" -p "$CONFIGDB_PORT" -U "$CONFIGDB_USER" -d "$CONFIGDB_NAME" \
+              -v hash="$HASH" \
+              -c "INSERT INTO admin_api_keys (key_hash, name, description) VALUES (:'hash', 'conductor-bootstrap', 'seeded by conductor bootstrap') ON CONFLICT (key_hash) DO NOTHING;"
+            echo "done"
+        env:
+          - name: ADMIN_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "conductor.adminKeySecretName" . }}
+                key: {{ include "conductor.adminKeySecretKey" . }}
+          - name: CONFIGDB_HOST
+            value: {{ .Values.configdb.lrdb.host | quote }}
+          - name: CONFIGDB_PORT
+            value: {{ .Values.configdb.lrdb.port | quote }}
+          - name: CONFIGDB_NAME
+            value: {{ .Values.configdb.lrdb.name | quote }}
+          - name: CONFIGDB_USER
+            value: {{ .Values.configdb.lrdb.username | quote }}
+          - name: CONFIGDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.configdb.secretName | quote }}
+                key: {{ .Values.configdb.passwordKey | default "CONFIGDB_PASSWORD" | quote }}
+{{- end }}
+```
+
+> **C-extension note:** C replaces the bare `INSERT ... ON CONFLICT DO NOTHING` with the fresh/adopt/error detection state machine (and fails the hook on `error`). B intentionally keeps it idempotent-but-dumb.
+
+- [ ] **Step 3: Verify render**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 --set bootstrap.org.ownerEmail=a@b.c --set bootstrap.bucket.name=b | yq 'select(.metadata.name=="c-bootstrap-key-seed") | .spec.template.spec.containers[0].args[0]'`
+Expected: the script containing the `INSERT INTO admin_api_keys` upsert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conductor/templates/bootstrap/key-seed-job.yaml
+git commit -m "feat(conductor): post-install key-seed job (idempotent admin_api_keys upsert)"
+```
+
+### Task 7: Wire MAESTRO_BOOTSTRAP_* into the maestro deployment
+
+**Files:** Modify `conductor/templates/maestro/maestro-deployment.yaml`
+
+- [ ] **Step 1: Locate the maestro container env block**
+
+Run: `grep -n 'env:\|MAESTRO_\|.Values.maestro.env' conductor/templates/maestro/maestro-deployment.yaml | head`
+Identify where the maestro container's `env:` list is and how `.Values.maestro.env` is appended.
+
+- [ ] **Step 2: Add the bootstrap env (gated on bootstrapEnabled)**
+
+In the maestro container `env:` list, insert (indented to match siblings):
+
+```yaml
+{{- if include "conductor.bootstrapEnabled" . }}
+- name: MAESTRO_BOOTSTRAP_ORG_ID
+  value: {{ required "bootstrap.org.id is required when bootstrap.mode!=never" .Values.bootstrap.org.id | quote }}
+- name: MAESTRO_BOOTSTRAP_ORG_NAME
+  value: {{ .Values.bootstrap.org.name | default "default" | quote }}
+- name: MAESTRO_BOOTSTRAP_OWNER_EMAIL
+  value: {{ required "bootstrap.org.ownerEmail is required when bootstrap.mode!=never" .Values.bootstrap.org.ownerEmail | quote }}
+- name: MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL
+  value: {{ include "conductor.queryApiUrl" . | quote }}
+- name: MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL
+  value: {{ include "conductor.adminApiUrl" . | quote }}
+- name: MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "conductor.adminKeySecretName" . }}
+      key: {{ include "conductor.adminKeySecretKey" . }}
+{{- if .Values.bootstrap.bucket.name }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_NAME
+  value: {{ .Values.bootstrap.bucket.name | quote }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_REGION
+  value: {{ .Values.bootstrap.bucket.region | default "us-east-1" | quote }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER
+  value: {{ .Values.bootstrap.bucket.cloudProvider | default "aws" | quote }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_COLLECTOR_NAME
+  value: {{ .Values.bootstrap.bucket.collectorName | default "default" | quote }}
+{{- with .Values.bootstrap.bucket.endpoint }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_ENDPOINT
+  value: {{ . | quote }}
+{{- end }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_USE_PATH_STYLE
+  value: {{ .Values.bootstrap.bucket.usePathStyle | default false | quote }}
+- name: MAESTRO_BOOTSTRAP_BUCKET_INSECURE_TLS
+  value: {{ .Values.bootstrap.bucket.insecureTls | default false | quote }}
+{{- end }}
+{{- end }}
+```
+
+- [ ] **Step 3: Verify render (bootstrap on) and absence (mode=never)**
+
+Run: `helm template c conductor -f conductor/tests/values-unified.yaml --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 --set bootstrap.org.ownerEmail=a@b.c --set bootstrap.bucket.name=lr --set bootstrap.bucket.endpoint=http://rustfs:9000 | yq 'select(.kind=="Deployment" and (.metadata.name|test("maestro$"))) | .spec.template.spec.containers[].env[] | select(.name|test("MAESTRO_BOOTSTRAP"))' | head`
+Expected: the 6 core/lakerunner vars + bucket vars; the admin key via `secretKeyRef`.
+
+Run with `--set bootstrap.mode=never` and confirm NO `MAESTRO_BOOTSTRAP_*` env appears.
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+helm lint conductor
+git add conductor/templates/maestro/maestro-deployment.yaml
+git commit -m "feat(conductor): wire MAESTRO_BOOTSTRAP_* (gated on bootstrap.mode)"
+```
+
+---
+
+## Part 2 — Scripted fresh-install test
+
+> These live under `test/fresh-install/` (NOT shipped in the chart). They target the kubepi cluster in a dedicated namespace (see memory: kubepi adoption/fresh test bed). All commands assume `kubectl`/`helm` point at kubepi and `NS=conductor-fresh`.
+
+### Task 8: Postgres 18 fixture
+
+**Files:** Create `test/fresh-install/10-postgres.yaml`
+
+- [ ] **Step 1: Write a Postgres 18 Deployment+Service+Secret+init**
+
+Create `test/fresh-install/10-postgres.yaml`: a `Secret` (`pg-credentials`: `LRDB_PASSWORD`, `CONFIGDB_PASSWORD`, `MAESTRO_DB_PASSWORD` all set to a test value), a `ConfigMap` with an init SQL that `CREATE DATABASE lakerunner; CREATE DATABASE configdb; CREATE DATABASE maestro;` and creates matching roles, a `Deployment` using `public.ecr.aws/docker/library/postgres:18-alpine` mounting the init SQL at `/docker-entrypoint-initdb.d/`, and a `Service` `postgres:5432`. Model role/db names on `install-scripts/generated/postgres-manifests.yaml` but Postgres 18 and add the `maestro` DB.
+
+- [ ] **Step 2: Apply and verify**
+
+Run: `kubectl -n $NS apply -f test/fresh-install/10-postgres.yaml && kubectl -n $NS rollout status deploy/postgres --timeout=120s`
+Run: `kubectl -n $NS exec deploy/postgres -- psql -U postgres -c '\l' | grep -E 'lakerunner|configdb|maestro'`
+Expected: all three databases present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/fresh-install/10-postgres.yaml
+git commit -m "test(fresh): Postgres 18 fixture (lakerunner/configdb/maestro DBs)"
+```
+
+### Task 9: rustfs S3 fixture + bucket
+
+**Files:** Create `test/fresh-install/20-rustfs.yaml`
+
+- [ ] **Step 1: Adapt rustfs manifests from conductor trial-testenv**
+
+Run: `ls ../conductor/dev/trial-testenv/ && grep -rl rustfs ../conductor/dev/trial-testenv/`
+Copy/adapt the rustfs Deployment+Service (S3 API on `:9000`, path-style, a known access/secret key) into `test/fresh-install/20-rustfs.yaml`. Add an init Job (or `mc`/`aws s3api` one-shot) that creates the bucket `lakerunner`. If trial-testenv has no standalone rustfs manifest, model it on its Helm values for the object store and pin `rustfs` image used there.
+
+- [ ] **Step 2: Apply and verify the bucket exists**
+
+Run: `kubectl -n $NS apply -f test/fresh-install/20-rustfs.yaml && kubectl -n $NS rollout status deploy/rustfs --timeout=120s`
+Run: a one-off `aws --endpoint-url http://rustfs.$NS.svc:9000 s3 ls` (path-style, test creds) shows the `lakerunner` bucket.
+Expected: bucket `lakerunner` listed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/fresh-install/20-rustfs.yaml
+git commit -m "test(fresh): rustfs S3-compatible store + lakerunner bucket"
+```
+
+### Task 10: conductor fresh-install values + install
+
+**Files:** Create `test/fresh-install/30-values.yaml`
+
+- [ ] **Step 1: Write fresh-install values**
+
+Create `test/fresh-install/30-values.yaml` wiring the chart to the fixtures: `database.lrdb`/`configdb.lrdb`/`maestroDatabase` → host `postgres`, the three DBs, creds from `pg-credentials`; object store (`maestro.objectStore` + lakerunner `cloudProvider`/`storageProfiles`) → endpoint `http://rustfs:9000`, bucket `lakerunner`, `usePathStyle: true`, test creds; `license` → a test license secret; `storageProfiles.yaml` with one entry for the bootstrap org id, bucket `lakerunner`, `endpoint http://rustfs:9000`, `use_path_style: true`; `pubsub.HTTP.enabled: true`; `bootstrap`: `mode: auto`, `org.id: 11111111-1111-1111-1111-111111111111`, `org.ownerEmail: admin@test.local`, `bucket.name: lakerunner`, `bucket.endpoint: http://rustfs:9000`, `bucket.usePathStyle: true`, `bucket.insecureTls: true`. Keep `ha.enabled: false`.
+
+- [ ] **Step 2: Install and wait for rollout**
+
+Run: `helm install conductor conductor -n $NS -f test/fresh-install/30-values.yaml`
+Run: `kubectl -n $NS get jobs` — expect `conductor-migrate-lakerunner`, `conductor-migrate-maestro` (pre) completed, then `conductor-bootstrap-key-seed` (post) completed.
+Run: `kubectl -n $NS rollout status deploy/conductor-maestro-maestro --timeout=300s` and the lakerunner deployments.
+Expected: migrations + key-seed Jobs `Complete`; pods Ready.
+
+- [ ] **Step 3: Verify the admin key landed in configdb and maestro provisioned**
+
+Run: `kubectl -n $NS exec deploy/postgres -- psql -U postgres -d configdb -c 'SELECT name FROM admin_api_keys;'`
+Expected: a `conductor-bootstrap` row.
+Run: `kubectl -n $NS logs deploy/conductor-maestro-maestro | grep -i bootstrap | tail`
+Expected: bootstrap created/þfound the shared deployment (no fatal errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/fresh-install/30-values.yaml
+git commit -m "test(fresh): conductor fresh-install values + install step"
+```
+
+### Task 11: collector fixture → telemetry into lakerunner
+
+**Files:** Create `test/fresh-install/40-collector.yaml`, `test/fresh-install/50-send-telemetry.sh`
+
+- [ ] **Step 1: Write the collector fixture**
+
+Create `test/fresh-install/40-collector.yaml` from `base-collector-manifests/gateway/configmap.yaml`: a `cardinalhq-otel-collector` Deployment + Service exposing OTLP (`4317`/`4318`), config with OTLP receivers and an `awss3` exporter targeting rustfs (`endpoint http://rustfs:9000`, `region us-east-1`, `s3_bucket lakerunner`, `s3_force_path_style true`, `s3_prefix otel-raw/11111111-1111-1111-1111-111111111111/default`) and `s3uploader.notifications.endpoint: http://conductor-lakerunner-pubsub-http:8080/`. Logs/metrics/traces pipelines all export to `awss3`. Inject rustfs creds via env.
+
+- [ ] **Step 2: Apply collector + send telemetry**
+
+Create `test/fresh-install/50-send-telemetry.sh` that uses a telemetrygen (or `otelgen`) Job, or `curl` OTLP/HTTP, to push a known log line, a metric, and a trace span (each tagged with a recognizable attribute, e.g. `service.name=fresh-test`) to the collector's `:4318`. Then wait ~60s for the awss3 flush + pubsub notification + processing.
+
+Run: `kubectl -n $NS apply -f test/fresh-install/40-collector.yaml && kubectl -n $NS rollout status deploy/otel-collector --timeout=120s && bash test/fresh-install/50-send-telemetry.sh`
+Run: `kubectl -n $NS exec deploy/postgres -- psql -U postgres -d lakerunner -c 'SELECT count(*) FROM lakerunner_inqueue;'` (or the relevant ingest table) to confirm objects were registered.
+Expected: object(s) registered for ingest; no errors in process-logs/metrics/traces logs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/fresh-install/40-collector.yaml test/fresh-install/50-send-telemetry.sh
+git commit -m "test(fresh): collector fixture + telemetry emit"
+```
+
+### Task 12: Validate via query-api direct AND maestro proxy
+
+**Files:** Create `test/fresh-install/60-validate.sh`
+
+- [ ] **Step 1: Mint a per-user API key for the maestro proxy**
+
+The proxy needs `X-Org-Id` + a per-user key. In `60-validate.sh`, create one by inserting a per-user API key row into the maestro DB for the bootstrap org/owner (find the table+hash via `grep -rin "api.key" ../conductor/packages/maestro/src | grep -i psk` and the proxy auth middleware), OR via any maestro admin endpoint if one exists. Capture the plaintext.
+
+- [ ] **Step 2: Query query-api directly (org key)**
+
+In `60-validate.sh`, get the org/admin key, then:
+```bash
+curl -fsS -H "x-cardinalhq-api-key: $ORG_KEY" -H 'content-type: application/json' \
+  -d '{"q":"*","s":-3600000,"e":0}' \
+  http://conductor-lakerunner-query-api.$NS.svc:8080/api/v1/logs/query | tee /tmp/direct.json
+```
+Assert the response contains the `fresh-test` data (grep for the marker attribute). Repeat for metrics and traces subpaths.
+
+- [ ] **Step 3: Query via the maestro proxy**
+
+```bash
+INSTANCE=$(kubectl -n $NS exec deploy/postgres -- psql -U postgres -d maestro -tAc "SELECT id FROM maestro_lakerunner_deployments LIMIT 1;")
+curl -fsS -H "X-Org-Id: 11111111-1111-1111-1111-111111111111" -H "X-CardinalHQ-API-Key: $USER_KEY" \
+  -H 'content-type: application/json' -d '{"q":"*","s":-3600000,"e":0}' \
+  http://conductor-maestro-maestro.$NS.svc:4200/api/lakerunner/$INSTANCE/query/logs/query | tee /tmp/proxy.json
+```
+Assert the proxy response contains the same `fresh-test` data.
+
+- [ ] **Step 4: Make the script exit non-zero on any missing data**
+
+The script must `grep -q` the marker in both `/tmp/direct.json` and `/tmp/proxy.json` and `exit 1` if either is missing, printing a clear PASS/FAIL summary.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/fresh-install/60-validate.sh
+git commit -m "test(fresh): validate query-api direct + maestro proxy return ingested data"
+```
+
+### Task 13: Orchestrator + teardown
+
+**Files:** Create `test/fresh-install/00-run.sh`, `test/fresh-install/99-teardown.sh`
+
+- [ ] **Step 1: Orchestrator**
+
+`00-run.sh`: set `NS=${NS:-conductor-fresh}`; `kubectl create ns $NS`; apply 10/20; `helm install` with 30-values; wait; apply 40 + run 50; run 60; print overall PASS/FAIL and exit with 60's code.
+
+- [ ] **Step 2: Teardown**
+
+`99-teardown.sh`: `helm uninstall conductor -n $NS; kubectl delete ns $NS`.
+
+- [ ] **Step 3: Full end-to-end run on kubepi**
+
+Run: `NS=conductor-fresh bash test/fresh-install/00-run.sh`
+Expected: final line `FRESH-INSTALL PASS` and exit 0 — telemetry ingested and returned by BOTH query-api direct and the maestro proxy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/fresh-install/00-run.sh test/fresh-install/99-teardown.sh
+git commit -m "test(fresh): orchestrator + teardown; full e2e passes on kubepi"
+```
+
+---
+
+## Self-review notes (spec coverage)
+
+- Phased migrate-lakerunner / migrate-maestro(-mcp) → Tasks 4, 5 (spec §6.2). ✓
+- Provision-both direct configdb key-seed (`admin_api_keys` upsert, sha256) → Task 6 (spec §6.1). ✓
+- Anchor Secret (lookup-stable + existingSecret override) → Task 3 (spec §6.1). ✓
+- MAESTRO_BOOTSTRAP_* wiring incl. bucket → Task 7 (spec §6.5). ✓
+- ecr-public lakerunner image → Task 1 (spec §5.4). ✓
+- `bootstrap.mode` knob (auto/never/force; never = adopt-safe no-render) → Tasks 2,6,7 (spec §6.6). ✓
+- Fresh-install test: rustfs + Postgres 18 + collector + curl via query-api AND maestro proxy → Tasks 8–13 (spec §8.2). ✓
+- Deferred to C (NOT in B): full fresh/adopt/error detection state machine + adopt-time MAESTRO_BOOTSTRAP_* gating + §8.3 failure-mode tests. Flagged in Task 6.
+- Open verification the implementer must do early: exact admin-api/query-api/pubsub-http **Service names** (Task 2 Step 2) and the maestro per-user API key table/mint path (Task 12 Step 1).
+```

--- a/docs/superpowers/plans/2026-06-06-fresh-install-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-06-fresh-install-bootstrap.md
@@ -324,7 +324,9 @@ spec:
           - name: CONFIGDB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.configdb.secretName | quote }}
+                # Use the helper — the chart creates the secret release-prefixed
+                # (c-lakerunner-configdb-credentials), NOT the bare values name.
+                name: {{ include "lakerunner.configdbSecretName" . | quote }}
                 key: {{ .Values.configdb.passwordKey | default "CONFIGDB_PASSWORD" | quote }}
 {{- end }}
 ```

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -257,6 +257,14 @@ assumptions:
   integration row), NOT `maestro_lakerunner_deployments.id`. (Corrects the B plan.)
 - **key-seed inlines the sha256 hex** into the `psql -c` string (hex-only → injection-safe)
   because `psql -c` does not expand `-v` variables.
+- **Postgres connection footprint (sizing — surfaced in C testing).** The full
+  lakerunner stack's pgx pools + maestro can exhaust a modestly-sized Postgres
+  (`too many clients`, SQLSTATE 53300), especially during a rolling **upgrade** that
+  briefly runs ~2× pods. The test fixture uses `max_connections=400`. Adoption/prod
+  implication: customers pointing at an existing Postgres must size `max_connections`
+  for the full stack (or front it with pgbouncer — already part of the LR topology;
+  note migrations need a direct, non-pgbouncer connection for advisory locks). Add this
+  to the migration guide's sizing prerequisites.
 - **Validated end-to-end:** collector → rustfs → pubsub-http → process-* → cooked
   segments; data returned by BOTH `query-api` direct (org key) and the maestro proxy
   (`X-Org-Id` + per-user key). Marker `service_name=fresh-test`.

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -113,6 +113,21 @@ chart/
 Flat, monolithic. A migration guide ships a values-mapping note for adopters
 concatenating their two override files onto the unified keys.
 
+### 5.4 Image registries
+Per the updated `lakerunner-cloudformation` reference (`cardinal-defaults.yaml`,
+`image_manifest.py`), the standard is **100% `public.ecr.aws/cardinalhq.io/*` for all
+Cardinal-owned images** (lakerunner, maestro, dex-customization, otel-collector),
+SHA-pinned, with third-party images mirrored on ecr-public
+(`public.ecr.aws/docker/library/postgres:18-alpine`, `public.ecr.aws/aws-cli/...`).
+**ecr-public is the default; ghcr.io is the documented alternate.** The unified chart
+should default Cardinal images to ecr-public for consistency.
+- **Discrepancy to resolve:** the legacy lakerunner chart defaults its image to
+  `ghcr.io/cardinalhq/lakerunner`, whereas maestro + CF use `public.ecr.aws/cardinalhq.io/*`.
+  Decision (pending user confirm): unify the default to `public.ecr.aws/cardinalhq.io/lakerunner`,
+  keeping ghcr.io as a documented override. **Deferred out of sub-project A** (which copies
+  live values verbatim to keep render-parity clean); applied as a deliberate values change
+  before/within sub-project B so the diff is intentional and reviewable.
+
 ## 6. Bootstrap — phased, not one monolithic hook
 
 Codex review rejected stuffing migrations + classification + credential minting +

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -1,7 +1,7 @@
 # Unified LakeRunner + Maestro Helm Chart — Design
 
 **Date:** 2026-06-05
-**Status:** Draft (Codex-reviewed; SA decision resolved; 2 open — see §11)
+**Status:** Draft (Codex-reviewed; all §11 decisions resolved — ready for user review)
 **Branch:** `worktree-unified-chart`
 
 ## 1. Goal
@@ -130,9 +130,9 @@ serialization. All phases are idempotent and driven by durable state.
 - **Rollback:** bootstrap Jobs must not run schema-assuming or destructive logic on
   `helm rollback`; migrations are forward-only and gated on detected schema version.
 
-### 6.1 Admin-key model (Secret-anchored, DB-reconciled)
-Chosen to eliminate the unrecoverable-crash failure mode (capturing a one-time random
-plaintext) and to make LakeRunner the durable owner:
+### 6.1 Admin-key model (Secret-anchored, DB-reconciled) — CHOSEN
+Selected over the alternative below. Eliminates the unrecoverable-crash failure mode
+(capturing a one-time random plaintext) and makes LakeRunner the durable owner:
 
 1. **Anchor the plaintext once.** Broker ensures a durable Secret holding the admin
    key plaintext: if `adminKey.existingSecret` is set, use it (operator-supplied,
@@ -164,12 +164,16 @@ Read durable state and classify (see §7). Output a clear status (configmap/Job 
 so operators can see *why* fresh/adopt/error was chosen.
 
 ### 6.4 Provisioning phase (fresh only)
-Maestro, via `MAESTRO_BOOTSTRAP_*`, provisions the shared LakeRunner deployment + org
-+ storage, authenticating to in-cluster admin-api with the anchor key. Because Maestro
-bootstrap runs at process start, it **must tolerate admin-api readiness delays** (retry
-/ backoff) — this is a hard prerequisite on the Maestro app (§11). If the app's
-bootstrap is not resilient to admin-api being down, provisioning moves into a dedicated
-Job that waits for admin-api readiness instead of relying on pod start order.
+Maestro, via `MAESTRO_BOOTSTRAP_*`, provisions the shared LakeRunner deployment + org +
+storage, authenticating to in-cluster admin-api with the anchor key. **Verified: the
+Maestro app already decouples this from admin-api readiness** — bootstrap writes a DB
+row (no admin-api call at startup), then an **async provisioning worker retries with
+exponential backoff** (`1s,2s,4s,8s,16s`, ≤6 attempts) and treats 5xx/network errors as
+retryable; a failure logs-and-continues (find-or-create idempotent on every boot). So
+**no dedicated provisioning Job and no readiness gate are required** — the chart only
+sets the env (§6.5). admin-api's `POST /api/v1/provision` is itself idempotent (upsert).
+Chart detail: point the admin-api readiness probe at **`/readyz`** (gates on DB
+connectivity), not `/healthz` (which goes 200 before DBs connect).
 
 ### 6.5 Maestro wiring (net-new in Helm)
 ```
@@ -271,9 +275,6 @@ Suggested order: **A → B → C → D** (D can overlap once maestro templates l
 
 ## 10. Risks
 
-- **MAESTRO_BOOTSTRAP_* app contract** is unproven in Helm (exists only in the ECS
-  reference). Pin exact env names, retry-on-admin-api-down behavior, restart
-  idempotency, and skip/fail logging before implementing B (§11 prerequisite).
 - **Maestro DB migrations on adopt** must be forward-only and safe against a populated
   maestro DB; the migration phase must prevent multi-replica concurrent auto-migrate.
 - **Admin-key lifecycle.** The anchor key is a high-value global admin credential.
@@ -291,11 +292,12 @@ Suggested order: **A → B → C → D** (D can overlap once maestro templates l
    a `controlPlane` SA with deployment-scale rights, a `maestro` SA); when a component
    names its own SA it gets a narrowly-scoped Role, else it uses the shared union SA.
    RBAC templates are structured so each component's Role binds to its *effective* SA.
-2. **Admin-key model.** §6.1 primary (Secret-anchored *and* DB-reconciled via
-   `UpsertAdminAPIKey`, so LakeRunner owns the hash) vs the §6.1 alternative
-   (Secret-only via `ADMIN_INITIAL_API_KEY` fallback, no DB row — simpler, matches
-   CloudFormation, but key not stored in LakeRunner). Recommendation: primary.
-3. **Maestro-bootstrap resilience prerequisite.** Implementing B cleanly assumes
-   Maestro's `MAESTRO_BOOTSTRAP_*` flow retries when admin-api isn't ready yet. If the
-   Maestro app doesn't already do this, we either fix it app-side or move provisioning
-   into a readiness-gated Job. Needs confirmation against the Maestro source.
+2. **Admin-key model — RESOLVED: primary** (§6.1: Secret-anchored *and* DB-reconciled
+   via `UpsertAdminAPIKey`, so LakeRunner owns the hash).
+3. **Maestro-bootstrap resilience — RESOLVED: no gap.** Verified against `../conductor`
+   (maestro source) and `../lakerunner`: maestro bootstrap writes a DB row and never
+   calls admin-api at startup; an async provisioning worker retries with exponential
+   backoff and treats 5xx/network errors as retryable; failures log-and-continue,
+   idempotent every boot. admin-api `/api/v1/provision` is idempotent (upsert). The
+   chart only sets `MAESTRO_BOOTSTRAP_*` and probes admin-api at `/readyz`. No app
+   change and no issue filed.

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -163,34 +163,48 @@ serialization. All phases are idempotent and driven by durable state.
 - **Rollback:** bootstrap Jobs must not run schema-assuming or destructive logic on
   `helm rollback`; migrations are forward-only and gated on detected schema version.
 
-### 6.1 Admin-key model (Secret-anchored, DB-reconciled) — CHOSEN
-Selected over the alternative below. Eliminates the unrecoverable-crash failure mode
-(capturing a one-time random plaintext) and makes LakeRunner the durable owner:
+### 6.1 Admin-key model — CHOSEN: provision-both seeds configdb directly
+The "provision-both" broker step already needs DB access to both databases (for
+detection), so it seeds the admin key by a **direct, idempotent SQL upsert into
+LakeRunner's configdb** — no missing LakeRunner CLI, no cross-repo change, and
+LakeRunner still owns the key (its hash lives in configdb). "Choose once, done."
 
-1. **Anchor the plaintext once.** Broker ensures a durable Secret holding the admin
-   key plaintext: if `adminKey.existingSecret` is set, use it (operator-supplied,
-   sealed-secrets/GitOps path); else generate a random value and create the Secret
-   with lookup-or-create (atomic; a losing concurrent creator reads the winner's).
-2. **Reconcile the DB hash from the anchor.** Feed that plaintext through the existing
-   `UpsertAdminAPIKey` import path → configdb stores the hash (LakeRunner = source of
-   truth). Deterministic: re-running re-hashes the same plaintext → same hash → no-op.
-3. admin-api validates the key from configdb (with the in-memory env fallback as a
-   belt-and-suspenders). Maestro reads the plaintext from the anchor Secret.
+1. **Anchor the plaintext once.** Broker ensures a durable Secret holds the admin-key
+   plaintext: if `adminKey.existingSecret` is set, use it (operator-supplied,
+   sealed-secrets/GitOps path); else generate a random `ak_<hex>` and create the Secret
+   lookup-or-create (atomic; a losing concurrent creator reads the winner's).
+2. **Seed the hash into configdb directly.** Compute `key_hash = sha256(plaintext)` (hex)
+   and upsert into the `admin_api_keys` table (current name — the `lrconfig_` prefix was
+   removed by migration `1755713265`). DDL: `(id UUID default gen_random_uuid() PK,
+   key_hash TEXT NOT NULL UNIQUE, name TEXT NOT NULL, description, created_at default
+   now())`. SQL: `INSERT INTO admin_api_keys (key_hash, name, description) VALUES (...)
+   ON CONFLICT (key_hash) DO NOTHING;`. Idempotent on the unique hash.
+   `admin-api ValidateAPIKey` hashes any presented key the same way and looks it up —
+   no key-format requirement — so the chosen plaintext is accepted.
+3. Maestro receives the same plaintext via `MAESTRO_BOOTSTRAP_..._ADMIN_API_KEY`
+   (from the anchor Secret); it stores it in its `maestro_lakerunner_deployments` row
+   (same unprotected-in-maestro-DB state as today, per user) and uses it to call
+   admin-api, which now accepts it.
 
-This is crash-idempotent in every order: Secret-but-no-DB-row → re-import; the anchor
-is created before anything depends on it, so plaintext is never lost.
+Crash-idempotent in every order: the anchor Secret is created before anything depends
+on it; the configdb upsert is idempotent on the hash; re-runs no-op.
 
-> **Alternative (simpler, if import wiring proves awkward):** skip step 2 and inject
-> the anchor value as `ADMIN_INITIAL_API_KEY` into admin-api (in-memory fallback,
-> no DB row) **and** as `MAESTRO_BOOTSTRAP_..._ADMIN_API_KEY` into Maestro — exactly
-> the CloudFormation shape. Trade-off: the key lives only in the Secret, not in
-> LakeRunner's DB. Recorded as the fallback in §11.
+> **Documented coupling:** the broker takes a schema dependency on the `admin_api_keys`
+> table. If that schema drifts, the broker's SQL must change. Escape hatch: add a
+> `lakerunner` CLI command to drive `internal/bootstrap` `UpsertAdminAPIKey` and have
+> the broker call that instead. Acceptable for now (user-confirmed "most direct").
+> The in-memory `ADMIN_INITIAL_API_KEY` fallback remains available as a belt-and-
+> suspenders but is not the primary mechanism.
 
-### 6.2 Migration phase (pre-workload)
-Run LakeRunner (`lrdb`,`configdb`) and Maestro DB migrations as a dedicated phase
-**before** app pods that depend on the schema start. One runner per DB; never let
-multiple Maestro replicas auto-migrate concurrently. Idempotent and safe on populated
-(adopted) DBs.
+### 6.2 Migration phases (pre-workload) — two ordered jobs
+Per user's "migrate-lakerunner, migrate-maestro(-mcp), provision both" model:
+- **migrate-lakerunner:** `lakerunner migrate --databases lrdb,configdb` (golang-migrate
+  handles its own locking; idempotent; safe on populated/adopted DBs).
+- **migrate-maestro:** mcp-gateway image with `MCP_MIGRATE_ONLY=true` — runs maestro DB
+  migrations (`gomigrate_maestro`, golang-migrate) and exits 0. This is the supported
+  migrate-only mode; it avoids multiple maestro replicas auto-migrating concurrently.
+Both run as pre-install/pre-upgrade hook Jobs (ordered via hook weights) before app pods
+that depend on the schema start.
 
 ### 6.3 Detection / classification phase
 Read durable state and classify (see §7). Output a clear status (configmap/Job log)

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -301,6 +301,17 @@ Detection lands in **adopt** and no-ops all provisioning.
   Postgres/object-store backup beforehand, and notes github-cache **cold-starts**
   (re-clones mirrors) after adoption.
 
+## 7a. Dex / OIDC (sub-project D) — outcome
+The chart-native dex (configmap/deployment/service + issuer/jwks/redirect/proxy helpers
+and `oidcEnv`) carried over from the maestro chart intact; **no ECS-specific assumptions
+exist** (point 6 satisfied). D's substantive fix: A's subdir move broke the one cross-file
+path reference — `dex-deployment.yaml`'s `checksum/config` used
+`$.Template.BasePath "/dex-configmap.yaml"`, now `"/maestro/dex-configmap.yaml"` — which
+had made dex fail to render when `dex.enabled=true` (missed by A's parity test and B's
+install because dex defaults off). Verified: dex renders; maestro `OIDC_ISSUER_URL`
+matches dex's `issuer`; JWKS via in-cluster service; redirect URI = baseUrl; disabled by
+default. (No other `Template.BasePath` references exist, so no sibling breakage.)
+
 ## 8. Testing
 
 ### 8.1 Adoption test (kubepi cluster, dedicated namespace)

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -237,6 +237,30 @@ provision. Because `auto` is self-correcting against DB state, an operator may s
 `never` for a first adopt install, then **delete the line** — `auto` keeps skipping
 because state is now populated. Removing the knob can never re-trigger bootstrap.
 
+## 6.7 B implementation outcomes (live-validated on kubepi)
+Facts the fresh-install e2e test surfaced — they constrain adoption (C) and corrected
+assumptions:
+- **Pre-install-hook dependency ordering.** The bootstrap migrate/key-seed Jobs are
+  pre-install hooks, so the resources they mount — the shared SA, Role/RoleBinding, the
+  DB-credential Secrets, and the storage-profiles ConfigMap — must ALSO be
+  `pre-install,pre-upgrade` hooks (weight `-10`, delete-policy **`before-hook-creation`**
+  only, so they persist for the main release). Minor consequences: each upgrade
+  deletes+recreates them (deterministic from values, cosmetic) and `helm uninstall` may
+  leave them orphaned (cleanup note for the migration guide).
+- **Maestro DB requires `pgvector` + CREATE EXTENSION.** mcp-gateway migrations run
+  `CREATE EXTENSION vector`, needing the extension available and a role that can create
+  it (test used `pgvector/pgvector:pg18` + a SUPERUSER maestro role). Adoption: existing
+  maestro DBs already have it; a fresh external Postgres must provide pgvector.
+- **A valid license is required to start.** mcp-gateway validates the license *before*
+  `MCP_MIGRATE_ONLY` runs, so the migrate-maestro Job must mount the license volume.
+- **Maestro proxy `instanceId` = `maestro_integrations.id`** (the lakerunner-type
+  integration row), NOT `maestro_lakerunner_deployments.id`. (Corrects the B plan.)
+- **key-seed inlines the sha256 hex** into the `psql -c` string (hex-only → injection-safe)
+  because `psql -c` does not expand `-v` variables.
+- **Validated end-to-end:** collector → rustfs → pubsub-http → process-* → cooked
+  segments; data returned by BOTH `query-api` direct (org key) and the maestro proxy
+  (`X-Org-Id` + per-user key). Marker `service_name=fresh-test`.
+
 ## 7. Adoption semantics & detection state machine
 
 Detection is a **state machine**, not a coarse "DB has rows ⇒ adopt" (which Codex

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -126,8 +126,8 @@ Discovered while building sub-project A; adopters' override files must account f
   matching the CF `cardinal-license` end-state). Default `license.secretName` =
   `cardinal-license`. Adopters who kept separate per-product license secrets, or a
   differently-named one, set `license.secretName` (+ `license.create:false`) to point at
-  their existing secret. **User confirm:** is one suite license correct for all existing
-  installs, or do any have genuinely distinct lakerunner vs maestro licenses?
+  their existing secret. **RESOLVED (user confirmed):** one shared suite license is
+  correct; the chart ships a single `license:` block (default secret `cardinal-license`).
 - **Known future-dedup debt (not defects; deferred):** duplicate `license-validation`
   hooks (one per family validating the same block), duplicate `cardinal-api-key` secrets
   (one per family, identical data), and large near-duplicate `_helpers-*.tpl` families.
@@ -141,12 +141,10 @@ SHA-pinned, with third-party images mirrored on ecr-public
 (`public.ecr.aws/docker/library/postgres:18-alpine`, `public.ecr.aws/aws-cli/...`).
 **ecr-public is the default; ghcr.io is the documented alternate.** The unified chart
 should default Cardinal images to ecr-public for consistency.
-- **Discrepancy to resolve:** the legacy lakerunner chart defaults its image to
-  `ghcr.io/cardinalhq/lakerunner`, whereas maestro + CF use `public.ecr.aws/cardinalhq.io/*`.
-  Decision (pending user confirm): unify the default to `public.ecr.aws/cardinalhq.io/lakerunner`,
-  keeping ghcr.io as a documented override. **Deferred out of sub-project A** (which copies
-  live values verbatim to keep render-parity clean); applied as a deliberate values change
-  before/within sub-project B so the diff is intentional and reviewable.
+- **RESOLVED (user confirmed):** unify the lakerunner default to
+  `public.ecr.aws/cardinalhq.io/lakerunner`, keeping ghcr.io as a documented override.
+  Applied as a deliberate, reviewed values change **in sub-project B** (kept out of A so
+  A's render-parity stayed clean).
 
 ## 6. Bootstrap — phased, not one monolithic hook
 

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -113,6 +113,26 @@ chart/
 Flat, monolithic. A migration guide ships a values-mapping note for adopters
 concatenating their two override files onto the unified keys.
 
+### 5.4a Values-contract changes from the merge (migration-guide inputs)
+Discovered while building sub-project A; adopters' override files must account for these:
+- **maestro DB config moved `database:` → `maestroDatabase:`.** The two charts had
+  incompatible `database:` schemas (lakerunner `database.lrdb.{host,...}` nested + flat
+  `secretName/create/passwordKey`; maestro `database.{host,...}` flat with different
+  values). Resolution: lakerunner's `database:` stays canonical; maestro's DB config is
+  namespaced as `maestroDatabase:` (rendered maestro DB wiring is byte-identical to
+  legacy — only the values key moved). Adopters with maestro `database:` overrides must
+  rename them to `maestroDatabase:`.
+- **Single shared `license:` block** (one CardinalHQ suite license for both products,
+  matching the CF `cardinal-license` end-state). Default `license.secretName` =
+  `cardinal-license`. Adopters who kept separate per-product license secrets, or a
+  differently-named one, set `license.secretName` (+ `license.create:false`) to point at
+  their existing secret. **User confirm:** is one suite license correct for all existing
+  installs, or do any have genuinely distinct lakerunner vs maestro licenses?
+- **Known future-dedup debt (not defects; deferred):** duplicate `license-validation`
+  hooks (one per family validating the same block), duplicate `cardinal-api-key` secrets
+  (one per family, identical data), and large near-duplicate `_helpers-*.tpl` families.
+  Candidates for consolidation in a later sub-project once parity/adoption are proven.
+
 ### 5.4 Image registries
 Per the updated `lakerunner-cloudformation` reference (`cardinal-defaults.yaml`,
 `image_manifest.py`), the standard is **100% `public.ecr.aws/cardinalhq.io/*` for all

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -1,7 +1,7 @@
 # Unified LakeRunner + Maestro Helm Chart — Design
 
 **Date:** 2026-06-05
-**Status:** Draft (Codex-reviewed; 2 decisions open for user — see §11)
+**Status:** Draft (Codex-reviewed; SA decision resolved; 2 open — see §11)
 **Branch:** `worktree-unified-chart`
 
 ## 1. Goal
@@ -51,7 +51,7 @@ The unified chart must support two distinct lifecycles:
 | Fresh-install bootstrap | **In-cluster port of the CloudFormation pattern** via idempotent broker Job(s) | Matches the stated end-state: naked LakeRunner + Maestro provisions the shared instance. |
 | Admin key model | **Secret-anchored, DB-reconciled** (see §6.1). Operator override via `existingSecret`. | LakeRunner ends up holding the key's hash (source of truth) while a durable Secret is the recoverable plaintext anchor — idempotent and crash-safe. |
 | Adopt vs fresh | **Detection-driven state machine (fresh/adopt/error), no required flag.** Optional `bootstrap: auto\|force\|never` override (default `auto`). | No "install fresh then remember to change something" footgun; removing any override can never re-trigger bootstrap. |
-| ServiceAccount | **OPEN — see §11.** Leaning: one SA for steady-state workloads + a separate, narrowly-scoped bootstrap SA. | User wanted one SA; Codex flagged blast-radius. Compromise honors both. |
+| ServiceAccount | **Configurable; single shared SA by default, splittable into two or more.** | Customers who don't care get one SA (simple). Security-conscious customers opt into per-component SAs with narrowly-scoped Roles. Honors the single-SA preference *and* Codex's blast-radius concern. |
 
 ## 4. Verified facts about the LakeRunner binary
 
@@ -92,8 +92,8 @@ chart/
   values.yaml           # one merged, flat values surface
   templates/
     _helpers.tpl        # merged helpers, one label/name scheme
-    serviceaccount.yaml # SAs (count TBD — §11)
-    rbac.yaml           # Role/RoleBindings (scoped per SA)
+    serviceaccount.yaml # one shared SA by default; per-component SAs opt-in
+    rbac.yaml           # Role/RoleBindings scoped per effective SA
     secrets/            # db, object-store, license, admin-key anchor
     lakerunner/         # LR workloads
     maestro/            # maestro, mcp-gateway, github-cache, dex, ingress
@@ -284,13 +284,13 @@ Suggested order: **A → B → C → D** (D can overlap once maestro templates l
 
 ## 11. Open decisions (need user input)
 
-1. **ServiceAccount split.** You wanted one normalized SA ("open to not, if enterprisey
-   reasons"). Codex's enterprisey reason: the broker needs **Secret-mutation** rights
-   and elevated DB access that no steady-state pod should carry, and LakeRunner
-   control-plane needs deployment-scale rights Maestro doesn't.
-   **Recommendation:** one normalized SA for steady-state workloads **+** a separate,
-   narrowly-scoped **bootstrap SA** (Secret write + DB). Optionally keep
-   control-plane's scaling RBAC on its own SA. Your call on how far to split.
+1. **ServiceAccount split — RESOLVED.** Configurable, with a **single shared SA as the
+   default** (broker + lakerunner + maestro all use it; its Role is the union of needed
+   perms) — simplest for customers who don't care. Operators who want least-privilege
+   **opt into per-component SAs** (e.g. a narrow `bootstrap` SA with Secret-write + DB,
+   a `controlPlane` SA with deployment-scale rights, a `maestro` SA); when a component
+   names its own SA it gets a narrowly-scoped Role, else it uses the shared union SA.
+   RBAC templates are structured so each component's Role binds to its *effective* SA.
 2. **Admin-key model.** §6.1 primary (Secret-anchored *and* DB-reconciled via
    `UpsertAdminAPIKey`, so LakeRunner owns the hash) vs the §6.1 alternative
    (Secret-only via `ADMIN_INITIAL_API_KEY` fallback, no DB row — simpler, matches

--- a/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-lakerunner-maestro-chart-design.md
@@ -1,0 +1,301 @@
+# Unified LakeRunner + Maestro Helm Chart — Design
+
+**Date:** 2026-06-05
+**Status:** Draft (Codex-reviewed; 2 decisions open for user — see §11)
+**Branch:** `worktree-unified-chart`
+
+## 1. Goal
+
+Merge the separate `lakerunner` and `maestro` Helm charts into a single chart. The
+two products are now considered one deployable unit. The legacy split charts will
+be retired once the unified chart reaches parity and the adoption path is proven.
+
+The unified chart must support two distinct lifecycles:
+
+1. **Fresh install** — stand up a working LakeRunner + Maestro from nothing,
+   following the "naked LakeRunner + Maestro-provisioned shared instance" pattern
+   that the `lakerunner-cloudformation` stack pioneered (the desired end state).
+2. **Adoption** — an operator deletes their existing split `lakerunner` and
+   `maestro` Helm releases and installs the unified chart with their existing
+   override values, pointed at the **same external Postgres and object store**.
+   Existing data, orgs, and configuration must be left untouched.
+
+## 2. Scope
+
+### In scope (keep)
+- All core LakeRunner data-plane and query-plane components (ingest/process,
+  compact, rollup, sweeper, query-api, query-worker, control-plane, admin-api).
+- Maestro API/UI, **mcp-gateway** (always-on; required component), **github-cache**
+  (HA infrastructure, auto-enabled when `ha.enabled=true`), **dex/OIDC**
+  (chart-native — we keep the chart's dex, not the ECS variant).
+- A new bootstrap/broker mechanism that wires LakeRunner ↔ Maestro automatically.
+
+### Out of scope (drop entirely)
+- **Grafana** (deployment, service, datasource configmap) — visualization is out.
+- **Bundled collector** (`collector.yaml`) as a shipped chart component. A collector
+  survives only as a **fresh-install test fixture**, not a chart-installable object.
+- **Perch / k8s-watcher** (clusterrole/deployment/configmap) — its LakeRunner↔Maestro
+  bridging role is being replaced; it leaves with the split chart.
+
+### Non-goals
+- No bundled Postgres or object store. Both are external, exactly as today.
+- No support for installing third-party observability tooling.
+- No changes to the behavior of existing (adopted) installs beyond schema
+  migrations, which are idempotent.
+
+## 3. Key decisions (resolved during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Chart structure | **Single monolithic chart** | Lakerunner+maestro are one unit now. Full control over resource names/labels/ordering (matters for a customer who checks in rendered `helm template` output and reviews diffs), no value nesting, no `helm dependency build` step, clean cross-cutting glue (shared secret, bootstrap). |
+| Fresh-install bootstrap | **In-cluster port of the CloudFormation pattern** via idempotent broker Job(s) | Matches the stated end-state: naked LakeRunner + Maestro provisions the shared instance. |
+| Admin key model | **Secret-anchored, DB-reconciled** (see §6.1). Operator override via `existingSecret`. | LakeRunner ends up holding the key's hash (source of truth) while a durable Secret is the recoverable plaintext anchor — idempotent and crash-safe. |
+| Adopt vs fresh | **Detection-driven state machine (fresh/adopt/error), no required flag.** Optional `bootstrap: auto\|force\|never` override (default `auto`). | No "install fresh then remember to change something" footgun; removing any override can never re-trigger bootstrap. |
+| ServiceAccount | **OPEN — see §11.** Leaning: one SA for steady-state workloads + a separate, narrowly-scoped bootstrap SA. | User wanted one SA; Codex flagged blast-radius. Compromise honors both. |
+
+## 4. Verified facts about the LakeRunner binary
+
+These shape the bootstrap design and are confirmed against `../lakerunner` source:
+
+1. **`ADMIN_INITIAL_API_KEY` is an in-memory fallback validator, not DB-seeded.**
+   admin-api accepts that key as valid **even with no DB row** (`internal/adminconfig/db.go:46-51`:
+   DB lookup first, then constant-time compare against the in-memory hash).
+2. **Keys are stored SHA256-hashed; random-generation paths return plaintext once.**
+   `create-initial-key` (CLI) and `POST /api/v1/admin-api-keys` generate random keys
+   and never re-expose plaintext; `create-initial-key` also fails if any key exists.
+   → We do **not** rely on capturing a one-time random key.
+3. **A plaintext-import/upsert path for admin keys exists.** `importAdminAPIKeys()` /
+   `UpsertAdminAPIKey` (`internal/bootstrap/import.go:195-211`) hashes a *caller-chosen*
+   plaintext and UPSERTs by hash — idempotent and re-runnable. (Org keys have an
+   analogous HTTP import at `POST /api/v1/organizations/{id}/api-keys/import`.)
+4. **No advisory lock guards key creation** (`cmd/admin_api.go:143-202`,
+   `admin/admin_api_keys.go:37-78`). → The broker must serialize its own mutations.
+5. **Admin keys are naked/global/no-org** (`lrconfig_admin_api_keys`); org keys require
+   an org. → "Naked LakeRunner, just a key, no orgs" = one admin key, zero orgs.
+6. **`lakerunner setup` runs migrations only** (idempotent); org/storage seeding is the
+   separate `initialize`/import path.
+
+### Verified facts about persistent state (de-risks adoption)
+- **maestro's `-data` PVC holds rebuildable working data** ("ephemeral working data:
+  orchestra artifact… falls back to in-memory artifact store"); in HA it must be off
+  (artifacts go to S3). **github-cache PVCs are warm git mirror caches** (rebuildable
+  by re-clone). The **precious state — orgs, config, telemetry — is all external**
+  (Postgres + object store). → delete-then-reinstall loses only rebuildable caches.
+
+## 5. Architecture
+
+### 5.1 Chart layout (monolithic)
+
+```
+chart/
+  Chart.yaml            # unified name/version; appVersion tracks both images
+  values.yaml           # one merged, flat values surface
+  templates/
+    _helpers.tpl        # merged helpers, one label/name scheme
+    serviceaccount.yaml # SAs (count TBD — §11)
+    rbac.yaml           # Role/RoleBindings (scoped per SA)
+    secrets/            # db, object-store, license, admin-key anchor
+    lakerunner/         # LR workloads
+    maestro/            # maestro, mcp-gateway, github-cache, dex, ingress
+    bootstrap/          # migration phase + broker/provision Job(s) — §6
+    NOTES.txt
+```
+
+### 5.2 Shared resources
+- **External Postgres**, one instance, three logical DBs: `lrdb`, `configdb`
+  (LakeRunner), `maestro` (Maestro). Values supply host/creds; chart does not create
+  the server.
+- **External object store** (S3-compatible). Values supply bucket/endpoint/creds.
+- **Admin-key anchor Secret** — durable, the plaintext source of truth for the
+  bootstrap credential (see §6.1).
+
+### 5.3 Values surface
+Flat, monolithic. A migration guide ships a values-mapping note for adopters
+concatenating their two override files onto the unified keys.
+
+## 6. Bootstrap — phased, not one monolithic hook
+
+Codex review rejected stuffing migrations + classification + credential minting +
+provisioning into a single `post-install` hook that races workload/admin-api
+readiness. Bootstrap is therefore split into **ordered phases** with explicit
+serialization. All phases are idempotent and driven by durable state.
+
+### 6.0 Serialization & ordering
+- A single **DB advisory lock** (LakeRunner already uses advisory locks for
+  migrations) OR a Kubernetes **Lease** serializes all bootstrap mutations, so
+  concurrent Helm syncs / Job retries / GitOps double-applies cannot race.
+- Phases run in order via Helm hook weights (pre-install/pre-upgrade for migrations
+  and key reconcile; post-install/post-upgrade for provisioning). Each phase
+  validates both sides of state before acting.
+- **Rollback:** bootstrap Jobs must not run schema-assuming or destructive logic on
+  `helm rollback`; migrations are forward-only and gated on detected schema version.
+
+### 6.1 Admin-key model (Secret-anchored, DB-reconciled)
+Chosen to eliminate the unrecoverable-crash failure mode (capturing a one-time random
+plaintext) and to make LakeRunner the durable owner:
+
+1. **Anchor the plaintext once.** Broker ensures a durable Secret holding the admin
+   key plaintext: if `adminKey.existingSecret` is set, use it (operator-supplied,
+   sealed-secrets/GitOps path); else generate a random value and create the Secret
+   with lookup-or-create (atomic; a losing concurrent creator reads the winner's).
+2. **Reconcile the DB hash from the anchor.** Feed that plaintext through the existing
+   `UpsertAdminAPIKey` import path → configdb stores the hash (LakeRunner = source of
+   truth). Deterministic: re-running re-hashes the same plaintext → same hash → no-op.
+3. admin-api validates the key from configdb (with the in-memory env fallback as a
+   belt-and-suspenders). Maestro reads the plaintext from the anchor Secret.
+
+This is crash-idempotent in every order: Secret-but-no-DB-row → re-import; the anchor
+is created before anything depends on it, so plaintext is never lost.
+
+> **Alternative (simpler, if import wiring proves awkward):** skip step 2 and inject
+> the anchor value as `ADMIN_INITIAL_API_KEY` into admin-api (in-memory fallback,
+> no DB row) **and** as `MAESTRO_BOOTSTRAP_..._ADMIN_API_KEY` into Maestro — exactly
+> the CloudFormation shape. Trade-off: the key lives only in the Secret, not in
+> LakeRunner's DB. Recorded as the fallback in §11.
+
+### 6.2 Migration phase (pre-workload)
+Run LakeRunner (`lrdb`,`configdb`) and Maestro DB migrations as a dedicated phase
+**before** app pods that depend on the schema start. One runner per DB; never let
+multiple Maestro replicas auto-migrate concurrently. Idempotent and safe on populated
+(adopted) DBs.
+
+### 6.3 Detection / classification phase
+Read durable state and classify (see §7). Output a clear status (configmap/Job log)
+so operators can see *why* fresh/adopt/error was chosen.
+
+### 6.4 Provisioning phase (fresh only)
+Maestro, via `MAESTRO_BOOTSTRAP_*`, provisions the shared LakeRunner deployment + org
++ storage, authenticating to in-cluster admin-api with the anchor key. Because Maestro
+bootstrap runs at process start, it **must tolerate admin-api readiness delays** (retry
+/ backoff) — this is a hard prerequisite on the Maestro app (§11). If the app's
+bootstrap is not resilient to admin-api being down, provisioning moves into a dedicated
+Job that waits for admin-api readiness instead of relying on pod start order.
+
+### 6.5 Maestro wiring (net-new in Helm)
+```
+MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL = http://<query-api-svc>:8080
+MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL = http://<admin-api-svc>:9091
+MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY = <from anchor Secret>
+MAESTRO_BOOTSTRAP_BUCKET_*                  = shared object-store coordinates
+```
+
+### 6.6 Bootstrap override knob
+`bootstrap: auto|force|never` (default `auto`): `auto` = detection-driven (safe
+default); `force` = always attempt provisioning (testing/recovery); `never` = never
+provision. Because `auto` is self-correcting against DB state, an operator may set
+`never` for a first adopt install, then **delete the line** — `auto` keeps skipping
+because state is now populated. Removing the knob can never re-trigger bootstrap.
+
+## 7. Adoption semantics & detection state machine
+
+Detection is a **state machine**, not a coarse "DB has rows ⇒ adopt" (which Codex
+correctly flagged as misclassifying partial/failed installs):
+
+- **fresh** — all relevant DBs are schema-current **and empty** of orgs/keys, and no
+  Maestro↔LakeRunner integration exists. → mint anchor + provision.
+- **adopt** — a valid existing Maestro LakeRunner integration/deployment exists *and*
+  points at consistent LakeRunner state. → skip minting + skip provisioning.
+- **error** — mixed/partial states (e.g. Maestro populated but `configdb` wiped;
+  anchor Secret present but no DB key; admin keys present from legacy `initialize`
+  with no Maestro integration). → **fail loudly** with a documented recovery path;
+  never silently choose fresh or adopt.
+
+Why detection is mandatory, not cosmetic: the legacy standalone Maestro never used
+`MAESTRO_BOOTSTRAP_*`; it learned about LakeRunner via a UI-configured integration in
+its DB. An adopted install already has a hand-made shared deployment, so blind
+bootstrap would create a duplicate. Detection prevents this.
+
+Determinism for GitOps: bootstrap manifests are always rendered; only runtime behavior
+branches on state. Rendered manifests stay a pure function of values — detection only
+ever *prevents* a mutation, never silently *causes* one.
+
+### Migration path
+Delete the split `lakerunner` + `maestro` releases, then install the unified chart
+with override values pointed at the same external Postgres + object store + secrets.
+Detection lands in **adopt** and no-ops all provisioning.
+- **PVCs:** all at-risk PVCs (maestro `-data`, github-cache) are rebuildable
+  caches/scratch; precious state is external (§4). Migration guide still recommends a
+  Postgres/object-store backup beforehand, and notes github-cache **cold-starts**
+  (re-clones mirrors) after adoption.
+
+## 8. Testing
+
+### 8.1 Adoption test (kubepi cluster, dedicated namespace)
+1. Install legacy split charts, healthy, with external-equivalent PG + object store.
+2. Configure a LakeRunner integration in Maestro the old (UI) way → populate the DB.
+3. `helm uninstall` both legacy releases.
+4. `helm install` the unified chart with equivalent overrides.
+5. **Assert:** services come up; detection → **adopt**; no duplicate orgs/deployments;
+   existing data/queries still work; github-cache cold-start completes.
+
+### 8.2 Fresh-install test (scripted, self-contained)
+- **Fixtures:** object store via **rustfs** (S3-compatible), **Postgres 18+**, a
+  **collector** fixture emitting logs/metrics/traces.
+- **Install:** unified chart, self-hosted mode, empty DBs → bootstrap anchors key +
+  provisions.
+- **Validation (curl-level acceptable for now):** (1) collector sends logs+metrics+
+  traces; (2) `query-api` returns it **directly** (curl); (3) the **same query via the
+  Maestro proxy path** returns it (curl) — proving provisioning + proxy route work;
+  (4) stretch: Maestro UI Explore shows it.
+
+The `../conductor` SaaS sandbox is a structural model only — customers do **not**
+install SaaS mode (`MAESTRO_DEPLOYMENT_MODE=saas` gates trial/license UX). The test
+runs **self-hosted**.
+
+### 8.3 Failure-mode acceptance tests (Codex-required before "adoption proven")
+- Broker crash after DB key reconcile but before Maestro reads the anchor.
+- Anchor-Secret/DB-key mismatch (e.g. sealed-secret changed after DB key existed).
+- Two concurrent bootstrap Jobs / GitOps double-sync (serialization holds).
+- `helm rollback` after an upgrade (no schema-assuming bootstrap re-run).
+- Populated Maestro + wiped `configdb` (and the inverse) → classified **error**, not a
+  silent fresh/adopt.
+- Missing/renamed PVC after adoption → cold-start path verified, no data loss.
+The broker emits a status summary (fresh/adopt/error + reason) for observability.
+
+## 9. Decomposition & build order
+
+Each sub-project gets its own spec → plan → implementation cycle:
+
+- **(A) Unified chart skeleton** — monolithic layout, merged helpers/labels,
+  SA(s)+RBAC (per §11), drop grafana/collector/perch. *Exit:* `helm template`/`lint`
+  render parity with the two legacy charts for equivalent values (minus dropped).
+- **(B) Fresh-install bootstrap** — phased migration + key anchor/reconcile +
+  `MAESTRO_BOOTSTRAP_*` wiring + serialization; plus the §8.2 fresh-install test.
+  *Exit:* fresh-install test passes end-to-end. **Depends on** the Maestro-bootstrap
+  resilience prerequisite (§11).
+- **(C) Adoption path** — detection state machine, `bootstrap` knob, migration guide +
+  values mapping; plus §8.1 + §8.3 tests. *Exit:* adoption + failure-mode tests pass.
+- **(D) Dex / OIDC consolidation** — settle chart-native dex into the unified chart.
+
+Suggested order: **A → B → C → D** (D can overlap once maestro templates land in A).
+
+## 10. Risks
+
+- **MAESTRO_BOOTSTRAP_* app contract** is unproven in Helm (exists only in the ECS
+  reference). Pin exact env names, retry-on-admin-api-down behavior, restart
+  idempotency, and skip/fail logging before implementing B (§11 prerequisite).
+- **Maestro DB migrations on adopt** must be forward-only and safe against a populated
+  maestro DB; the migration phase must prevent multi-replica concurrent auto-migrate.
+- **Admin-key lifecycle.** The anchor key is a high-value global admin credential.
+  Need a documented rotation flow (ensure new key → update Secret → roll Maestro →
+  verify → revoke old) and compromise/sealed-secret-mismatch behavior. Open whether
+  Maestro can use a least-privileged credential post-bootstrap instead of global admin.
+- **RBAC union** correctness once SAs/Roles are finalized (§11).
+
+## 11. Open decisions (need user input)
+
+1. **ServiceAccount split.** You wanted one normalized SA ("open to not, if enterprisey
+   reasons"). Codex's enterprisey reason: the broker needs **Secret-mutation** rights
+   and elevated DB access that no steady-state pod should carry, and LakeRunner
+   control-plane needs deployment-scale rights Maestro doesn't.
+   **Recommendation:** one normalized SA for steady-state workloads **+** a separate,
+   narrowly-scoped **bootstrap SA** (Secret write + DB). Optionally keep
+   control-plane's scaling RBAC on its own SA. Your call on how far to split.
+2. **Admin-key model.** §6.1 primary (Secret-anchored *and* DB-reconciled via
+   `UpsertAdminAPIKey`, so LakeRunner owns the hash) vs the §6.1 alternative
+   (Secret-only via `ADMIN_INITIAL_API_KEY` fallback, no DB row — simpler, matches
+   CloudFormation, but key not stored in LakeRunner). Recommendation: primary.
+3. **Maestro-bootstrap resilience prerequisite.** Implementing B cleanly assumes
+   Maestro's `MAESTRO_BOOTSTRAP_*` flow retries when admin-api isn't ready yet. If the
+   Maestro app doesn't already do this, we either fix it app-side or move provisioning
+   into a readiness-gated Job. Needs confirmation against the Maestro source.

--- a/test/adoption/00-run.sh
+++ b/test/adoption/00-run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Orchestrator for the conductor split->single ADOPTION test on kubepi.
+#
+# Proves: conductor can adopt an existing legacy split (lakerunner+maestro)
+# install against an external Postgres+store with bootstrap.mode=adopt, WITHOUT
+# duplicating or clobbering data; AND that mode=auto correctly ABORTS on a
+# legacy-shaped DB (safety net).
+#
+# SAFETY: every step pins --context kubepi (via lib.sh). Aborts if the current
+# context is not kubepi.
+#
+# Usage:  bash test/adoption/00-run.sh
+# Prints `ADOPTION PASS` and exits 0 on success. On failure leaves the namespace
+# up for inspection.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+export SNAP="${SNAP:-/tmp/conductor-adopt-snapshot.env}"
+
+echo "############################################################"
+echo "# conductor ADOPTION test  (context=$CTX ns=$NS)"
+echo "############################################################"
+
+bash "$HERE/10-legacy-install.sh"  || { echo "ADOPTION FAIL (10-legacy-install)"; exit 1; }
+bash "$HERE/20-populate-legacy.sh" || { echo "ADOPTION FAIL (20-populate-legacy)"; exit 1; }
+
+echo "==> [snapshot] capturing pre-adoption configdb/maestro counts -> $SNAP"
+{
+  echo "SNAP_ORGS=$(psql_db config configdb "SELECT count(*) FROM organizations;")"
+  echo "SNAP_BUCKETS=$(psql_db config configdb "SELECT count(*) FROM organization_buckets;")"
+  echo "SNAP_MORGS=$(psql_db maestro maestro "SELECT count(*) FROM maestro_organizations;")"
+} > "$SNAP"
+cat "$SNAP" | sed 's/^/    /'
+
+bash "$HERE/30-uninstall-legacy.sh" || { echo "ADOPTION FAIL (30-uninstall-legacy)"; exit 1; }
+bash "$HERE/40-adopt-install.sh"    || { echo "ADOPTION FAIL (40-adopt-install)"; exit 1; }
+bash "$HERE/50-assert-adopt.sh"     || { echo "ADOPTION FAIL (50-assert-adopt)"; exit 1; }
+bash "$HERE/60-assert-auto-aborts.sh" || { echo "ADOPTION FAIL (60-assert-auto-aborts)"; exit 1; }
+
+echo
+echo "ADOPTION PASS"

--- a/test/adoption/05-fixtures.yaml
+++ b/test/adoption/05-fixtures.yaml
@@ -1,0 +1,178 @@
+# Shared external Postgres 18 (pgvector) + rustfs S3 store for the adoption test.
+# These are the EXTERNAL stores that survive `helm uninstall` of the legacy
+# charts and are then adopted by conductor. Namespace-agnostic (short service
+# names only), so the same manifest works in conductor-adopt / conductor-fail.
+#
+# Mirrors test/fresh-install/10-postgres.yaml + 20-rustfs.yaml.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pg-credentials
+  labels: { app: postgres }
+type: Opaque
+stringData:
+  LRDB_PASSWORD: "testpassword123"
+  CONFIGDB_PASSWORD: "testpassword123"
+  MAESTRO_DB_PASSWORD: "testpassword123"
+  POSTGRES_PASSWORD: "testpassword123"
+---
+# Shared S3 credentials secret used by BOTH legacy charts (lakerunner +
+# maestro) and conductor — so maestro's objectStore.auth.existingSecret and
+# lakerunner's cloudProvider.aws.secretName both resolve to the same secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+  labels: { app: rustfs }
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: "rustfsadmin"
+  AWS_SECRET_ACCESS_KEY: "rustfsadmin"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  labels: { app: postgres }
+data:
+  01-init.sql: |
+    CREATE ROLE config WITH LOGIN PASSWORD 'testpassword123';
+    CREATE DATABASE configdb OWNER config;
+    GRANT ALL PRIVILEGES ON DATABASE configdb TO config;
+
+    CREATE ROLE maestro WITH LOGIN SUPERUSER PASSWORD 'testpassword123';
+    CREATE DATABASE maestro OWNER maestro;
+    GRANT ALL PRIVILEGES ON DATABASE maestro TO maestro;
+
+    ALTER ROLE lakerunner CREATEDB;
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels: { app: postgres }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels: { app: postgres }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector: { matchLabels: { app: postgres } }
+  template:
+    metadata:
+      labels: { app: postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg18
+          env:
+            - { name: POSTGRES_USER, value: "lakerunner" }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: pg-credentials, key: POSTGRES_PASSWORD } }
+            - { name: POSTGRES_DB, value: "lakerunner" }
+            - { name: PGDATA, value: "/var/lib/postgresql/data/pgdata" }
+          ports: [{ containerPort: 5432 }]
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+            - { name: init, mountPath: /docker-entrypoint-initdb.d }
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "lakerunner"] }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec: { command: ["pg_isready", "-U", "lakerunner"] }
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - { name: data, persistentVolumeClaim: { claimName: postgres-data } }
+        - { name: init, configMap: { name: postgres-init } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels: { app: postgres }
+spec:
+  selector: { app: postgres }
+  ports: [{ port: 5432, targetPort: 5432 }]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustfs-data
+  labels: { app: rustfs }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustfs
+  labels: { app: rustfs }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector: { matchLabels: { app: rustfs } }
+  template:
+    metadata:
+      labels: { app: rustfs }
+    spec:
+      securityContext: { fsGroup: 10001 }
+      containers:
+        - name: rustfs
+          image: rustfs/rustfs:1.0.0-beta.7
+          env:
+            - { name: RUSTFS_ACCESS_KEY, value: "rustfsadmin" }
+            - { name: RUSTFS_SECRET_KEY, value: "rustfsadmin" }
+            - { name: RUSTFS_VOLUMES, value: "/data" }
+            - { name: RUSTFS_CONSOLE_ADDRESS, value: ":9001" }
+          ports: [{ containerPort: 9000 }, { containerPort: 9001 }]
+          volumeMounts: [{ name: data, mountPath: /data }]
+      volumes: [{ name: data, persistentVolumeClaim: { claimName: rustfs-data } }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs
+  labels: { app: rustfs }
+spec:
+  selector: { app: rustfs }
+  ports:
+    - { name: api, port: 9000, targetPort: 9000 }
+    - { name: console, port: 9001, targetPort: 9001 }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rustfs-mkbucket
+  labels: { app: rustfs }
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels: { app: rustfs-mkbucket }
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-04-08T15-39-49Z
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              until mc alias set m http://rustfs:9000 rustfsadmin rustfsadmin; do
+                echo "waiting for rustfs..."; sleep 3
+              done
+              mc mb --ignore-existing m/lakerunner
+              mc ls m

--- a/test/adoption/05-fixtures.yaml
+++ b/test/adoption/05-fixtures.yaml
@@ -74,6 +74,10 @@ spec:
       containers:
         - name: postgres
           image: pgvector/pgvector:pg18
+          # Raise the connection ceiling — the full lakerunner stack's pgx pools
+          # (especially during rolling upgrades that briefly double pods) exceed
+          # Postgres's default max_connections=100 → "too many clients".
+          args: ["-c", "max_connections=400", "-c", "shared_buffers=256MB"]
           env:
             - { name: POSTGRES_USER, value: "lakerunner" }
             - name: POSTGRES_PASSWORD

--- a/test/adoption/10-legacy-install.sh
+++ b/test/adoption/10-legacy-install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Task 4 step 1: install the legacy split stack (lakerunner@3.13.6 +
+# maestro@0.8.22) against the EXTERNAL postgres+rustfs fixtures, with a legacy
+# org provisioned in configdb via storageProfiles + apiKeys.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+
+echo "==> [legacy] namespace $NS"
+kcg get ns "$NS" >/dev/null 2>&1 || kcg create ns "$NS"
+
+echo "==> [legacy] license secret"
+ensure_license
+
+echo "==> [legacy] external postgres + rustfs fixtures"
+kc apply -f "$HERE/05-fixtures.yaml" >/dev/null
+kc rollout status deploy/postgres --timeout=300s
+kc rollout status deploy/rustfs --timeout=300s
+kc wait --for=condition=complete job/rustfs-mkbucket --timeout=180s || true
+
+echo "==> [legacy] helm install lr (lakerunner 3.13.6)"
+helm install lr "$ROOT/lakerunner" -n "$NS" -f "$HERE/legacy-lakerunner-values.yaml" --timeout 600s
+
+echo "==> [legacy] helm install ms (maestro 0.8.22)"
+helm install ms "$ROOT/maestro" -n "$NS" -f "$HERE/legacy-maestro-values.yaml" --timeout 600s
+
+echo "==> [legacy] wait for setup job + rollouts"
+kc wait --for=condition=complete job/lr-lakerunner-setup --timeout=300s || true
+kc rollout status deploy/lr-lakerunner-query-api --timeout=300s
+kc rollout status deploy/lr-lakerunner-pubsub-http --timeout=300s
+kc rollout status deploy/ms-maestro-maestro --timeout=420s
+
+echo "==> [legacy] configdb org/bucket rows (should show legacy org)"
+echo "    organizations:        $(psql_db config configdb "SELECT count(*) FROM organizations;")"
+echo "    organization_buckets: $(psql_db config configdb "SELECT count(*) FROM organization_buckets;")"
+echo "[legacy] install complete"

--- a/test/adoption/20-populate-legacy.sh
+++ b/test/adoption/20-populate-legacy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Task 4 step 2: simulate the legacy maestro<->lakerunner integration the way the
+# legacy maestro UI would, via direct DB inserts into the maestro DB.
+#
+# SCHEMA NOTE (chart/plan finding): the plan called for a row
+#   maestro_integrations(type='lakerunner', deployment_id IS NULL)
+# but maestro v1.53.0 (the appVersion both the legacy maestro@0.8.22 chart AND
+# conductor pin) forbids that with CHECK chk_lakerunner_has_deployment
+#   (type <> 'lakerunner' OR deployment_id IS NOT NULL).
+# So the detection signal `M_LEGACY = count(... deployment_id IS NULL)` can NEVER
+# be > 0 on a real v1.53.0 maestro DB — it is effectively dead. The real legacy
+# signal that DOES fire (and that we exercise here) is M_ORGS>0 via a
+# maestro_organizations row. We additionally build a fully constraint-valid
+# legacy lakerunner integration (source='external_byo' deployment + a site,
+# auto_add_to_all_orgs=false so M_SHARED stays 0) so the "integration intact +
+# not duplicated" assertion has a real row to check.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+
+SITE_ID="44444444-4444-4444-4444-444444444444"
+DEPLOY_ID="33333333-3333-3333-3333-333333333333"
+
+echo "==> [populate] insert legacy maestro org + site + external_byo deployment + integration"
+psql_db maestro maestro "
+BEGIN;
+  -- Legacy org (UI-created). Drives the M_ORGS detection signal (M_STATE=1).
+  INSERT INTO maestro_organizations (id, name, slug)
+  VALUES ('${LEGACY_ORG}', 'Legacy Org', 'legacy-org')
+  ON CONFLICT (id) DO NOTHING;
+
+  -- A site for the customer-brought-their-own (external_byo) deployment.
+  INSERT INTO maestro_sites (site_id, org_id, name, mode, purpose, status)
+  VALUES ('${SITE_ID}', '${LEGACY_ORG}', 'legacy-site', 'self_managed', 'standard', 'registered')
+  ON CONFLICT (site_id) DO NOTHING;
+
+  -- A legacy (non-conductor) lakerunner deployment. source='external_byo':
+  --   * connection_owner must be 'customer' (chk_source_connection_owner_lockstep)
+  --   * org_id AND site_id must be set (chk_scope_invariant)
+  --   * auto_add_to_all_orgs=false (chk_auto_add_only_shared) -> NOT counted by M_SHARED
+  INSERT INTO maestro_lakerunner_deployments
+    (id, name, source, connection_owner, enabled, is_demo, auto_add_to_all_orgs,
+     org_id, site_id, admin_api_url, admin_api_key, query_api_url)
+  VALUES ('${DEPLOY_ID}', 'Legacy Lakerunner', 'external_byo', 'customer',
+          true, false, false,
+          '${LEGACY_ORG}', '${SITE_ID}',
+          'http://lr-lakerunner-admin-api:8081', '${LEGACY_KEY}',
+          'http://lr-lakerunner-query-api:8080')
+  ON CONFLICT (id) DO NOTHING;
+
+  -- The integration row the legacy UI creates, referencing that deployment
+  -- (deployment_id NOT NULL satisfies chk_lakerunner_has_deployment).
+  INSERT INTO maestro_integrations
+    (org_id, type, slug, name, credentials, deployment_id, status)
+  VALUES ('${LEGACY_ORG}', 'lakerunner', 'legacy-lakerunner', 'Legacy Lakerunner',
+          jsonb_build_object('api_key', '${LEGACY_KEY}'),
+          '${DEPLOY_ID}', 'active')
+  ON CONFLICT (org_id, type, slug) DO NOTHING;
+COMMIT;
+"
+
+echo "==> [populate] verify detection signals"
+echo "    maestro_organizations (M_ORGS):         $(psql_db maestro maestro "SELECT count(*) FROM maestro_organizations;")"
+echo "    lakerunner integrations:                $(psql_db maestro maestro "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner';")"
+echo "    shared_cardinal deployments (M_SHARED): $(psql_db maestro maestro "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';")"
+psql_db maestro maestro "SELECT type, deployment_id IS NOT NULL AS has_deploy, slug FROM maestro_integrations;" | sed 's/^/    integ: /'
+echo "[populate] done"

--- a/test/adoption/30-uninstall-legacy.sh
+++ b/test/adoption/30-uninstall-legacy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Task 5 step 1: uninstall the legacy split charts. The EXTERNAL postgres +
+# rustfs (and all their data: configdb orgs/buckets, maestro orgs/integrations,
+# the lakerunner bucket) REMAIN — that is exactly what conductor adopts.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+
+echo "==> [uninstall] helm uninstall lr ms"
+helm uninstall lr -n "$NS" --wait || true
+helm uninstall ms -n "$NS" --wait || true
+
+echo "==> [uninstall] wait for legacy app pods to disappear (postgres/rustfs stay)"
+for i in $(seq 1 60); do
+  remaining="$(kc get pods -l 'app.kubernetes.io/name in (lakerunner,maestro)' --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  # also catch the github-cache / mcp pods by release label
+  remaining2="$(kc get pods --no-headers 2>/dev/null | grep -E '^(lr|ms)-' | wc -l | tr -d ' ')"
+  if [ "$remaining2" = "0" ]; then break; fi
+  sleep 5
+done
+echo "    leftover lr/ms pods: $(kc get pods --no-headers 2>/dev/null | grep -E '^(lr|ms)-' | wc -l | tr -d ' ')"
+echo "    external stores still up:"
+kc get deploy postgres rustfs --no-headers 2>/dev/null | sed 's/^/      /'
+
+echo "==> [uninstall] confirm external DB data survived uninstall"
+echo "    configdb organizations:        $(psql_db config configdb "SELECT count(*) FROM organizations;")"
+echo "    configdb organization_buckets: $(psql_db config configdb "SELECT count(*) FROM organization_buckets;")"
+echo "    maestro_organizations:         $(psql_db maestro maestro "SELECT count(*) FROM maestro_organizations;")"
+echo "[uninstall] done"

--- a/test/adoption/40-adopt-install.sh
+++ b/test/adoption/40-adopt-install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Task 5 step 2: helm install conductor with bootstrap.mode=adopt, pointed at the
+# SAME external postgres + rustfs the legacy split charts used.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+
+echo "==> [adopt] helm install conductor (bootstrap.mode=adopt)"
+helm install conductor "$ROOT/conductor" -n "$NS" \
+  -f "$HERE/conductor-adopt-values.yaml" --timeout 600s
+
+echo "==> [adopt] wait for rollouts"
+kc rollout status deploy/conductor-maestro-maestro --timeout=420s
+kc rollout status deploy/conductor-lakerunner-query-api --timeout=300s
+kc rollout status deploy/conductor-lakerunner-pubsub-http --timeout=300s
+echo "[adopt] install complete"

--- a/test/adoption/50-assert-adopt.sh
+++ b/test/adoption/50-assert-adopt.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Task 5 step 3: assert adoption correctness.
+#   (a) all conductor pods Ready
+#   (b) NO new bootstrap: M_SHARED (shared_cardinal deployment) still 0, and the
+#       legacy maestro_integrations row intact + singular (not duplicated)
+#   (c) configdb org/bucket counts unchanged from the pre-adoption snapshot
+#   (d) existing data still queryable via query-api with the legacy org key
+#       (auth accepted -> HTTP 200; no telemetry was ingested so result is empty)
+# Reads the pre-adoption snapshot from $SNAP (written by 00-run.sh before 30).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+SNAP="${SNAP:-/tmp/conductor-adopt-snapshot.env}"
+
+FAIL=0
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; FAIL=1; }
+
+echo "==> (a) all conductor pods Ready"
+NOTREADY=$(kc get pods -l app.kubernetes.io/instance=conductor --no-headers 2>/dev/null \
+  | awk '{split($2,a,"/"); if (a[1]!=a[2] || $3!="Running") print $1" "$2" "$3}')
+if [ -z "$NOTREADY" ]; then pass "all conductor pods Ready"; else fail "not-ready conductor pods:"; echo "$NOTREADY" | sed 's/^/    /'; fi
+
+echo "==> (b) no new bootstrap (M_SHARED==0, legacy integration singular)"
+M_SHARED=$(psql_db maestro maestro "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal' AND enabled AND is_demo=false AND auto_add_to_all_orgs AND btrim(coalesce(admin_api_url,''))<>'' AND btrim(coalesce(admin_api_key,''))<>'';")
+INTEG=$(psql_db maestro maestro "SELECT count(*) FROM maestro_integrations WHERE type='lakerunner';")
+M_ORGS=$(psql_db maestro maestro "SELECT count(*) FROM maestro_organizations;")
+echo "    M_SHARED=$M_SHARED  lakerunner_integrations=$INTEG  maestro_orgs=$M_ORGS"
+[ "$M_SHARED" = "0" ] && pass "no shared_cardinal deployment created (M_SHARED=0)" || fail "adopt created a shared_cardinal deployment (M_SHARED=$M_SHARED)"
+[ "$INTEG" = "1" ]    && pass "legacy lakerunner integration intact + singular (count=1)" || fail "lakerunner integration count is $INTEG (expected 1 — duplication?)"
+
+echo "==> (c) configdb org/bucket counts unchanged from pre-adoption snapshot"
+# shellcheck disable=SC1090
+[ -f "$SNAP" ] && . "$SNAP" || { fail "snapshot $SNAP missing"; SNAP_ORGS=""; SNAP_BUCKETS=""; SNAP_MORGS=""; }
+LR_ORGS_NOW=$(psql_db config configdb "SELECT count(*) FROM organizations;")
+LR_BUCKETS_NOW=$(psql_db config configdb "SELECT count(*) FROM organization_buckets;")
+M_ORGS_NOW="$M_ORGS"
+echo "    configdb orgs: snapshot=$SNAP_ORGS now=$LR_ORGS_NOW"
+echo "    configdb buckets: snapshot=$SNAP_BUCKETS now=$LR_BUCKETS_NOW"
+echo "    maestro orgs: snapshot=$SNAP_MORGS now=$M_ORGS_NOW"
+[ -n "$SNAP_ORGS" ]    && [ "$LR_ORGS_NOW" = "$SNAP_ORGS" ]       && pass "configdb organizations unchanged ($LR_ORGS_NOW)" || fail "configdb organizations changed ($SNAP_ORGS -> $LR_ORGS_NOW)"
+[ -n "$SNAP_BUCKETS" ] && [ "$LR_BUCKETS_NOW" = "$SNAP_BUCKETS" ] && pass "configdb organization_buckets unchanged ($LR_BUCKETS_NOW)" || fail "configdb organization_buckets changed ($SNAP_BUCKETS -> $LR_BUCKETS_NOW)"
+[ -n "$SNAP_MORGS" ]   && [ "$M_ORGS_NOW" = "$SNAP_MORGS" ]       && pass "maestro_organizations unchanged ($M_ORGS_NOW)" || fail "maestro_organizations changed ($SNAP_MORGS -> $M_ORGS_NOW)"
+
+echo "==> (d) legacy org queryable via query-api with the legacy org key"
+HELPER=adopt-validate-curl
+kc delete pod "$HELPER" --ignore-not-found >/dev/null 2>&1
+kc run "$HELPER" --image=curlimages/curl:latest --restart=Never --command -- sleep 300 >/dev/null
+for _ in $(seq 1 30); do
+  [ "$(kc get pod "$HELPER" -o jsonpath='{.status.phase}' 2>/dev/null)" = "Running" ] && break; sleep 2
+done
+trap 'kc delete pod "$HELPER" --ignore-not-found >/dev/null 2>&1 || true' EXIT
+QUERY='{"q":"{service_name=\"anything\"}","s":"e-1h","e":"now"}'
+CODE=""
+for attempt in 1 2 3 4 5 6; do
+  CODE=$(kc exec "$HELPER" -- curl -sS -m 60 -o /dev/null -w '%{http_code}' \
+    -H "x-cardinalhq-api-key: ${LEGACY_KEY}" -H 'content-type: application/json' \
+    -d "$QUERY" \
+    "http://conductor-lakerunner-query-api.${NS}.svc:8080/api/v1/logs/query" 2>/dev/null)
+  echo "    query-api HTTP $CODE (attempt $attempt)"
+  [ "$CODE" = "200" ] && break
+  sleep 10
+done
+[ "$CODE" = "200" ] && pass "query-api accepted the legacy org key (HTTP 200 — configdb apikey+profile survived)" \
+                    || fail "query-api rejected the legacy org key (HTTP $CODE)"
+
+echo
+if [ "$FAIL" -ne 0 ]; then echo "ADOPT ASSERTIONS FAILED"; exit 1; fi
+echo "ADOPT ASSERTIONS PASSED"

--- a/test/adoption/60-assert-auto-aborts.sh
+++ b/test/adoption/60-assert-auto-aborts.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Task 6 step 1: against the SAME legacy-populated external DBs, attempt
+# `helm install conductor-auto ... --set bootstrap.mode=auto` and assert it
+# FAILS with the detect Job classifying ADOPT_LEGACY. This proves the safety
+# net prevents accidental duplication when the operator forgets mode=adopt.
+#
+# The detect Job's hook-delete-policy is `before-hook-creation,hook-succeeded`,
+# so a FAILED detect job is NOT deleted — its pod + logs remain for inspection.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+REL=conductor-auto
+
+FAIL=0
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; FAIL=1; }
+
+echo "==> [auto-abort] cleanup any prior conductor-auto release/job"
+helm uninstall "$REL" -n "$NS" >/dev/null 2>&1 || true
+kc delete job "${REL}-bootstrap-detect" --ignore-not-found >/dev/null 2>&1 || true
+
+echo "==> [auto-abort] helm install $REL --set bootstrap.mode=auto (expected to FAIL)"
+# Supply valid bootstrap.org/bucket so the chart RENDERS under mode=auto (those
+# fields are required when bootstrap is active) — the abort we are proving must
+# come from the pre-install DETECT Job classifying the legacy DB, NOT from a
+# render-time required-field error.
+set +e
+helm install "$REL" "$ROOT/conductor" -n "$NS" \
+  -f "$HERE/conductor-adopt-values.yaml" --set bootstrap.mode=auto \
+  --set bootstrap.org.id=11111111-1111-1111-1111-111111111111 \
+  --set bootstrap.org.ownerEmail=admin@test.local \
+  --set bootstrap.bucket.name=lakerunner \
+  --set bootstrap.bucket.endpoint=http://rustfs:9000 \
+  --set bootstrap.bucket.usePathStyle=true \
+  --set bootstrap.bucket.insecureTls=true \
+  --timeout 300s > /tmp/auto-abort-helm.log 2>&1
+HELM_RC=$?
+set -e 2>/dev/null || true
+echo "    helm rc=$HELM_RC"
+tail -5 /tmp/auto-abort-helm.log | sed 's/^/    helm: /'
+
+[ "$HELM_RC" -ne 0 ] && pass "helm install aborted (rc=$HELM_RC) under mode=auto on a legacy DB" \
+                     || fail "helm install SUCCEEDED under mode=auto on a legacy DB (should have aborted!)"
+
+echo "==> [auto-abort] detect Job log (should show ADOPT_LEGACY)"
+# The failed detect job/pod is retained (hook-delete-policy excludes hook-failed).
+DETECT_LOG="$(kc logs job/${REL}-bootstrap-detect 2>/dev/null || true)"
+if [ -z "$DETECT_LOG" ]; then
+  # fall back to the pod by label if the job object query missed
+  POD="$(kc get pods -l job-name=${REL}-bootstrap-detect -o name 2>/dev/null | head -1)"
+  [ -n "$POD" ] && DETECT_LOG="$(kc logs "$POD" 2>/dev/null || true)"
+fi
+echo "------- detect job log -------"
+echo "$DETECT_LOG" | sed 's/^/    /'
+echo "------------------------------"
+echo "$DETECT_LOG" | grep -q 'ADOPT_LEGACY' && pass "detect Job classified ADOPT_LEGACY" \
+                                            || fail "detect Job did NOT log ADOPT_LEGACY"
+
+echo "==> [auto-abort] assert no shared_cardinal deployment was created by the aborted run"
+M_SHARED=$(psql_db maestro maestro "SELECT count(*) FROM maestro_lakerunner_deployments WHERE source='shared_cardinal';")
+[ "$M_SHARED" = "0" ] && pass "no shared_cardinal deployment created by aborted auto run (M_SHARED=0)" \
+                      || fail "aborted auto run left a shared_cardinal deployment (M_SHARED=$M_SHARED)"
+
+echo "==> [auto-abort] cleanup failed release + retained detect job"
+helm uninstall "$REL" -n "$NS" >/dev/null 2>&1 || true
+kc delete job "${REL}-bootstrap-detect" --ignore-not-found >/dev/null 2>&1 || true
+
+echo
+if [ "$FAIL" -ne 0 ]; then echo "AUTO-ABORT ASSERTIONS FAILED"; exit 1; fi
+echo "AUTO-ABORT ASSERTIONS PASSED"

--- a/test/adoption/99-teardown.sh
+++ b/test/adoption/99-teardown.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Teardown for the adoption test: delete the throwaway namespace.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/lib.sh"
+echo "==> deleting namespace $NS"
+kcg delete ns "$NS" --wait=false
+echo "done (namespace deletion is async)"

--- a/test/adoption/conductor-adopt-values.yaml
+++ b/test/adoption/conductor-adopt-values.yaml
@@ -1,0 +1,101 @@
+# conductor adopt-mode values — points at the SAME external postgres + rustfs
+# that the legacy split charts used. bootstrap.mode=adopt renders NO detection,
+# key-seed, anchor Secret, or MAESTRO_BOOTSTRAP_* — conductor simply attaches to
+# the existing external DB/store and provisions nothing.
+
+global:
+  resources:
+    enabled: false
+  autoscaling:
+    mode: disabled
+
+license:
+  create: false
+  secretName: "cardinal-license"
+
+database:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "LRDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "lakerunner"
+    username: "lakerunner"
+    sslMode: "disable"
+
+configdb:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "CONFIGDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "configdb"
+    username: "config"
+    sslMode: "disable"
+
+maestroDatabase:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  host: "postgres"
+  port: 5432
+  name: "maestro"
+  username: "maestro"
+  sslMode: "disable"
+
+cloudProvider:
+  provider: "aws"
+  aws:
+    region: "us-east-1"
+    # Shared aws-credentials secret created by 05-fixtures.yaml.
+    create: false
+    secretName: "aws-credentials"
+    inject: true
+
+# Adopting: orgs/keys/profiles already exist in the external configdb. Render
+# none from the chart.
+storageProfiles:
+  source: config
+  create: true
+  yaml: []
+apiKeys:
+  source: config
+  create: true
+  yaml: []
+
+# Maestro's own object-store access (artifacts) — same rustfs bucket/creds.
+objectStore:
+  bucket: "lakerunner"
+  region: "us-east-1"
+  endpoint: "http://rustfs:9000"
+  forcePathStyle: true
+  auth:
+    existingSecret: "aws-credentials"
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+
+pubsub:
+  HTTP:
+    enabled: true
+    replicas: 1
+
+ha:
+  enabled: false
+
+maestro:
+  enabled: true
+  replicas: 1
+  baseUrl: "http://conductor-maestro-maestro.conductor-adopt.svc.cluster.local:4200"
+  tls:
+    enabled: false
+
+dex:
+  enabled: false
+
+grafana:
+  enabled: false
+
+bootstrap:
+  mode: adopt

--- a/test/adoption/legacy-lakerunner-values.yaml
+++ b/test/adoption/legacy-lakerunner-values.yaml
@@ -1,0 +1,79 @@
+# Legacy lakerunner@3.13.6 install values, wired to the EXTERNAL postgres+rustfs
+# fixtures (05-fixtures.yaml). Provisions a legacy org via storageProfiles +
+# apiKeys (the pre-conductor way). After uninstall, configdb retains this org's
+# organizations / organization_buckets rows, which conductor adopts.
+
+global:
+  resources:
+    enabled: false
+  autoscaling:
+    mode: disabled
+
+license:
+  create: false
+  secretName: "cardinal-license"
+
+database:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "LRDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "lakerunner"
+    username: "lakerunner"
+    sslMode: "disable"
+
+configdb:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "CONFIGDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "configdb"
+    username: "config"
+    sslMode: "disable"
+
+cloudProvider:
+  provider: "aws"
+  aws:
+    region: "us-east-1"
+    # Shared aws-credentials secret is created by 05-fixtures.yaml so both
+    # legacy charts (and conductor) reference the same secret.
+    create: false
+    secretName: "aws-credentials"
+    inject: true
+
+storageProfiles:
+  source: config
+  create: true
+  yaml:
+    - organization_id: "22222222-2222-2222-2222-222222222222"
+      instance_num: 1
+      collector_name: "legacy"
+      cloud_provider: "aws"
+      region: "us-east-1"
+      bucket: "lakerunner"
+      endpoint: "http://rustfs:9000"
+      use_path_style: true
+      insecure_tls: true
+
+apiKeys:
+  source: config
+  create: true
+  yaml:
+    - organization_id: "22222222-2222-2222-2222-222222222222"
+      keys:
+        - "legacy-api-key-2222"
+
+pubsub:
+  HTTP:
+    enabled: true
+    replicas: 1
+
+ha:
+  enabled: false
+
+grafana:
+  enabled: false

--- a/test/adoption/legacy-maestro-values.yaml
+++ b/test/adoption/legacy-maestro-values.yaml
@@ -1,0 +1,46 @@
+# Legacy maestro@0.8.22 install values, wired to the EXTERNAL postgres fixture.
+# No MAESTRO_BOOTSTRAP_* — legacy maestro does NOT auto-create a shared_cardinal
+# deployment. The maestro<->lakerunner integration is a manual UI step, which we
+# simulate after install with a direct DB insert (20-populate-legacy.sh). After
+# uninstall, the maestro DB retains the org + integration rows.
+
+ha:
+  enabled: false
+
+image:
+  repository: public.ecr.aws/cardinalhq.io/maestro
+  pullPolicy: IfNotPresent
+
+objectStore:
+  bucket: "lakerunner"
+  region: "us-east-1"
+  endpoint: "http://rustfs:9000"
+  forcePathStyle: true
+  auth:
+    existingSecret: "aws-credentials"
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+
+license:
+  create: false
+  secretName: "cardinal-license"
+
+database:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  host: "postgres"
+  port: 5432
+  name: "maestro"
+  username: "maestro"
+  sslMode: "disable"
+
+maestro:
+  enabled: true
+  replicas: 1
+  baseUrl: "http://ms-maestro.conductor-adopt.svc.cluster.local:4200"
+  tls:
+    enabled: false
+
+dex:
+  enabled: false

--- a/test/adoption/lib.sh
+++ b/test/adoption/lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Shared helpers + safety for the conductor adoption test (kubepi only).
+#
+# SAFETY: every kubectl/helm call MUST go through kc()/helm() which pin
+# --context kubepi. Sourcing this file aborts if the current kube context is
+# not kubepi, so a stray default-context never touches aws-prod.
+set -uo pipefail
+
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-adopt}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+# The org we provision in the legacy lakerunner (configdb) + maestro.
+LEGACY_ORG="${LEGACY_ORG:-22222222-2222-2222-2222-222222222222}"
+LEGACY_KEY="${LEGACY_KEY:-legacy-api-key-2222}"
+
+kc()   { command kubectl --context "$CTX" -n "$NS" "$@"; }
+kcg()  { command kubectl --context "$CTX" "$@"; }
+helm() { command helm --kube-context "$CTX" "$@"; }
+
+# psql into the bundled postgres (read or write) as a given role/db.
+psql_db() { # role db sql
+  kc exec -i deploy/postgres -- psql -U "$1" -d "$2" -tAc "$3"
+}
+
+_safety_check() {
+  local current
+  current="$(command kubectl config current-context 2>/dev/null)"
+  if [ "$current" != "$CTX" ]; then
+    echo "ABORT: current kube context is '$current', expected '$CTX'. Refusing to run." >&2
+    exit 2
+  fi
+}
+_safety_check
+
+# Mint a michael-dev-signing license into secret cardinal-license in $NS.
+# Reuses the same approach as the fresh-install rig.
+ensure_license() {
+  local lic=/tmp/conductor-adopt-license.json
+  if [ ! -s "$lic" ]; then
+    local sign_dir=/tmp/conductor-adopt-signing
+    mkdir -p "$sign_dir"
+    command kubectl --context "$CTX" -n test-saas get secret license-signing-keys \
+      -o jsonpath='{.data.michael-dev-signing\.private\.pem}' | base64 -d > "$sign_dir/key.pem"
+    local mint="$ROOT/../conductor/dev/trial-testenv/scripts/mint-license.mjs"
+    [ -f "$mint" ] || mint="/Users/explorer/git/github/cardinalhq/conductor/dev/trial-testenv/scripts/mint-license.mjs"
+    node "$mint" --key "$sign_dir/key.pem" --key-id michael-dev-signing \
+      --kind lakerunner --customer "$NS" --days 365 > "$lic"
+  fi
+  kc create secret generic cardinal-license --from-file=license.json="$lic" \
+    --dry-run=client -o yaml | kc apply -f - >/dev/null
+}

--- a/test/adoption/lib.sh
+++ b/test/adoption/lib.sh
@@ -19,9 +19,27 @@ kc()   { command kubectl --context "$CTX" -n "$NS" "$@"; }
 kcg()  { command kubectl --context "$CTX" "$@"; }
 helm() { command helm --kube-context "$CTX" "$@"; }
 
-# psql into the bundled postgres (read or write) as a given role/db.
+# Resolve the concrete Running postgres pod (avoids `deploy/postgres` exec races
+# during/after a rollout, and the flaky `-i` with no stdin returning empty).
+pg_pod() {
+  kc get pods -l app=postgres --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# psql into the bundled postgres (read or write) as a given role/db. Targets the
+# pod by name (no `-i`) and retries so a transient empty result during a rollout
+# does not silently return "".
 psql_db() { # role db sql
-  kc exec -i deploy/postgres -- psql -U "$1" -d "$2" -tAc "$3"
+  local out pod
+  for _ in 1 2 3 4 5 6; do
+    pod="$(pg_pod)"
+    if [ -n "$pod" ]; then
+      out="$(kc exec "$pod" -- psql -U "$1" -d "$2" -tAc "$3" 2>/dev/null | tr -d '[:space:]')"
+      [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+    fi
+    sleep 2
+  done
+  printf '%s\n' "$out"
 }
 
 _safety_check() {

--- a/test/failure-modes/fail-values.yaml
+++ b/test/failure-modes/fail-values.yaml
@@ -1,0 +1,93 @@
+# conductor values for the failure-mode tests (ns conductor-fail). Wired to the
+# in-namespace external postgres + rustfs fixtures (test/adoption/05-fixtures.yaml).
+# bootstrap.mode=auto, fresh org — github-cache StatefulSet ENABLED so the
+# PVC cold-start case (5) has a stateful workload to exercise.
+
+global:
+  resources:
+    enabled: false
+  autoscaling:
+    mode: disabled
+
+license:
+  create: false
+  secretName: "cardinal-license"
+
+database:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "LRDB_PASSWORD"
+  lrdb: { host: "postgres", port: 5432, name: "lakerunner", username: "lakerunner", sslMode: "disable" }
+
+configdb:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "CONFIGDB_PASSWORD"
+  lrdb: { host: "postgres", port: 5432, name: "configdb", username: "config", sslMode: "disable" }
+
+maestroDatabase:
+  create: false
+  secretName: "pg-credentials"
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  host: "postgres"
+  port: 5432
+  name: "maestro"
+  username: "maestro"
+  sslMode: "disable"
+
+cloudProvider:
+  provider: "aws"
+  aws: { region: "us-east-1", create: false, secretName: "aws-credentials", inject: true }
+
+objectStore:
+  bucket: "lakerunner"
+  region: "us-east-1"
+  endpoint: "http://rustfs:9000"
+  forcePathStyle: true
+  auth:
+    existingSecret: "aws-credentials"
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+
+storageProfiles: { source: config, create: true, yaml: [] }
+apiKeys: { source: config, create: true, yaml: [] }
+
+pubsub:
+  HTTP: { enabled: true, replicas: 1 }
+
+ha:
+  enabled: false
+
+maestro:
+  enabled: true
+  replicas: 1
+  baseUrl: "http://conductor-maestro-maestro.conductor-fail.svc.cluster.local:4200"
+  tls: { enabled: false }
+
+dex:
+  enabled: false
+
+grafana:
+  enabled: false
+
+# Enable the github-cache StatefulSet (off by default in POC) so case 5
+# (PVC cold-start) has a stateful workload with a volumeClaimTemplate.
+githubCache:
+  enabled: true
+  serving:
+    replicas: 1
+
+bootstrap:
+  mode: auto
+  org:
+    id: "11111111-1111-1111-1111-111111111111"
+    name: "default"
+    ownerEmail: "admin@test.local"
+  bucket:
+    name: "lakerunner"
+    region: "us-east-1"
+    cloudProvider: "aws"
+    collectorName: "default"
+    endpoint: "http://rustfs:9000"
+    usePathStyle: true
+    insecureTls: true

--- a/test/failure-modes/run.sh
+++ b/test/failure-modes/run.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Task 7: §8.3 failure-mode acceptance tests for conductor, on kubepi, in the
+# throwaway namespace conductor-fail. Each case prints PASS/FAIL; the script
+# exits non-zero if ANY case fails.
+#
+# Cases:
+#   1. split-brain (maestro populated, configdb empty) -> auto detect aborts
+#      with ERROR (only one side populated).
+#   2. anchor-Secret / DB-key mismatch -> maestro surfaces an auth error but does
+#      NOT crashloop the whole release; re-running key-seed reconciles.
+#   3. two concurrent key-seed Jobs -> ON CONFLICT keeps exactly one
+#      admin_api_keys row, no error.
+#   4. helm rollback after an upgrade -> release healthy, migrations not
+#      destructively re-run.
+#   5. PVC cold-start after adoption -> github-cache StatefulSet re-clones (no
+#      data loss; eventually Ready).
+#
+# SAFETY: every kubectl/helm call is pinned to --context kubepi; aborts if the
+# current context is not kubepi.
+set -uo pipefail
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-fail}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"          # test/
+REPO="$(cd "$ROOT/.." && pwd)"          # repo root
+REL=conductor
+
+kc()   { command kubectl --context "$CTX" -n "$NS" "$@"; }
+kcg()  { command kubectl --context "$CTX" "$@"; }
+helm() { command helm --kube-context "$CTX" "$@"; }
+
+# Resolve the concrete postgres pod name (avoids `deploy/postgres` exec races
+# during/after a rollout, and the flaky `-i` with no stdin).
+pg_pod() {
+  kc get pods -l app=postgres \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# psql into the bundled postgres as <role> <db> <sql>. Targets the pod by name
+# (no `-i`), retries a few times so a transient empty/connection-refused result
+# during a rollout does not silently return "". Returns trimmed stdout.
+psql_db() { # role db sql
+  local role="$1" db="$2" sql="$3" out pod
+  for _ in 1 2 3 4 5 6; do
+    pod="$(pg_pod)"
+    if [ -n "$pod" ]; then
+      out="$(kc exec "$pod" -- psql -U "$role" -d "$db" -tAc "$sql" 2>/dev/null | tr -d '[:space:]')"
+      [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+    fi
+    sleep 2
+  done
+  printf '%s' "$out"
+}
+
+# psql_int: like psql_db but ONLY returns when the result is a clean integer
+# (used for count(*) reads). Retries until it gets a non-empty integer or gives
+# up, in which case it prints nothing (caller must guard with :- defaults).
+psql_int() { # role db sql
+  local role="$1" db="$2" sql="$3" out
+  for _ in 1 2 3 4 5 6 7 8; do
+    out="$(psql_db "$role" "$db" "$sql")"
+    case "$out" in
+      ''|*[!0-9]*) sleep 2 ;;
+      *) printf '%s' "$out"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Count pods that are genuinely not-ready: Running-but-not-all-containers-ready,
+# or Error/CrashLoopBackOff. EXCLUDES Completed/Succeeded hook pods (e.g.
+# conductor-bootstrap-migrate-*), which are done-by-design, not failures.
+notready_pods() { # label-selector
+  kc get pods -l "$1" --no-headers 2>/dev/null | awk '
+    {
+      ready=$2; status=$3
+      if (status=="Completed" || status=="Succeeded") next
+      split(ready,a,"/")
+      if (status=="Running" && a[1]!=a[2]) { print $1" "$2" "$3; next }
+      if (status=="Error" || status=="CrashLoopBackOff" || status ~ /BackOff/ || status=="ImagePullBackOff" || status=="ErrImagePull") { print $1" "$2" "$3 }
+    }'
+}
+
+CUR="$(command kubectl config current-context 2>/dev/null)"
+[ "$CUR" = "$CTX" ] || { echo "ABORT: current kube context is '$CUR', expected '$CTX'." >&2; exit 2; }
+
+RESULTS=()
+record() { RESULTS+=("$1"); echo "$1"; }
+FAILED=0
+
+echo "############################################################"
+echo "# conductor FAILURE-MODE tests (context=$CTX ns=$NS)"
+echo "############################################################"
+
+# ---------------------------------------------------------------------------
+# Setup: namespace, license, external postgres + rustfs (reuse adoption fixture)
+# ---------------------------------------------------------------------------
+echo "==> [setup] namespace"
+kcg get ns "$NS" >/dev/null 2>&1 || kcg create ns "$NS"
+
+echo "==> [setup] license secret"
+LIC=/tmp/conductor-fail-license.json
+if [ ! -s "$LIC" ]; then
+  SIGN=/tmp/conductor-fail-signing; mkdir -p "$SIGN"
+  kcg -n test-saas get secret license-signing-keys \
+    -o jsonpath='{.data.michael-dev-signing\.private\.pem}' | base64 -d > "$SIGN/key.pem"
+  MINT="$REPO/../conductor/dev/trial-testenv/scripts/mint-license.mjs"
+  [ -f "$MINT" ] || MINT="/Users/explorer/git/github/cardinalhq/conductor/dev/trial-testenv/scripts/mint-license.mjs"
+  node "$MINT" --key "$SIGN/key.pem" --key-id michael-dev-signing \
+    --kind lakerunner --customer "$NS" --days 365 > "$LIC"
+fi
+kc create secret generic cardinal-license --from-file=license.json="$LIC" \
+  --dry-run=client -o yaml | kc apply -f - >/dev/null
+
+echo "==> [setup] external postgres + rustfs fixtures"
+kc apply -f "$ROOT/adoption/05-fixtures.yaml" >/dev/null
+kc rollout status deploy/postgres --timeout=300s
+kc rollout status deploy/rustfs --timeout=300s
+kc wait --for=condition=complete job/rustfs-mkbucket --timeout=180s || true
+
+# ===========================================================================
+# CASE 1 — split-brain: maestro populated, configdb empty -> auto detect ERROR
+# ===========================================================================
+echo
+echo "=== CASE 1: split-brain (maestro populated, configdb empty) ==="
+# Run lakerunner+maestro migrations only (no bootstrap) so both schemas exist,
+# then populate ONLY maestro. Easiest: a throwaway adopt-mode migrate via helm
+# is heavy; instead bring schemas up by a one-shot mode=adopt install+uninstall
+# is also heavy. We already have empty schemas? No — fresh DBs have no tables.
+# Bring up just the schemas by installing in adopt mode (renders only migrate
+# hooks), then uninstall the release object but keep the migrated DBs.
+echo "    [case1] migrating schemas (helm install adopt, then uninstall keeps DB)"
+helm install c1 "$REPO/conductor" -n "$NS" -f "$HERE/fail-values.yaml" \
+  --set bootstrap.mode=adopt --timeout 300s >/tmp/c1-install.log 2>&1 || true
+# wait for both schemas to exist (migrate hooks complete during install)
+for _ in $(seq 1 40); do
+  HASTAB=$(psql_db maestro maestro "SELECT to_regclass('public.maestro_organizations') IS NOT NULL;")
+  HASLR=$(psql_db config configdb "SELECT to_regclass('public.organizations') IS NOT NULL;")
+  [ "$HASTAB" = "t" ] && [ "$HASLR" = "t" ] && break
+  sleep 5
+done
+echo "    [case1] schemas present: maestro_organizations=$HASTAB organizations=$HASLR"
+helm uninstall c1 -n "$NS" --wait >/dev/null 2>&1 || true
+# now wipe configdb back to empty and populate ONLY maestro
+psql_db config configdb "TRUNCATE organizations, organization_buckets, admin_api_keys CASCADE;" >/dev/null 2>&1 || true
+psql_db maestro maestro "INSERT INTO maestro_organizations (id,name,slug) VALUES ('55555555-5555-5555-5555-555555555555','SB Org','sb-org') ON CONFLICT DO NOTHING;" >/dev/null
+C1_LRORGS=$(psql_int config configdb 'SELECT count(*) FROM organizations;'); C1_LRORGS=${C1_LRORGS:-?}
+C1_MORGS=$(psql_int maestro maestro 'SELECT count(*) FROM maestro_organizations;'); C1_MORGS=${C1_MORGS:-?}
+echo "    [case1] signals: lr_orgs=$C1_LRORGS m_orgs=$C1_MORGS (want lr=0 m=1)"
+kc delete job c1-bootstrap-detect --ignore-not-found >/dev/null 2>&1 || true
+# NOTE: this script intentionally runs WITHOUT errexit (set -uo pipefail only);
+# every fallible step checks its own rc. Do not re-enable `set -e` mid-script.
+helm install c1 "$REPO/conductor" -n "$NS" -f "$HERE/fail-values.yaml" \
+  --set bootstrap.mode=auto --timeout 240s >/tmp/c1-auto.log 2>&1
+C1_RC=$?
+C1_LOG="$(kc logs job/c1-bootstrap-detect 2>/dev/null || true)"
+echo "------- case1 detect log -------"; echo "$C1_LOG" | sed 's/^/    /'; echo "--------------------------------"
+if [ "$C1_RC" -ne 0 ] && echo "$C1_LOG" | grep -Eq 'ERROR|ADOPT_LEGACY'; then
+  record "CASE 1 PASS: split-brain aborted (rc=$C1_RC), detect classified $(echo "$C1_LOG" | grep -Eo 'ERROR|ADOPT_LEGACY' | head -1)"
+else
+  record "CASE 1 FAIL: rc=$C1_RC, detect log did not show ERROR/ADOPT_LEGACY"; FAILED=1
+fi
+helm uninstall c1 -n "$NS" >/dev/null 2>&1 || true
+kc delete job c1-bootstrap-detect --ignore-not-found >/dev/null 2>&1 || true
+# helm/StatefulSets do NOT delete volumeClaimTemplate PVCs on uninstall — drop the
+# orphaned c1 github-cache PVC so it can't be mistaken for the real conductor one
+# in CASE 5's cold-start (it shares the github-cache component label).
+kc delete pvc mirrors-c1-maestro-github-cache-0 --ignore-not-found >/dev/null 2>&1 || true
+# reset DBs to empty for the clean fresh install below
+psql_db maestro maestro "TRUNCATE maestro_organizations CASCADE;" >/dev/null 2>&1 || true
+psql_db config configdb "TRUNCATE organizations, organization_buckets, admin_api_keys CASCADE;" >/dev/null 2>&1 || true
+
+# ===========================================================================
+# Fresh auto install used by cases 2, 4, 5
+# ===========================================================================
+echo
+echo "=== fresh auto install (for cases 2/4/5) ==="
+helm install "$REL" "$REPO/conductor" -n "$NS" -f "$HERE/fail-values.yaml" --timeout 600s >/tmp/fresh.log 2>&1
+FRESH_RC=$?
+if [ "$FRESH_RC" -ne 0 ]; then
+  echo "    fresh install FAILED (rc=$FRESH_RC):"; tail -15 /tmp/fresh.log | sed 's/^/    /'
+  record "SETUP FAIL: fresh auto install for cases 2/4/5 failed"; FAILED=1
+fi
+kc rollout status deploy/${REL}-maestro-maestro --timeout=420s || true
+kc rollout status deploy/${REL}-lakerunner-query-api --timeout=300s || true
+
+# Case order note: CASE 4 (helm rollback) runs BEFORE CASE 2 (anchor-Secret
+# mutation). CASE 2 mutates the helm-managed anchor Secret with `kubectl patch`,
+# which would take server-side-apply field ownership of .data.admin-api-key and
+# make a later `helm rollback` (helm v4 uses SSA) conflict — a test-ordering
+# artifact, not a chart behavior. Running rollback first avoids that.
+
+# ===========================================================================
+# CASE 3 — concurrent key-seed jobs -> exactly one admin_api_keys row, no error
+# ===========================================================================
+echo
+echo "=== CASE 3: two concurrent key-seed jobs ==="
+# Snapshot the seeded admin key hash count for the anchor key.
+ANCHOR=$(kc get secret ${REL}-admin-api-key -o jsonpath='{.data.admin-api-key}' | base64 -d)
+ANCHOR_HASH=$(printf %s "$ANCHOR" | shasum -a 256 | cut -d' ' -f1)
+BEFORE=$(psql_int config configdb "SELECT count(*) FROM admin_api_keys WHERE key_hash='$ANCHOR_HASH';"); BEFORE=${BEFORE:-?}
+echo "    rows for anchor hash before: ${BEFORE}"
+# Launch two manual key-seed jobs concurrently that run the SAME insert the
+# chart's key-seed uses (INSERT ... ON CONFLICT (key_hash) DO NOTHING).
+kc delete job c3-keyseed-a c3-keyseed-b --ignore-not-found >/dev/null 2>&1 || true
+for n in a b; do
+  cat <<EOF | kc apply -f - >/dev/null
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: c3-keyseed-$n
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: seed
+        image: public.ecr.aws/docker/library/postgres:18-alpine
+        command: ["/bin/sh","-ec"]
+        args:
+          - |
+            HASH=\$(printf %s "\$ADMIN_KEY" | sha256sum | cut -d' ' -f1)
+            PGPASSWORD=testpassword123 psql --set=ON_ERROR_STOP=1 -h postgres -p 5432 -U config -d configdb \\
+              -c "INSERT INTO admin_api_keys (key_hash, name, description) VALUES ('\$HASH','conductor-bootstrap','c3') ON CONFLICT (key_hash) DO NOTHING;"
+            echo done
+        env:
+        - { name: PGSSLMODE, value: "disable" }
+        - { name: ADMIN_KEY, value: "$ANCHOR" }
+EOF
+done
+# Poll for both jobs to reach succeeded=1 (more robust than a single `kc wait`).
+A_OK=0; B_OK=0
+for _ in $(seq 1 40); do
+  A_OK=$(kc get job c3-keyseed-a -o jsonpath='{.status.succeeded}' 2>/dev/null); A_OK=${A_OK:-0}
+  B_OK=$(kc get job c3-keyseed-b -o jsonpath='{.status.succeeded}' 2>/dev/null); B_OK=${B_OK:-0}
+  A_FAIL=$(kc get job c3-keyseed-a -o jsonpath='{.status.failed}' 2>/dev/null); A_FAIL=${A_FAIL:-0}
+  B_FAIL=$(kc get job c3-keyseed-b -o jsonpath='{.status.failed}' 2>/dev/null); B_FAIL=${B_FAIL:-0}
+  { [ "$A_OK" = "1" ] && [ "$B_OK" = "1" ]; } && break
+  { [ "${A_FAIL:-0}" -gt 0 ] || [ "${B_FAIL:-0}" -gt 0 ]; } && break
+  sleep 5
+done
+AFTER=$(psql_int config configdb "SELECT count(*) FROM admin_api_keys WHERE key_hash='$ANCHOR_HASH';"); AFTER=${AFTER:-?}
+echo "    rows for anchor hash after: $AFTER  (jobs succeeded a=$A_OK b=$B_OK)"
+if [ "$AFTER" = "1" ] && [ "$A_OK" = "1" ] && [ "$B_OK" = "1" ]; then
+  record "CASE 3 PASS: two concurrent key-seed jobs both succeeded, exactly 1 admin_api_keys row (ON CONFLICT held)"
+else
+  record "CASE 3 FAIL: rows=$AFTER (want 1), jobs succeeded a=$A_OK b=$B_OK (want 1/1)"; FAILED=1
+fi
+kc delete job c3-keyseed-a c3-keyseed-b --ignore-not-found >/dev/null 2>&1 || true
+
+# ===========================================================================
+# CASE 4 — helm rollback after upgrade -> healthy, migrations not destructive
+# ===========================================================================
+echo
+echo "=== CASE 4: helm rollback after upgrade ==="
+# Capture a marker row count that must survive an upgrade+rollback (no
+# destructive migration re-run): the org row count in configdb.
+ORG_BEFORE=$(psql_int config configdb "SELECT count(*) FROM organizations;"); ORG_BEFORE=${ORG_BEFORE:-?}
+echo "    configdb organizations before upgrade: $ORG_BEFORE"
+# Upgrade (trivial change: bump query-api replicas) -> creates revision N+1.
+# Under mode=auto the pre-upgrade detect classifies ADOPT_CONDUCTOR (shared
+# deployment present) and proceeds idempotently.
+helm upgrade "$REL" "$REPO/conductor" -n "$NS" -f "$HERE/fail-values.yaml" \
+  --set queryApi.replicas=1 --timeout 420s >/tmp/c4-upgrade.log 2>&1
+C4_UP=$?
+echo "    upgrade rc=$C4_UP"
+kc rollout status deploy/${REL}-maestro-maestro --timeout=300s >/dev/null 2>&1 || true
+# Roll back to the previous revision.
+helm rollback "$REL" -n "$NS" --wait --timeout 420s >/tmp/c4-rollback.log 2>&1
+C4_RB=$?
+echo "    rollback rc=$C4_RB"
+kc rollout status deploy/${REL}-maestro-maestro --timeout=300s >/dev/null 2>&1 || true
+kc rollout status deploy/${REL}-lakerunner-query-api --timeout=300s >/dev/null 2>&1 || true
+ORG_AFTER=$(psql_int config configdb "SELECT count(*) FROM organizations;"); ORG_AFTER=${ORG_AFTER:-?}
+DEPLOYED=$(helm status $REL -n $NS -o json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["info"]["status"])' 2>/dev/null)
+NOTREADY=$(notready_pods "app.kubernetes.io/instance=$REL")
+echo "    configdb organizations after rollback: $ORG_AFTER  helm status=$DEPLOYED"
+[ -n "$NOTREADY" ] && { echo "    not-ready pods:"; echo "$NOTREADY" | sed 's/^/      /'; }
+if [ "$C4_RB" -eq 0 ] && [ "$DEPLOYED" = "deployed" ] && [ "$ORG_AFTER" = "$ORG_BEFORE" ] && [ -z "$NOTREADY" ]; then
+  record "CASE 4 PASS: rollback healthy (status=$DEPLOYED), org rows preserved ($ORG_AFTER), all pods Ready"
+else
+  record "CASE 4 FAIL: rb_rc=$C4_RB status=$DEPLOYED orgs=$ORG_BEFORE->$ORG_AFTER notready=[$NOTREADY]"; FAILED=1
+fi
+
+# ===========================================================================
+# CASE 2 — anchor-Secret / DB-key mismatch -> auth error, no whole-release
+#          crashloop; re-running key-seed reconciles. (Runs last because it
+#          mutates the helm-managed anchor Secret — see case-order note above.)
+# ===========================================================================
+echo
+echo "=== CASE 2: anchor-Secret / DB-key mismatch ==="
+# Rotate the anchor Secret to a brand-new key value, but DO NOT seed its hash
+# into configdb yet -> the anchor key now mismatches what configdb knows. Roll
+# maestro so it picks up the new MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY.
+NEWKEY="ak_mismatch_$(date +%s)"
+NEWKEY_B64=$(printf %s "$NEWKEY" | base64)
+NEWKEY_HASH=$(printf %s "$NEWKEY" | shasum -a 256 | cut -d' ' -f1)
+kc patch secret ${REL}-admin-api-key --type merge -p "{\"data\":{\"admin-api-key\":\"$NEWKEY_B64\"}}" >/dev/null
+echo "    rotated anchor secret to a key whose hash is NOT in configdb"
+MISMATCH0=$(psql_int config configdb "SELECT count(*) FROM admin_api_keys WHERE key_hash='$NEWKEY_HASH';"); MISMATCH0=${MISMATCH0:-?}
+echo "    configdb rows for new hash (should be 0): $MISMATCH0"
+kc rollout restart deploy/${REL}-maestro-maestro >/dev/null
+# Give maestro time to come back with the mismatched key; it must NOT crashloop.
+kc rollout status deploy/${REL}-maestro-maestro --timeout=240s >/tmp/c2-rollout.log 2>&1
+C2_ROLL=$?
+# Assert: maestro deployment is Available (it tolerates the auth failure and
+# does not bring the whole release down) — its provisioning worker retries.
+MAESTRO_AVAIL=$(kc get deploy ${REL}-maestro-maestro -o jsonpath='{.status.availableReplicas}' 2>/dev/null)
+MAESTRO_RESTARTS=$(kc get pods -l app.kubernetes.io/component=maestro -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null)
+echo "    maestro availableReplicas=$MAESTRO_AVAIL restartCount=$MAESTRO_RESTARTS (rollout rc=$C2_ROLL)"
+NOT_CRASH=0; { [ "${MAESTRO_AVAIL:-0}" -ge 1 ]; } && NOT_CRASH=1
+# Reconcile: seed the new hash (what the chart's key-seed would do on re-run).
+echo "    re-running key-seed to reconcile the new anchor key into configdb"
+psql_db config configdb "INSERT INTO admin_api_keys (key_hash,name,description) VALUES ('$NEWKEY_HASH','conductor-bootstrap','reconcile') ON CONFLICT (key_hash) DO NOTHING;" >/dev/null
+RECONCILED=$(psql_int config configdb "SELECT count(*) FROM admin_api_keys WHERE key_hash='$NEWKEY_HASH';"); RECONCILED=${RECONCILED:-?}
+echo "    configdb rows for new hash after reconcile (should be 1): $RECONCILED"
+if [ "$NOT_CRASH" = "1" ] && [ "$RECONCILED" = "1" ]; then
+  record "CASE 2 PASS: maestro stayed Available under key mismatch (availableReplicas=$MAESTRO_AVAIL, restarts=$MAESTRO_RESTARTS); re-seed reconciled the key into configdb"
+else
+  record "CASE 2 FAIL: maestro avail=$MAESTRO_AVAIL (want >=1), reconciled=$RECONCILED (want 1)"; FAILED=1
+fi
+
+# ===========================================================================
+# CASE 5 — PVC cold-start: delete github-cache PVC+pod -> re-clones, Ready
+# ===========================================================================
+echo
+echo "=== CASE 5: github-cache PVC cold-start ==="
+STS=${REL}-maestro-github-cache
+kc rollout status statefulset/$STS --timeout=300s >/tmp/c5-pre.log 2>&1 || true
+# Target THIS release's stable per-replica PVC by exact name. A label selector
+# (app.kubernetes.io/component=github-cache) can also match an ORPHAN PVC left by
+# an earlier `helm uninstall` (helm/StatefulSets do not delete volumeClaimTemplate
+# PVCs), and `head -1` could then delete the wrong volume — leaving the live
+# conductor pod to restart on its existing PVC and never actually cold-starting.
+PVC="pvc/mirrors-${STS}-0"
+PV=$(kc get pvc mirrors-${STS}-0 -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+echo "    deleting github-cache pod-0 + its PVC ($PVC, pv=$PV) to force a cold-start re-clone"
+kc delete "$PVC" --wait=false >/dev/null 2>&1 || true
+kc delete pod ${STS}-0 --grace-period=0 --force >/dev/null 2>&1 || true
+# StatefulSet controller re-creates the pod and (because the PVC was deleted)
+# a brand-new empty PVC, forcing a fresh clone.
+sleep 5
+kc rollout status statefulset/$STS --timeout=420s >/tmp/c5-post.log 2>&1
+C5_RC=$?
+READY=$(kc get statefulset $STS -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+NEWPVC=$(kc get pvc mirrors-${STS}-0 -o jsonpath='{.status.phase}' 2>/dev/null)
+NEWPV=$(kc get pvc mirrors-${STS}-0 -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+# A genuine cold-start binds a BRAND-NEW PersistentVolume (the old one was
+# deleted with the PVC), so NEWPV must differ from the pre-delete PV.
+FRESHVOL=0; { [ -n "$NEWPV" ] && [ "$NEWPV" != "$PV" ]; } && FRESHVOL=1
+echo "    statefulset readyReplicas=$READY new PVC mirrors-${STS}-0 phase=$NEWPVC pv=$NEWPV (was $PV, fresh=$FRESHVOL, rollout rc=$C5_RC)"
+if [ "$C5_RC" -eq 0 ] && [ "${READY:-0}" -ge 1 ] && [ "$NEWPVC" = "Bound" ] && [ "$FRESHVOL" = "1" ]; then
+  record "CASE 5 PASS: github-cache cold-started — fresh PV ($NEWPV) Bound, StatefulSet Ready ($READY)"
+else
+  record "CASE 5 FAIL: rollout rc=$C5_RC ready=$READY pvc=$NEWPVC pv=$NEWPV (was $PV) fresh=$FRESHVOL"; FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "===================== FAILURE-MODE RESULTS ====================="
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo "==============================================================="
+if [ "$FAILED" -ne 0 ]; then
+  echo "FAILURE-MODE TESTS FAILED"
+  exit 1
+fi
+echo "FAILURE-MODE TESTS PASSED"

--- a/test/fresh-install/00-run.sh
+++ b/test/fresh-install/00-run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# End-to-end fresh-install test for the unified `conductor` Helm chart on kubepi.
+#
+# Stands up Postgres(pgvector) + rustfs in a dedicated namespace, fresh-installs
+# conductor (bootstrap.mode=auto), sends logs/metrics/traces through a collector,
+# and validates the data is queryable via query-api DIRECT and the maestro PROXY.
+#
+# SAFETY: every kubectl/helm call is pinned to --context kubepi. Aborts if the
+# current kube context is anything else.
+#
+# Usage:  NS=conductor-fresh bash test/fresh-install/00-run.sh
+# Prints `FRESH-INSTALL PASS` and exits 0 on success; leaves the install RUNNING
+# for inspection (run 99-teardown.sh to clean up).
+set -uo pipefail
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-fresh}"
+RELEASE="${RELEASE:-conductor}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="${CHART:-$HERE/../../conductor}"
+
+kc()   { command kubectl --context "$CTX" -n "$NS" "$@"; }
+helm() { command helm --kube-context "$CTX" "$@"; }
+
+# --- SAFETY: refuse to run against any context but kubepi ---
+CURRENT="$(command kubectl config current-context 2>/dev/null)"
+if [ "$CURRENT" != "$CTX" ]; then
+  echo "ABORT: current kube context is '$CURRENT', expected '$CTX'. Refusing to run."
+  exit 2
+fi
+[ -d "$CHART" ] || { echo "ABORT: chart not found at $CHART"; exit 2; }
+
+echo "############################################################"
+echo "# conductor FRESH-INSTALL test  (context=$CTX ns=$NS)"
+echo "############################################################"
+
+echo "==> [0] namespace"
+command kubectl --context "$CTX" get ns "$NS" >/dev/null 2>&1 || command kubectl --context "$CTX" create ns "$NS"
+
+echo "==> [1] license secret (michael-dev-signing) for both families"
+# Mint a fresh license signed with the kubepi dev signing key (trusted by
+# lakerunner license-go >= v0.2.1 and maestro). Reuse an existing
+# license-signing-keys secret on the cluster (test-saas) so we do not embed a
+# private key in the repo.
+LIC=/tmp/conductor-fresh-license.json
+if [ ! -s "$LIC" ]; then
+  SIGN_DIR=/tmp/conductor-fresh-signing
+  mkdir -p "$SIGN_DIR"
+  command kubectl --context "$CTX" -n test-saas get secret license-signing-keys \
+    -o jsonpath='{.data.michael-dev-signing\.private\.pem}' | base64 -d > "$SIGN_DIR/key.pem"
+  MINT="$HERE/../../../conductor/dev/trial-testenv/scripts/mint-license.mjs"
+  # Fall back to the canonical sibling path if the worktree-relative one misses.
+  [ -f "$MINT" ] || MINT="/Users/explorer/git/github/cardinalhq/conductor/dev/trial-testenv/scripts/mint-license.mjs"
+  node "$MINT" --key "$SIGN_DIR/key.pem" --key-id michael-dev-signing \
+    --kind lakerunner --customer "$NS" --days 365 > "$LIC"
+fi
+kc create secret generic cardinal-license --from-file=license.json="$LIC" \
+  --dry-run=client -o yaml | kc apply -f - >/dev/null
+
+echo "==> [2] Postgres (pgvector) fixture"
+kc apply -f "$HERE/10-postgres.yaml" >/dev/null
+kc rollout status deploy/postgres --timeout=300s
+
+echo "==> [3] rustfs S3 store + bucket"
+kc apply -f "$HERE/20-rustfs.yaml" >/dev/null
+kc rollout status deploy/rustfs --timeout=300s
+kc wait --for=condition=complete job/rustfs-mkbucket --timeout=180s || true
+
+echo "==> [4] helm install conductor (bootstrap.mode=auto)"
+helm install "$RELEASE" "$CHART" -n "$NS" -f "$HERE/30-values.yaml" --timeout 600s
+
+echo "==> [5] verify migrations + key-seed + maestro provisioning"
+kc rollout status deploy/${RELEASE}-maestro-maestro --timeout=300s
+kc rollout status deploy/${RELEASE}-lakerunner-query-api --timeout=300s
+kc rollout status deploy/${RELEASE}-lakerunner-pubsub-http --timeout=300s
+echo "    admin_api_keys: $(kc exec deploy/postgres -- psql -U config -d configdb -tAc "SELECT name FROM admin_api_keys;" 2>/dev/null | tr -d '[:space:]')"
+echo "    maestro org:    $(kc exec deploy/postgres -- psql -U maestro -d maestro -tAc "SELECT name FROM maestro_organizations LIMIT 1;" 2>/dev/null | tr -d '[:space:]')"
+
+echo "==> [6] collector fixture"
+kc apply -f "$HERE/40-collector.yaml" >/dev/null
+kc rollout status deploy/otel-collector --timeout=300s
+
+echo "==> [7] send telemetry (logs/metrics/traces, service.name=fresh-test)"
+NS="$NS" CTX="$CTX" bash "$HERE/50-send-telemetry.sh"
+
+echo "==> [8] validate (query-api direct + maestro proxy)"
+NS="$NS" CTX="$CTX" bash "$HERE/60-validate.sh"
+RC=$?
+
+echo
+if [ "$RC" -eq 0 ]; then
+  echo "FRESH-INSTALL PASS"
+else
+  echo "FRESH-INSTALL FAIL (validation rc=$RC)"
+fi
+exit "$RC"

--- a/test/fresh-install/10-postgres.yaml
+++ b/test/fresh-install/10-postgres.yaml
@@ -1,0 +1,110 @@
+# Postgres 18 fixture for the conductor fresh-install test.
+#
+# Provides the three databases the unified chart expects, each owned by its own
+# role (matching the chart's default usernames):
+#   - lakerunner  (db lakerunner, role lakerunner)  -> LRDB
+#   - configdb    (db configdb,   role config)       -> CONFIGDB
+#   - maestro     (db maestro,    role maestro)      -> MAESTRO_DB
+#
+# All roles share one test password. NO TLS (the chart values set sslMode=disable).
+# Modeled on conductor/dev/trial-testenv/scripts/07-lakerunner.sh (postgres:18-alpine,
+# PGDATA subdir, init SQL via /docker-entrypoint-initdb.d) but with all three DBs.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pg-credentials
+  labels: { app: postgres }
+type: Opaque
+stringData:
+  # The chart-created credential secrets read these key names; we keep one
+  # password for every role so a single value flows everywhere.
+  LRDB_PASSWORD: "testpassword123"
+  CONFIGDB_PASSWORD: "testpassword123"
+  MAESTRO_DB_PASSWORD: "testpassword123"
+  POSTGRES_PASSWORD: "testpassword123"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  labels: { app: postgres }
+data:
+  # initdb runs *.sql once on first boot (empty PGDATA). The default POSTGRES_DB
+  # (lakerunner) + role (lakerunner) are created by the entrypoint from env; here
+  # we add the configdb + maestro databases and their owning roles.
+  01-init.sql: |
+    -- configdb (chart default db name "configdb" in our values; role "config")
+    CREATE ROLE config WITH LOGIN PASSWORD 'testpassword123';
+    CREATE DATABASE configdb OWNER config;
+    GRANT ALL PRIVILEGES ON DATABASE configdb TO config;
+
+    -- maestro
+    CREATE ROLE maestro WITH LOGIN PASSWORD 'testpassword123';
+    CREATE DATABASE maestro OWNER maestro;
+    GRANT ALL PRIVILEGES ON DATABASE maestro TO maestro;
+
+    -- lakerunner role/db are created by the entrypoint (POSTGRES_USER/DB), but
+    -- make the lakerunner role a superuser-lite so migrations can create
+    -- extensions/objects freely.
+    ALTER ROLE lakerunner CREATEDB;
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels: { app: postgres }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels: { app: postgres }
+spec:
+  replicas: 1
+  # RWO PVC: never run two pods at once.
+  strategy: { type: Recreate }
+  selector: { matchLabels: { app: postgres } }
+  template:
+    metadata:
+      labels: { app: postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: public.ecr.aws/docker/library/postgres:18-alpine
+          env:
+            - { name: POSTGRES_USER, value: "lakerunner" }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: pg-credentials, key: POSTGRES_PASSWORD } }
+            - { name: POSTGRES_DB, value: "lakerunner" }
+            # Keep initdb off the volume root (lost+found on some CSIs).
+            - { name: PGDATA, value: "/var/lib/postgresql/data/pgdata" }
+          ports: [{ containerPort: 5432 }]
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+            - { name: init, mountPath: /docker-entrypoint-initdb.d }
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "lakerunner"] }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec: { command: ["pg_isready", "-U", "lakerunner"] }
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - { name: data, persistentVolumeClaim: { claimName: postgres-data } }
+        - { name: init, configMap: { name: postgres-init } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels: { app: postgres }
+spec:
+  selector: { app: postgres }
+  ports: [{ port: 5432, targetPort: 5432 }]

--- a/test/fresh-install/10-postgres.yaml
+++ b/test/fresh-install/10-postgres.yaml
@@ -85,6 +85,10 @@ spec:
         - name: postgres
           # pgvector-enabled Postgres 18 (maestro migrations need CREATE EXTENSION vector)
           image: pgvector/pgvector:pg18
+          # Raise the connection ceiling — the full lakerunner stack's pgx pools
+          # (especially during rolling upgrades that briefly double pods) exceed
+          # Postgres's default max_connections=100 → "too many clients".
+          args: ["-c", "max_connections=400", "-c", "shared_buffers=256MB"]
           env:
             - { name: POSTGRES_USER, value: "lakerunner" }
             - name: POSTGRES_PASSWORD

--- a/test/fresh-install/10-postgres.yaml
+++ b/test/fresh-install/10-postgres.yaml
@@ -1,4 +1,9 @@
-# Postgres 18 fixture for the conductor fresh-install test.
+# Postgres 18 (pgvector) fixture for the conductor fresh-install test.
+#
+# Image: pgvector/pgvector:pg18 — Postgres 18 with the pgvector ("vector")
+# extension preinstalled. The maestro/mcp-gateway migrations require the
+# vector, pgcrypto, and citext extensions; plain postgres:18-alpine lacks
+# pgvector and fails migration 000001 with `extension "vector" is not available`.
 #
 # Provides the three databases the unified chart expects, each owned by its own
 # role (matching the chart's default usernames):
@@ -39,8 +44,10 @@ data:
     CREATE DATABASE configdb OWNER config;
     GRANT ALL PRIVILEGES ON DATABASE configdb TO config;
 
-    -- maestro
-    CREATE ROLE maestro WITH LOGIN PASSWORD 'testpassword123';
+    -- maestro. SUPERUSER so the mcp-gateway migrations can run
+    -- `CREATE EXTENSION vector/pgcrypto/citext` (vector is not a trusted
+    -- extension, so a plain role cannot create it). Test-only convenience.
+    CREATE ROLE maestro WITH LOGIN SUPERUSER PASSWORD 'testpassword123';
     CREATE DATABASE maestro OWNER maestro;
     GRANT ALL PRIVILEGES ON DATABASE maestro TO maestro;
 
@@ -76,7 +83,8 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: public.ecr.aws/docker/library/postgres:18-alpine
+          # pgvector-enabled Postgres 18 (maestro migrations need CREATE EXTENSION vector)
+          image: pgvector/pgvector:pg18
           env:
             - { name: POSTGRES_USER, value: "lakerunner" }
             - name: POSTGRES_PASSWORD

--- a/test/fresh-install/20-rustfs.yaml
+++ b/test/fresh-install/20-rustfs.yaml
@@ -1,0 +1,89 @@
+# rustfs S3-compatible object store fixture for the conductor fresh-install test.
+#
+# Adapted from conductor/dev/trial-testenv/scripts/07-lakerunner.sh. rustfs runs as
+# uid/gid 10001, so fsGroup=10001 lets it write the freshly-provisioned PVC.
+#
+# NOTE on the ingest-notification path: we do NOT use rustfs webhook notifications
+# here. The collector's awss3 exporter (40-collector.yaml) POSTs the S3-event
+# envelope to pubsub-http directly via s3uploader.notifications.endpoint, which is
+# simpler and avoids the rustfs ARN/webhook quirks. rustfs only needs to serve the
+# S3 API and hold the bucket.
+#
+# Access/secret key: rustfsadmin / rustfsadmin (path-style, region us-east-1).
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustfs-data
+  labels: { app: rustfs }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustfs
+  labels: { app: rustfs }
+spec:
+  replicas: 1
+  # RWO PVC: never run two pods at once.
+  strategy: { type: Recreate }
+  selector: { matchLabels: { app: rustfs } }
+  template:
+    metadata:
+      labels: { app: rustfs }
+    spec:
+      # rustfs runs as non-root uid/gid 10001; without fsGroup the server FATALs
+      # with "Permission denied" writing /data on a fresh PVC.
+      securityContext: { fsGroup: 10001 }
+      containers:
+        - name: rustfs
+          image: rustfs/rustfs:1.0.0-beta.7
+          env:
+            - { name: RUSTFS_ACCESS_KEY, value: "rustfsadmin" }
+            - { name: RUSTFS_SECRET_KEY, value: "rustfsadmin" }
+            - { name: RUSTFS_VOLUMES, value: "/data" }
+            - { name: RUSTFS_CONSOLE_ADDRESS, value: ":9001" }
+          ports: [{ containerPort: 9000 }, { containerPort: 9001 }]
+          volumeMounts: [{ name: data, mountPath: /data }]
+      volumes: [{ name: data, persistentVolumeClaim: { claimName: rustfs-data } }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs
+  labels: { app: rustfs }
+spec:
+  selector: { app: rustfs }
+  ports:
+    - { name: api, port: 9000, targetPort: 9000 }
+    - { name: console, port: 9001, targetPort: 9001 }
+---
+# One-shot bucket create. mc (the MinIO client) drives rustfs unchanged for
+# bucket ops. Idempotent (--ignore-existing) and retries until rustfs is up.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rustfs-mkbucket
+  labels: { app: rustfs }
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels: { app: rustfs-mkbucket }
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-04-08T15-39-49Z
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              until mc alias set m http://rustfs.conductor-fresh.svc.cluster.local:9000 rustfsadmin rustfsadmin; do
+                echo "waiting for rustfs..."; sleep 3
+              done
+              mc mb --ignore-existing m/lakerunner
+              mc ls m

--- a/test/fresh-install/30-values.yaml
+++ b/test/fresh-install/30-values.yaml
@@ -1,0 +1,135 @@
+# conductor fresh-install values for the kubepi conductor-fresh test.
+#
+# Wires the unified chart to the in-namespace fixtures:
+#   - Postgres  (10-postgres.yaml): host "postgres", DBs lakerunner/configdb/maestro
+#   - rustfs    (20-rustfs.yaml):   S3 endpoint http://rustfs:9000, bucket "lakerunner"
+#
+# The shared org / storage profile / per-org API key are NOT pre-baked here.
+# bootstrap.mode=auto makes the chart:
+#   - run lakerunner + maestro migrations (pre-install hooks),
+#   - seed the admin key into configdb.admin_api_keys (post-install hook),
+#   - render MAESTRO_BOOTSTRAP_* so maestro provisions the shared org into
+#     lakerunner via admin-api at boot (writes storage profile + per-org key to
+#     configdb dynamically).
+#
+# Local Postgres is non-TLS, so every sslMode is "disable" (chart default is
+# "require"). The key-seed job reads PGSSLMODE from configdb.lrdb.sslMode.
+
+global:
+  # Tune nothing fancy; let components take what they need.
+  resources:
+    enabled: false
+  autoscaling:
+    mode: disabled
+
+# ---- License (BYOS): a michael-dev-signing-signed license pre-created in the
+#      namespace as secret "cardinal-license" (key license.json) by 00-run.sh.
+#      One secret is shared by both lakerunner and maestro families. ----
+license:
+  create: false
+  secretName: "cardinal-license"
+
+# ---- Databases (bundled postgres; one password for all three roles) ----
+database:
+  create: true
+  secretName: "pg-credentials"
+  passwordKey: "LRDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "lakerunner"
+    username: "lakerunner"
+    password: "testpassword123"
+    sslMode: "disable"
+
+configdb:
+  create: true
+  secretName: "configdb-credentials"
+  passwordKey: "CONFIGDB_PASSWORD"
+  lrdb:
+    host: "postgres"
+    port: 5432
+    name: "configdb"
+    username: "config"
+    password: "testpassword123"
+    sslMode: "disable"
+
+maestroDatabase:
+  create: true
+  secretName: "maestro-pg-credentials"
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  host: "postgres"
+  port: 5432
+  name: "maestro"
+  username: "maestro"
+  password: "testpassword123"
+  sslMode: "disable"
+
+# ---- Object storage (bundled rustfs; S3-compatible, path-style) ----
+cloudProvider:
+  provider: "aws"
+  aws:
+    region: "us-east-1"
+    create: true
+    secretName: "aws-credentials"
+    inject: true
+    accessKeyId: "rustfsadmin"
+    secretAccessKey: "rustfsadmin"
+
+# storageProfiles/apiKeys are provisioned dynamically by maestro into configdb
+# (POST /api/v1/provision via admin-api). No pre-baked org.
+storageProfiles:
+  source: config
+  create: true
+  yaml: []
+apiKeys:
+  source: config
+  create: true
+  yaml: []
+
+# ---- Ingest: receive S3-event notifications over HTTP from the collector ----
+pubsub:
+  HTTP:
+    enabled: true
+    replicas: 1
+
+# Single-node POC: no HA.
+ha:
+  enabled: false
+
+# ---- Maestro ----
+maestro:
+  enabled: true
+  replicas: 1
+  # In-cluster only; backend test curls the Service directly. OIDC/Dex are not
+  # needed (the proxy uses the X-CardinalHQ-API-Key per-user key path, which is
+  # independent of OIDC; maestro boots fine with "OIDC not configured").
+  baseUrl: "http://conductor-maestro-maestro.conductor-fresh.svc.cluster.local:4200"
+  tls:
+    enabled: false
+
+# Dex disabled — backend-only validation does not exercise the browser OIDC flow.
+dex:
+  enabled: false
+
+grafana:
+  enabled: false
+
+# ---- Fresh-install bootstrap ----
+bootstrap:
+  mode: auto
+  org:
+    id: "11111111-1111-1111-1111-111111111111"
+    name: "default"
+    ownerEmail: "admin@test.local"
+  adminKey:
+    existingSecret: ""
+    existingSecretKey: "admin-api-key"
+  bucket:
+    name: "lakerunner"
+    region: "us-east-1"
+    cloudProvider: "aws"
+    collectorName: "default"
+    endpoint: "http://rustfs:9000"
+    usePathStyle: true
+    insecureTls: true

--- a/test/fresh-install/40-collector.yaml
+++ b/test/fresh-install/40-collector.yaml
@@ -1,0 +1,135 @@
+# cardinalhq-otel-collector fixture for the conductor fresh-install test.
+#
+# A single-pod gateway collector that:
+#   - receives OTLP over grpc/http (4317/4318), no auth (in-cluster test only)
+#   - exports logs/metrics/traces to rustfs via the awss3 exporter, writing keys
+#     under otel-raw/<org>/default/... so lakerunner's pubsub parser extracts
+#     org=<org>, collector=default, signal=<filename prefix> (metrics_/logs_/traces_).
+#   - on each successful S3 upload POSTs an S3-event envelope to pubsub-http via
+#     s3uploader.notifications.endpoint, which drives ingest (process-*).
+#
+# Distilled from base-collector-manifests/gateway + conductor trial-testenv
+# intake-collector. We drop the chqauth/loadbalancing/servicegraph machinery —
+# a single pod sees all data and we attribute everything to the fixed bootstrap
+# org statically (no api-key auth), which is all the e2e test needs.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  labels: { app: otel-collector }
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      # Stamp the bucket prefix so every object lands under
+      # otel-raw/<org>/default/. lakerunner's pubsub parser reads org from
+      # path part [1] and collector from part [2].
+      resource/prefix:
+        attributes:
+          - key: "_cardinalhq.bucket_prefix"
+            action: upsert
+            value: "otel-raw/11111111-1111-1111-1111-111111111111/default"
+      batch/s3:
+        timeout: 5s
+        send_batch_size: 1
+
+    exporters:
+      awss3:
+        marshaler: otlp_proto
+        s3uploader:
+          region: "${env:AWS_REGION}"
+          s3_bucket: "${env:AWS_S3_BUCKET}"
+          endpoint: "${env:AWS_S3_ENDPOINT}"
+          s3_force_path_style: true
+          disable_ssl: true
+          compression: gzip
+          # POST an S3-event envelope to pubsub-http on each successful upload.
+          notifications:
+            endpoint: "${env:PUBSUB_HTTP_ENDPOINT}"
+        # Per-resource dynamic prefix set by resource/prefix above.
+        resource_attrs_to_s3:
+          s3_prefix: "_cardinalhq.bucket_prefix"
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+        path: /healthz
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [resource/prefix, batch/s3]
+          exporters: [awss3]
+        metrics:
+          receivers: [otlp]
+          processors: [resource/prefix, batch/s3]
+          exporters: [awss3]
+        traces:
+          receivers: [otlp]
+          processors: [resource/prefix, batch/s3]
+          exporters: [awss3]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels: { app: otel-collector }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: otel-collector } }
+  template:
+    metadata:
+      labels: { app: otel-collector }
+      annotations:
+        # bump to force a rollout when the config changes
+        cfg/rev: "1"
+    spec:
+      containers:
+        - name: collector
+          image: public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
+          command:
+            - /app/bin/cardinalhq-otel-collector
+            - --config=/app/config/collector.yaml
+          env:
+            - { name: AWS_REGION, value: "us-east-1" }
+            - { name: AWS_S3_BUCKET, value: "lakerunner" }
+            - { name: AWS_S3_ENDPOINT, value: "http://rustfs:9000" }
+            - { name: AWS_ACCESS_KEY_ID, value: "rustfsadmin" }
+            - { name: AWS_SECRET_ACCESS_KEY, value: "rustfsadmin" }
+            - name: PUBSUB_HTTP_ENDPOINT
+              value: "http://conductor-lakerunner-pubsub-http:8080/"
+          ports:
+            - { name: otlp-grpc, containerPort: 4317 }
+            - { name: otlp-http, containerPort: 4318 }
+            - { name: healthz, containerPort: 13133 }
+          readinessProbe:
+            httpGet: { path: /healthz, port: 13133 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - { name: config, mountPath: /app/config }
+            - { name: scratch, mountPath: /app/scratch }
+      volumes:
+        - { name: config, configMap: { name: otel-collector-config } }
+        - { name: scratch, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels: { app: otel-collector }
+spec:
+  selector: { app: otel-collector }
+  ports:
+    - { name: otlp-grpc, port: 4317, targetPort: 4317 }
+    - { name: otlp-http, port: 4318, targetPort: 4318 }

--- a/test/fresh-install/50-send-telemetry.sh
+++ b/test/fresh-install/50-send-telemetry.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Send logs + metrics + traces tagged service.name=fresh-test through the
+# otel-collector fixture, which exports them to rustfs (awss3) and notifies
+# pubsub-http so lakerunner ingests them.
+#
+# Uses telemetrygen (one-shot Jobs) over OTLP/gRPC to otel-collector:4317.
+# service.name=fresh-test becomes resource_service_name=fresh-test in lakerunner,
+# the marker 60-validate.sh greps for.
+set -euo pipefail
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-fresh}"
+TGIMG="${TGIMG:-ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest}"
+EP="otel-collector.${NS}.svc.cluster.local:4317"
+MARKER="fresh-test"
+
+kubectl() { command kubectl --context "$CTX" -n "$NS" "$@"; }
+
+run_gen() {
+  local signal="$1"; shift
+  local job="telemetrygen-${signal}"
+  echo ">> sending ${signal} (service.name=${MARKER}) to ${EP}"
+  kubectl delete job "$job" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job}
+  labels: { app: telemetrygen }
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels: { app: telemetrygen }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: telemetrygen
+          image: ${TGIMG}
+          args:
+$(for a in "$@"; do echo "            - '$a'"; done)
+YAML
+  kubectl wait --for=condition=complete "job/${job}" --timeout=120s 2>&1 || {
+    echo "!! ${signal} generation did not complete; logs:"; kubectl logs "job/${job}" 2>&1 | tail -20; return 1; }
+  echo "   ${signal} sent."
+}
+
+# logs: 50 log records
+run_gen logs    logs    --otlp-endpoint "$EP" --otlp-insecure --service "$MARKER" --logs 50    --otlp-attributes 'test.marker="fresh-test"'
+# metrics: 50 gauge data points
+run_gen metrics metrics --otlp-endpoint "$EP" --otlp-insecure --service "$MARKER" --metrics 50 --otlp-attributes 'test.marker="fresh-test"'
+# traces: 50 spans
+run_gen traces  traces  --otlp-endpoint "$EP" --otlp-insecure --service "$MARKER" --traces 50  --otlp-attributes 'test.marker="fresh-test"'
+
+echo ">> telemetry sent. Waiting ~90s for awss3 flush + pubsub notify + process-* ingest..."
+sleep 90
+echo ">> done waiting."

--- a/test/fresh-install/60-validate.sh
+++ b/test/fresh-install/60-validate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Validate the fresh conductor install end-to-end by querying the ingested
+# fresh-test telemetry TWO ways and asserting both return the marker:
+#   (1) query-api DIRECT with the per-org admin/api key
+#   (2) the maestro PROXY path (/api/lakerunner/{instanceId}/query/...) with
+#       X-Org-Id + a per-user maestro API key
+#
+# Exits non-zero if either path is missing the `fresh-test` marker.
+#
+# Services are ClusterIP, so curls run from a transient in-cluster pod.
+set -uo pipefail
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-fresh}"
+ORG="${ORG:-11111111-1111-1111-1111-111111111111}"
+MARKER="fresh-test"
+QUERY='{"q":"{service_name=\"fresh-test\"}","s":"e-6h","e":"now"}'
+HELPER=fresh-validate-curl
+
+kc() { command kubectl --context "$CTX" -n "$NS" "$@"; }
+PSQL_LR() { kc exec deploy/postgres -- psql -U lakerunner -d lakerunner -tAc "$1" 2>/dev/null | tr -d '[:space:]'; }
+PSQL_MAESTRO() { kc exec deploy/postgres -- psql -U maestro -d maestro -tAc "$1" 2>/dev/null; }
+
+echo "==> Resolving credentials and instance id"
+# Per-org lakerunner key the maestro provisioner minted (stored in the integration
+# credentials; this is the org key query-api validates for direct calls).
+ORGKEY=$(PSQL_MAESTRO "SELECT credentials->>'lakerunner-api-key' FROM maestro_integrations WHERE type='lakerunner' AND org_id='$ORG' LIMIT 1;" | tr -d '[:space:]')
+# The proxy :instanceId is the lakerunner integration's id.
+INSTANCE=$(PSQL_MAESTRO "SELECT id FROM maestro_integrations WHERE type='lakerunner' AND org_id='$ORG' LIMIT 1;" | tr -d '[:space:]')
+[ -n "$ORGKEY" ]  || { echo "FAIL: no per-org lakerunner key found in maestro_integrations"; exit 1; }
+[ -n "$INSTANCE" ] || { echo "FAIL: no lakerunner integration (instance id) for org $ORG"; exit 1; }
+echo "    org key: ${ORGKEY:0:8}...  instance: $INSTANCE"
+
+echo "==> Minting a per-user maestro API key for the proxy path"
+# Contract (packages/maestro/src/lib/api-key.ts + db/repositories/api-keys.ts):
+#   plaintext = randomBytes(32) hex (64 chars); key_hash = sha256(plaintext) hex;
+#   key_prefix = plaintext[0:8]; owner_type='organization', owner_id=<org>,
+#   scopes=[] (unrestricted, required so the proxy path is allowed).
+USERKEY=$(head -c32 /dev/urandom | xxd -p -c64 | tr -d '\n')
+UHASH=$(printf %s "$USERKEY" | shasum -a 256 | cut -d' ' -f1)
+UPREFIX=${USERKEY:0:8}
+PSQL_MAESTRO "INSERT INTO maestro_api_keys (key_hash, key_prefix, owner_type, owner_id, label, scopes)
+  VALUES ('$UHASH','$UPREFIX','organization','$ORG','fresh-test-user','[]'::jsonb)
+  ON CONFLICT (key_hash) DO NOTHING;" >/dev/null
+echo "    user key: ${USERKEY:0:8}..."
+
+echo "==> Starting in-cluster curl helper"
+kc delete pod "$HELPER" --ignore-not-found >/dev/null 2>&1
+kc run "$HELPER" --image=curlimages/curl:latest --restart=Never --command -- sleep 900 >/dev/null
+# wait for Running
+for _ in $(seq 1 30); do
+  [ "$(kc get pod "$HELPER" -o jsonpath='{.status.phase}' 2>/dev/null)" = "Running" ] && break
+  sleep 2
+done
+
+cleanup() { kc delete pod "$HELPER" --ignore-not-found >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+curl_in() { kc exec "$HELPER" -- curl -sS -m 90 "$@" 2>&1; }
+
+# Retry loop helper: run the curl, grep for marker, retry a few times for
+# eventual consistency (ingest/compaction may lag the telemetry send).
+query_with_retry() {
+  local label="$1" outfile="$2"; shift 2
+  local attempt
+  for attempt in 1 2 3 4 5 6; do
+    curl_in "$@" > "$outfile" 2>&1
+    if grep -q "$MARKER" "$outfile"; then
+      echo "    [$label] marker found (attempt $attempt)"
+      return 0
+    fi
+    echo "    [$label] marker not yet present (attempt $attempt), retrying in 15s..."
+    sleep 15
+  done
+  return 1
+}
+
+echo "==> (1) Direct query-api logs query"
+query_with_retry direct /tmp/direct.json \
+  -H "x-cardinalhq-api-key: $ORGKEY" -H 'content-type: application/json' \
+  -d "$QUERY" \
+  "http://conductor-lakerunner-query-api.${NS}.svc:8080/api/v1/logs/query"
+DIRECT_OK=$?
+
+echo "==> (2) Maestro proxy logs query"
+query_with_retry proxy /tmp/proxy.json \
+  -H "X-Org-Id: $ORG" -H "X-CardinalHQ-API-Key: $USERKEY" -H 'content-type: application/json' \
+  -d "$QUERY" \
+  "http://conductor-maestro-maestro.${NS}.svc:4200/api/lakerunner/${INSTANCE}/query/logs/query"
+PROXY_OK=$?
+
+echo
+echo "===================== RESULTS ====================="
+echo "--- direct response (head) ---"; head -c 400 /tmp/direct.json; echo
+echo "--- proxy  response (head) ---"; head -c 400 /tmp/proxy.json; echo
+echo "==================================================="
+
+FAIL=0
+if [ "$DIRECT_OK" -eq 0 ]; then echo "PASS: query-api DIRECT returned the '$MARKER' data"; else echo "FAIL: query-api DIRECT did NOT return '$MARKER'"; FAIL=1; fi
+if [ "$PROXY_OK" -eq 0 ];  then echo "PASS: maestro PROXY returned the '$MARKER' data";  else echo "FAIL: maestro PROXY did NOT return '$MARKER'";  FAIL=1; fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FRESH-INSTALL VALIDATION FAILED"
+  exit 1
+fi
+echo "FRESH-INSTALL VALIDATION PASSED (both direct + proxy returned $MARKER)"
+exit 0

--- a/test/fresh-install/99-teardown.sh
+++ b/test/fresh-install/99-teardown.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tear down the conductor fresh-install test: uninstall the release and delete
+# the namespace (which removes Postgres/rustfs/collector and all PVCs).
+#
+# SAFETY: pinned to --context kubepi; aborts if the current context differs.
+set -uo pipefail
+CTX="${CTX:-kubepi}"
+NS="${NS:-conductor-fresh}"
+RELEASE="${RELEASE:-conductor}"
+
+CURRENT="$(command kubectl config current-context 2>/dev/null)"
+if [ "$CURRENT" != "$CTX" ]; then
+  echo "ABORT: current kube context is '$CURRENT', expected '$CTX'. Refusing to run."
+  exit 2
+fi
+
+echo "==> helm uninstall $RELEASE -n $NS"
+command helm --kube-context "$CTX" uninstall "$RELEASE" -n "$NS" 2>/dev/null || true
+
+echo "==> delete namespace $NS (removes all fixtures + PVCs)"
+command kubectl --context "$CTX" delete ns "$NS" --wait=false 2>/dev/null || true
+
+echo "teardown initiated (namespace deletion is async)"


### PR DESCRIPTION
Merges the separate `lakerunner` and `maestro` Helm charts into a single monolithic chart, **`conductor/`**. The legacy split charts are left in place for now and retire once this is proven.

## What's here
- **A — unified chart skeleton** (`conductor/`): monolithic merge; drops grafana/collector/perch; keeps mcp-gateway/github-cache/dex; one release-named ServiceAccount; the chart name never appears in resource names (stay `<release>-lakerunner-*` / `<release>-maestro-*`). Render-parity vs the legacy charts.
- **B — fresh-install bootstrap**: phased pre-install migrate hooks (lakerunner `migrate`; maestro via mcp-gateway `MCP_MIGRATE_ONLY`); a "provision-both" post-install key-seed that upserts `sha256(plaintext)` into configdb `admin_api_keys` (lakerunner owns the key); a persistent, lookup-stable anchor admin-key Secret (or `existingSecret`); `MAESTRO_BOOTSTRAP_*` wiring; ecr-public image defaults. **Validated live on kubepi** end-to-end: collector → rustfs → pubsub → processing, data returned via query-api **and** the maestro proxy.
- **C — adoption + detection**: `bootstrap.mode = auto | adopt | force`; a pre-install detection job that classifies fresh / adopt-conductor / adopt-legacy / error and **aborts rather than ever clobbering or duplicating**; split→single migration guide. Classifier truth-table verified; adoption no-duplication + `auto`-aborts-on-legacy validated live.
- **D — dex/OIDC**: chart-native dex confirmed (no ECS assumptions); fixed a merge bug where `dex-deployment.yaml`'s `checksum/config` `Template.BasePath` pointed at the pre-move path, breaking `dex.enabled=true`.

## Adopter notes (see `docs/conductor-migration-guide.md`)
- maestro DB config moved `database:` → `maestroDatabase:`
- one shared suite license (`cardinal-license`)
- maestro DB needs `pgvector` + CREATE EXTENSION
- size Postgres `max_connections` for the full stack (or pgbouncer; migrations need a direct connection)

## Tests
- `test/fresh-install/` — scripted fresh-install (Postgres 18 + rustfs + collector), curl validation via query-api + maestro proxy.
- `test/adoption/` — legacy split install → populate → uninstall → adopt; asserts no duplication + `auto` aborts on a legacy DB.
- `test/failure-modes/` — harness for split-brain / mismatch / concurrent / rollback / PVC cold-start. *Live execution of this suite is a deferred follow-up (slow; design-validating work already done).*

Specs + plans under `docs/superpowers/`.

Note: merging lands the chart in-repo only; it does not publish to ECR or change any prod pin.