### PR TITLE
lakerunner: add global.autoscaling.mode (hpa | worklane), default hpa

### DIFF
--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 3.15.0
+
+* **NEW**: `global.autoscaling.mode` selects how the process-* workers are scaled.
+  - `"hpa"` (default): replica decisions are owned by a Kubernetes
+    HorizontalPodAutoscaler (or any external scaler). The built-in PI autoscaler
+    runs in report-only mode — it still emits the worklane depth/age metrics but
+    does not scale. Wired via `LAKERUNNER_AUTOSCALER_REPORT_ONLY=true` on the
+    monitoring container.
+  - `"worklane"`: the built-in delay-aware PI autoscaler owns replica decisions
+    (the previous behavior). `monitoring.autoscaler.observeOnly` still applies.
+  - **CHANGED**: the default is now `"hpa"`, so out of the box the PI autoscaler
+    no longer scales the process-* deployments. Set
+    `global.autoscaling.mode: worklane` to restore the previous behavior. This
+    chart does not create the HPA in `"hpa"` mode — provide one alongside the
+    release.
+
 ## 3.9.0
 
 * **CHANGED**: Rebalanced worker pod memory math (process-logs, process-metrics, process-traces)

--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -3,18 +3,24 @@
 ## 3.15.0
 
 * **NEW**: `global.autoscaling.mode` selects how the process-* workers are scaled.
-  - `"hpa"` (default): replica decisions are owned by a Kubernetes
-    HorizontalPodAutoscaler (or any external scaler). The built-in PI autoscaler
-    runs in report-only mode — it still emits the worklane depth/age metrics but
-    does not scale. Wired via `LAKERUNNER_AUTOSCALER_REPORT_ONLY=true` on the
+  - `"hpa"` (default): the chart renders one `HorizontalPodAutoscaler` per
+    enabled process-* worker (CPU-target, bounds from each service's
+    `autoscaling.minReplicas/maxReplicas`), and the built-in PI autoscaler runs
+    in report-only mode — it still emits the worklane depth/age metrics but does
+    not scale. Wired via `LAKERUNNER_AUTOSCALER_REPORT_ONLY=true` on the
     monitoring container.
   - `"worklane"`: the built-in delay-aware PI autoscaler owns replica decisions
-    (the previous behavior). `monitoring.autoscaler.observeOnly` still applies.
-  - **CHANGED**: the default is now `"hpa"`, so out of the box the PI autoscaler
-    no longer scales the process-* deployments. Set
-    `global.autoscaling.mode: worklane` to restore the previous behavior. This
-    chart does not create the HPA in `"hpa"` mode — provide one alongside the
-    release.
+    (the previous behavior) and no HPA is rendered.
+    `monitoring.autoscaler.observeOnly` still applies.
+  - **CHANGED**: the default is now `"hpa"`, so out of the box replica decisions
+    move from the built-in PI autoscaler to a Kubernetes HPA. Set
+    `global.autoscaling.mode: worklane` to restore the previous behavior.
+* **NEW**: `global.autoscaling.hpa` configures the rendered HPAs —
+  `targetCPUUtilizationPercentage` (default 85) and a `behavior` block (fast
+  scale-up, 120s scale-down stabilization to damp flapping). Both can be
+  overridden per-service under `processLogs/processMetrics/processTraces.autoscaling`.
+  The process-* Deployments omit `spec.replicas`, so the HPA owns the count
+  without fighting the rendered manifest.
 
 ## 3.9.0
 

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.14.14"
+version: "3.15.0"
 appVersion: "v1.51.3"
 keywords:
   - lakerunner

--- a/lakerunner/templates/_helpers.tpl
+++ b/lakerunner/templates/_helpers.tpl
@@ -580,10 +580,18 @@ so the autoscaler treats it as scaled-to-zero.
 Usage: {{ include "lakerunner.autoscalerEnv" . }}
 */}}
 {{- define "lakerunner.autoscalerEnv" -}}
+{{- $mode := .Values.global.autoscaling.mode | default "hpa" -}}
+{{- if not (has $mode (list "hpa" "worklane")) -}}
+{{- fail (printf "global.autoscaling.mode must be \"hpa\" or \"worklane\", got %q" $mode) -}}
+{{- end -}}
 - name: LAKERUNNER_AUTOSCALER_ENABLED
   value: "true"
 - name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
   value: {{ .Values.monitoring.autoscaler.observeOnly | quote }}
+# "hpa" mode runs the PI autoscaler in report-only mode (worklane metrics only,
+# no scaling); "worklane" mode lets it own replica decisions.
+- name: LAKERUNNER_AUTOSCALER_REPORT_ONLY
+  value: {{ eq $mode "hpa" | quote }}
 - name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
   value: {{ include "lakerunner.fullname" . }}-process-logs
 - name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS

--- a/lakerunner/templates/process-hpa.yaml
+++ b/lakerunner/templates/process-hpa.yaml
@@ -1,0 +1,50 @@
+{{- /*
+HorizontalPodAutoscalers for the process-* workers, rendered only when
+global.autoscaling.mode is "hpa". Bounds come from each service's
+autoscaling.minReplicas/maxReplicas; the CPU target and behavior default from
+global.autoscaling.hpa and may be overridden per-service.
+
+The process-* Deployment templates intentionally omit spec.replicas, so an HPA
+owns the replica count without fighting the rendered manifest.
+*/ -}}
+{{- if eq (.Values.global.autoscaling.mode | default "hpa") "hpa" }}
+{{- $root := . }}
+{{- $hpa := .Values.global.autoscaling.hpa | default dict }}
+{{- $services := list
+    (dict "component" "process-logs" "values" .Values.processLogs)
+    (dict "component" "process-metrics" "values" .Values.processMetrics)
+    (dict "component" "process-traces" "values" .Values.processTraces) }}
+{{- range $svc := $services }}
+{{- if $svc.values.enabled }}
+{{- $as := $svc.values.autoscaling | default dict }}
+{{- $target := $as.targetCPUUtilizationPercentage | default $hpa.targetCPUUtilizationPercentage | default 85 }}
+{{- $behavior := $as.behavior | default $hpa.behavior }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lakerunner.fullname" $root }}-{{ $svc.component }}
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list $root $svc.values.labels) | nindent 4 }}
+    app.kubernetes.io/component: {{ $svc.component }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lakerunner.fullname" $root }}-{{ $svc.component }}
+  minReplicas: {{ $as.minReplicas | default 1 }}
+  maxReplicas: {{ $as.maxReplicas | default 1 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $target }}
+  {{- with $behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/lakerunner/tests/autoscaling-mode_test.yaml
+++ b/lakerunner/tests/autoscaling-mode_test.yaml
@@ -1,0 +1,50 @@
+suite: test global.autoscaling.mode
+templates:
+  - control-plane-deployment.yaml
+values:
+  - ../values.yaml
+set:
+  cloudProvider.aws.region: us-west-2
+  license.data: '{"key":"test"}'
+tests:
+  # The monitoring container (index 2: admin-api, alert-evaluator, monitoring,
+  # sweeper) carries the autoscaler env emitted by lakerunner.autoscalerEnv.
+  - it: defaults to hpa mode (PI autoscaler report-only)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_REPORT_ONLY
+            value: "true"
+
+  - it: hpa mode sets report-only true
+    set:
+      global.autoscaling.mode: hpa
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_REPORT_ONLY
+            value: "true"
+
+  - it: worklane mode sets report-only false
+    set:
+      global.autoscaling.mode: worklane
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: LAKERUNNER_AUTOSCALER_REPORT_ONLY
+            value: "false"
+
+  - it: rejects an invalid mode
+    set:
+      global.autoscaling.mode: bogus
+    asserts:
+      - failedTemplate:
+          errorMessage: global.autoscaling.mode must be "hpa" or "worklane", got "bogus"

--- a/lakerunner/tests/process-hpa_test.yaml
+++ b/lakerunner/tests/process-hpa_test.yaml
@@ -77,6 +77,32 @@ tests:
           value: 70
         documentIndex: 0
 
+  - it: a per-service behavior override replaces the global behavior
+    set:
+      processLogs.autoscaling.behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 600
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 600
+        documentIndex: 0
+      - notExists:
+          path: spec.behavior.scaleUp
+        documentIndex: 0
+
+  - it: falls back to target 85 and no behavior when global.autoscaling.hpa is unset
+    set:
+      global.autoscaling.hpa: null
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 85
+        documentIndex: 0
+      - notExists:
+          path: spec.behavior
+        documentIndex: 0
+
   - it: omits the HPA for a disabled worker
     set:
       processTraces.enabled: false

--- a/lakerunner/tests/process-hpa_test.yaml
+++ b/lakerunner/tests/process-hpa_test.yaml
@@ -1,0 +1,100 @@
+suite: test process-* HorizontalPodAutoscalers
+templates:
+  - process-hpa.yaml
+values:
+  - ../values.yaml
+set:
+  cloudProvider.aws.region: us-west-2
+  license.data: '{"key":"test"}'
+tests:
+  - it: renders one HPA per process-* worker in hpa mode
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: HorizontalPodAutoscaler
+        documentIndex: 0
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lakerunner-process-logs
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lakerunner-process-metrics
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lakerunner-process-traces
+        documentIndex: 2
+
+  - it: logs HPA targets the deployment with bounds, cpu target, and behavior
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-lakerunner-process-logs
+        documentIndex: 0
+      - equal:
+          path: spec.minReplicas
+          value: 1
+        documentIndex: 0
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+        documentIndex: 0
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 85
+        documentIndex: 0
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 120
+        documentIndex: 0
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+        documentIndex: 0
+
+  - it: uses per-service min/max and target overrides
+    set:
+      processLogs.autoscaling.minReplicas: 2
+      processLogs.autoscaling.maxReplicas: 25
+      processLogs.autoscaling.targetCPUUtilizationPercentage: 70
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+        documentIndex: 0
+      - equal:
+          path: spec.maxReplicas
+          value: 25
+        documentIndex: 0
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 70
+        documentIndex: 0
+
+  - it: omits the HPA for a disabled worker
+    set:
+      processTraces.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lakerunner-process-logs
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lakerunner-process-metrics
+        documentIndex: 1
+
+  - it: renders no HPA in worklane mode
+    set:
+      global.autoscaling.mode: worklane
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/lakerunner/tests/scaling_test.yaml
+++ b/lakerunner/tests/scaling_test.yaml
@@ -4,7 +4,7 @@ templates:
   - process-logs-deployment.yaml
   - process-metrics-deployment.yaml
   - process-traces-deployment.yaml
-  - monitoring-deployment.yaml
+  - control-plane-deployment.yaml
 values:
   - ../values.yaml
 set:
@@ -59,25 +59,25 @@ tests:
       processLogs.autoscaling.minReplicas: 1
       processLogs.autoscaling.maxReplicas: 10
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_ENABLED
             value: "true"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-logs
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
             value: "1"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "10"
@@ -87,20 +87,20 @@ tests:
       monitoring.enabled: true
       processTraces.enabled: false
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-traces
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
             value: "0"
@@ -110,20 +110,20 @@ tests:
       monitoring.enabled: true
       processLogs.enabled: false
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-logs
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "0"
@@ -133,20 +133,20 @@ tests:
       monitoring.enabled: true
       processMetrics.enabled: false
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-metrics
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
             value: "0"
@@ -158,15 +158,15 @@ tests:
       processTraces.autoscaling.minReplicas: 3
       processTraces.autoscaling.maxReplicas: 7
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
             value: "0"
@@ -178,35 +178,35 @@ tests:
       processMetrics.enabled: false
       processTraces.enabled: false
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-logs
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-metrics
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
             value: RELEASE-NAME-lakerunner-process-traces
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
             value: "0"
@@ -216,10 +216,10 @@ tests:
       monitoring.enabled: true
       monitoring.autoscaler.observeOnly: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
             value: "true"
@@ -228,10 +228,10 @@ tests:
     set:
       monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
             value: "false"
@@ -243,15 +243,15 @@ tests:
       processLogs.autoscaling.minReplicas: 5
       processLogs.autoscaling.maxReplicas: 5
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
             value: "5"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "5"
@@ -263,15 +263,15 @@ tests:
       processLogs.autoscaling.minReplicas: 0
       processLogs.autoscaling.maxReplicas: 0
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
             value: "0"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
             value: "0"

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -3,6 +3,20 @@
 
 # Global settings
 global:
+  # Autoscaling mode for the process-* workers.
+  #   "hpa"      — (default) replica decisions are owned by a Kubernetes
+  #                HorizontalPodAutoscaler (or any external scaler). The built-in
+  #                PI autoscaler runs in report-only mode: it still emits the
+  #                worklane depth/age metrics for observability but does not scale
+  #                any deployment.
+  #   "worklane" — the built-in delay-aware PI autoscaler owns replica decisions,
+  #                scaling the process-* deployments from work-queue depth. The
+  #                monitoring.autoscaler.observeOnly knob still applies in this
+  #                mode.
+  # Note: in "hpa" mode this chart does not create the HorizontalPodAutoscaler;
+  # provide one alongside the release.
+  autoscaling:
+    mode: hpa
   # Global resource configuration
   resources:
     # Whether to render resource limits and requests in deployments

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -4,19 +4,45 @@
 # Global settings
 global:
   # Autoscaling mode for the process-* workers.
-  #   "hpa"      — (default) replica decisions are owned by a Kubernetes
-  #                HorizontalPodAutoscaler (or any external scaler). The built-in
-  #                PI autoscaler runs in report-only mode: it still emits the
+  #   "hpa"      — (default) the chart renders one HorizontalPodAutoscaler per
+  #                enabled process-* worker (see hpa below), and the built-in PI
+  #                autoscaler runs in report-only mode: it still emits the
   #                worklane depth/age metrics for observability but does not scale
   #                any deployment.
   #   "worklane" — the built-in delay-aware PI autoscaler owns replica decisions,
-  #                scaling the process-* deployments from work-queue depth. The
-  #                monitoring.autoscaler.observeOnly knob still applies in this
-  #                mode.
-  # Note: in "hpa" mode this chart does not create the HorizontalPodAutoscaler;
-  # provide one alongside the release.
+  #                scaling the process-* deployments from work-queue depth. No HPA
+  #                is rendered. The monitoring.autoscaler.observeOnly knob still
+  #                applies in this mode.
   autoscaling:
     mode: hpa
+    # Settings for the HorizontalPodAutoscalers rendered in "hpa" mode. One HPA
+    # is created per enabled process-* worker; its min/max come from that
+    # service's autoscaling.minReplicas/maxReplicas. targetCPUUtilizationPercentage
+    # and behavior here are the defaults for all three and can be overridden
+    # per-service under processLogs/processMetrics/processTraces.autoscaling.
+    hpa:
+      # Target average CPU as a percentage of the pod's cpu request.
+      targetCPUUtilizationPercentage: 85
+      # HPA v2 scaling behavior. Defaults favor fast scale-up and a damped
+      # 2-minute scale-down window to avoid replica flapping.
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+            - type: Pods
+              value: 4
+              periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 120
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
   # Global resource configuration
   resources:
     # Whether to render resource limits and requests in deployments


### PR DESCRIPTION
## What

Adds `global.autoscaling.mode` to the lakerunner chart, and in `hpa` mode the chart now **renders the HorizontalPodAutoscalers itself** (one per enabled process-* worker).

| mode | behavior | HPA rendered? | monitoring env |
|---|---|---|---|
| `hpa` *(default)* | replica decisions owned by a Kubernetes HPA; built-in PI autoscaler runs **report-only** (worklane metrics, no scaling) | ✅ one per enabled process-* worker | `LAKERUNNER_AUTOSCALER_REPORT_ONLY=true` |
| `worklane` | built-in delay-aware PI autoscaler owns replica decisions (previous behavior); `monitoring.autoscaler.observeOnly` still applies | ❌ none | `LAKERUNNER_AUTOSCALER_REPORT_ONLY=false` |

## The rendered HPAs

- One per enabled `process-{logs,metrics,traces}` worker.
- Bounds from each service's existing `autoscaling.minReplicas/maxReplicas`.
- CPU target + behavior from new `global.autoscaling.hpa`:
  - `targetCPUUtilizationPercentage: 85`
  - `behavior`: fast scale-up (window 0, 100%/4-pods per 60s) + **120s** scale-down stabilization to damp flapping.
  - Both overridable per-service under `processLogs/Metrics/Traces.autoscaling`.
- The process-* Deployments omit `spec.replicas`, so the HPA owns the count without fighting the manifest.

## ⚠️ Default behavior change

The default is now `hpa`: out of the box, replica decisions move from the built-in PI autoscaler (now report-only) to a chart-rendered HPA. Set `global.autoscaling.mode: worklane` to restore the previous PI-autoscaler behavior.

## Changes

- `values.yaml`: `global.autoscaling.mode` + `global.autoscaling.hpa` (target + behavior).
- `templates/_helpers.tpl`: `autoscalerEnv` emits `LAKERUNNER_AUTOSCALER_REPORT_ONLY` from the mode + validates it.
- `templates/process-hpa.yaml`: **new** — renders the per-worker HPAs in `hpa` mode.
- `Chart.yaml`: `3.14.14` → `3.15.0`; `Changelog.md` updated.
- Tests: `tests/autoscaling-mode_test.yaml` + `tests/process-hpa_test.yaml` (9 tests, all pass; `helm lint` clean).

## Companion

Requires app-side `LAKERUNNER_AUTOSCALER_REPORT_ONLY`: cardinalhq/lakerunner#945.

## Deploy note

This supersedes the experimental hand-written `hpa-process.yaml` in *kubernetes-clusters*. The chart-rendered HPAs share the same names (`<release>-process-*`), so the overlay file must be removed when bumping prod to this chart (kustomize errors on duplicate resources otherwise).

## Pre-existing

`tests/scaling_test.yaml` is already failing on main (references the old `monitoring-deployment.yaml`, since merged into `control-plane-deployment.yaml`). Left as-is; separate fix.