### PR TITLE
lakerunner: chart 3.14.8, appVersion v1.47.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.14.7"
-appVersion: "v1.46.1"
+version: "3.14.8"
+appVersion: "v1.47.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.47.0 release (probe wave engagement fix, compaction bleed control, force-recompact heal CLI).