### PR TITLE
docs(maestro): document optional OUTCOMES_SUMMARY_* env knobs

### DIFF
--- a/maestro/values.yaml
+++ b/maestro/values.yaml
@@ -134,6 +134,16 @@ maestro:
   #     value: uid                          # changing on a live install is a migration event
   #   - name: OIDC_TRUST_UNVERIFIED_EMAILS  # default: false — pair carefully with a
   #     value: "true"                       # remapped OIDC_EMAIL_CLAIM (see docs)
+  #
+  #   # Agent Outcomes session summarizer (all optional; sensible defaults).
+  #   # Writes a short LLM-authored title per agent session and flags cost
+  #   # drift. Uses the org's configured LLM (prefers a Haiku-tier model).
+  #   - name: OUTCOMES_SUMMARY_MODEL              # default: prefers "haiku" in the
+  #     value: haiku                             # model catalog, else first available
+  #   - name: OUTCOMES_SUMMARY_COST_WATERMARK_USD # default: 5 — re-summarize once a
+  #     value: "5"                               # session's spend grows this much
+  #   - name: OUTCOMES_SUMMARY_COST_FLOOR_USD     # default: 0.5 — skip sessions
+  #     value: "0.5"                             # cheaper than this
   env: []
   extraVolumes: []       # additional volumes
   extraVolumeMounts: []  # additional volume mounts


### PR DESCRIPTION
Documents the optional Agent Outcomes session-summarizer env knobs in the commented `maestro.env` example: `OUTCOMES_SUMMARY_MODEL`, `OUTCOMES_SUMMARY_COST_WATERMARK_USD`, `OUTCOMES_SUMMARY_COST_FLOOR_USD`. No template change — the chart already passes `maestro.env` through; all three have code defaults.

Companion to conductor#1013 (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)