### PR TITLE
lakerunner: chart 3.14.11, appVersion v1.50.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.14.10"
-appVersion: "v1.49.0"
+version: "3.14.11"
+appVersion: "v1.50.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner v1.50.0 release (cardinalhq/lakerunner#931 — per-turn telemetry tap + C3 promotion-candidates endpoint).