### PR TITLE
lakerunner: chart 3.14.9, appVersion v1.48.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.14.8"
-appVersion: "v1.47.0"
+version: "3.14.9"
+appVersion: "v1.48.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner v1.48.0 (toolkit token metering, lakerunner#907).