### PR TITLE
conductor: bump lakerunner v1.41.6 / maestro v1.53.1, themed Dex by default

### DIFF
--- a/conductor/templates/_helpers-maestro.tpl
+++ b/conductor/templates/_helpers-maestro.tpl
@@ -770,8 +770,11 @@ pathPrefix: {{ dig "pathPrefix" "/dex" $d | quote }}
 clientId: {{ dig "clientId" "maestro-ui" $d | quote }}
 superadminGroup: {{ dig "superadminGroup" "maestro-superadmin" $d | quote }}
 image:
-  repository: {{ dig "repository" "ghcr.io/dexidp/dex" $img | quote }}
-  tag: {{ dig "tag" "v2.41.1" $img | quote }}
+  # Cardinal-themed Dex (drop-in for ghcr.io/dexidp/dex; theme is compiled
+  # into the binary as the embedded default — gives the branded login pages).
+  # dex-customization vX.Y.Z embeds upstream dex; v0.3.0 = dex v2.45.1.
+  repository: {{ dig "repository" "public.ecr.aws/cardinalhq.io/dex-customization" $img | quote }}
+  tag: {{ dig "tag" "v0.3.0" $img | quote }}
   pullPolicy: {{ dig "pullPolicy" "IfNotPresent" $img | quote }}
 {{- end -}}
 

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -33,7 +33,7 @@ global:
     # Pinned explicitly here so lakerunner images do NOT default to the unified
     # Chart.appVersion (which tracks maestro). Mirrors the legacy lakerunner
     # chart's appVersion. Per-component image.tag still wins over this.
-    tag: "v1.40.4"
+    tag: "v1.41.6"
     # Default pull policy for all images
     pullPolicy: "IfNotPresent"
   # Global temporary storage (scratch / DuckDB temp / cache) configuration.
@@ -847,7 +847,7 @@ objectStore:
 # Entrypoint selects which component to run.
 image:
   repository: public.ecr.aws/cardinalhq.io/maestro
-  tag: "v1.53.0"   # pinned (mirrors legacy maestro appVersion); do not rely on Chart.appVersion
+  tag: "v1.53.1"   # pinned (mirrors legacy maestro appVersion); do not rely on Chart.appVersion
   pullPolicy: IfNotPresent
 
 # Maestro API server + UI configuration
@@ -1180,13 +1180,17 @@ ingress:
 # templates. `resources` is surfaced here so operators can tune CPU/memory
 # without chasing template internals.
 dex:
-  # Dex container image. Defaults are also defined in templates/_helpers-maestro.tpl
-  # (maestro.dexConfig) so `--set dex.enabled=true` keeps working with
-  # zero extra fields. Surfaced here so air-gapped/private-registry
-  # installs can override without chasing template internals.
+  # Dex container image. Always Cardinal's themed Dex build (dex-customization):
+  # the branded login pages are compiled into the binary as the embedded
+  # default — no init container or extra config needed. Defaults are also
+  # defined in templates/_helpers-maestro.tpl (maestro.dexConfig) so
+  # `--set dex.enabled=true` keeps working with zero extra fields.
+  # Surfaced here so air-gapped/private-registry installs can point at their
+  # own MIRROR of the themed image. Do not point this at upstream
+  # ghcr.io/dexidp/dex — that ships the generic, unbranded Dex login.
   # image:
-  #   repository: ghcr.io/dexidp/dex
-  #   tag: v2.41.1
+  #   repository: public.ecr.aws/cardinalhq.io/dex-customization
+  #   tag: v0.3.0   # embeds upstream dex v2.45.1
   #   pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary
Update the unified **conductor** chart to the latest component images and make the Cardinal-themed Dex the default.

| Image | Before | After | Source tag |
|---|---|---|---|
| lakerunner | `v1.40.4` | **`v1.41.6`** | `cardinalhq/lakerunner` @ `v1.41.6` |
| maestro | `v1.53.0` | **`v1.53.1`** | `cardinalhq/conductor` @ `maestro/v1.53.1` (provisioning cold-start retry fix) |
| dex | `ghcr.io/dexidp/dex:v2.41.1` | **`public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0`** | `cardinalhq/dex-customization` @ `v0.3.0` |

## Themed Dex
`dex-customization` is a drop-in for upstream dex with the branded login pages compiled into the binary as the embedded default (no init container, no extra config). Conductor keeps its existing ConfigMap-driven dex config and `command: dex serve /etc/dex/config.yaml` — only the default image changes. `v0.3.0` embeds upstream dex **v2.45.1** (the config fields conductor uses are stable across 2.41→2.45, and 2.45.1 is what CF ships). We never want an unthemed install; the image override is documented for mirroring the themed image into a private registry only — **not** for pointing back at upstream dex.

## Verification
- `helm lint conductor` → 0 failed
- Rendered pins confirmed: `lakerunner:v1.41.6`, `maestro:v1.53.1`, `dex-customization:v0.3.0`

## Note for CF parity
lakerunner-cloudformation still pins lakerunner `v1.40.4`; `v1.41.6` is the latest. maestro (`v1.53.1`) and dex (`dex-customization:v0.3.0`) already match CF.