### PR TITLE
lakerunner: repair chart unit tests after the control-plane deployment merge

### DIFF
--- a/lakerunner/tests/conditional-rendering_test.yaml
+++ b/lakerunner/tests/conditional-rendering_test.yaml
@@ -12,8 +12,7 @@ templates:
   - process-logs-deployment.yaml
   - process-metrics-deployment.yaml
   - process-traces-deployment.yaml
-  - sweeper-deployment.yaml
-  - alert-evaluator-deployment.yaml
+  - control-plane-deployment.yaml
   - deprecation-warnings.yaml
   - pubsub-http-deployment.yaml
   - pubsub-sqs-deployment.yaml
@@ -154,33 +153,37 @@ tests:
       processLogs.enabled: true
       processMetrics.enabled: true
       processTraces.enabled: true
-      sweeper.enabled: true
     templates:
       - process-logs-deployment.yaml
       - process-metrics-deployment.yaml
       - process-traces-deployment.yaml
-      - sweeper-deployment.yaml
     asserts:
       - isKind:
           of: Deployment
 
-  - it: should render alert evaluator when enabled
-    set:
-      alertEvaluator.enabled: true
+  # sweeper and alert-evaluator are colocated in the control-plane pod; their
+  # containers are always rendered as part of the control-plane Deployment.
+  - it: should render sweeper and alert-evaluator containers in the control-plane deployment
     templates:
-      - alert-evaluator-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - isKind:
           of: Deployment
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sweeper")].name
+          value: sweeper
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="alert-evaluator")].name
+          value: alert-evaluator
 
-  - it: should not render alert evaluator when disabled
+  - it: should fail when legacy alertEvaluator.enabled is configured
     set:
       alertEvaluator.enabled: false
     templates:
-      - alert-evaluator-deployment.yaml
+      - deprecation-warnings.yaml
     asserts:
-      - hasDocuments:
-          count: 0
+      - failedTemplate:
+          errorPattern: "alertEvaluator.enabled"
 
   - it: should fail when notificationSender is still configured
     set:

--- a/lakerunner/tests/env_test.yaml
+++ b/lakerunner/tests/env_test.yaml
@@ -11,13 +11,12 @@ templates:
   - query-api-deployment.yaml
   - query-worker-deployment.yaml
   - grafana-deployment.yaml
-  - monitoring-deployment.yaml
+  - control-plane-deployment.yaml
   - setup-job.yaml
   - pubsub-http-deployment.yaml
   - pubsub-sqs-deployment.yaml
   - pubsub-gcp-deployment.yaml
   - pubsub-azure-deployment.yaml
-  - sweeper-deployment.yaml
 tests:
   - it: should render common environment variables for all components
     set:
@@ -271,15 +270,15 @@ tests:
       database.lrdb.host: "postgresql.default.svc.cluster.local"
       sweeper.env: []
     templates:
-      - sweeper-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="sweeper")].env
           content:
             name: GLOBAL_ONLY
             value: "global-only"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="sweeper")].env
           content:
             name: LRDB_HOST
             value: "postgresql.default.svc.cluster.local"

--- a/lakerunner/tests/global-resources_test.yaml
+++ b/lakerunner/tests/global-resources_test.yaml
@@ -12,8 +12,7 @@ templates:
   - process-logs-deployment.yaml
   - process-metrics-deployment.yaml
   - process-traces-deployment.yaml
-  - sweeper-deployment.yaml
-  - monitoring-deployment.yaml
+  - control-plane-deployment.yaml
   - pubsub-http-deployment.yaml
   - pubsub-sqs-deployment.yaml
   - pubsub-gcp-deployment.yaml
@@ -84,12 +83,12 @@ tests:
       - template: process-logs-deployment.yaml
         exists:
           path: spec.template.spec.containers[0].resources.limits.cpu
-      - template: sweeper-deployment.yaml
+      - template: control-plane-deployment.yaml
         exists:
-          path: spec.template.spec.containers[0].resources.requests.cpu
-      - template: sweeper-deployment.yaml
+          path: spec.template.spec.containers[?(@.name=="sweeper")].resources.requests.cpu
+      - template: control-plane-deployment.yaml
         exists:
-          path: spec.template.spec.containers[0].resources.limits.cpu
+          path: spec.template.spec.containers[?(@.name=="sweeper")].resources.limits.memory
 
   - it: should render resources on pubsub components when enabled
     set:

--- a/lakerunner/tests/health-checks_test.yaml
+++ b/lakerunner/tests/health-checks_test.yaml
@@ -8,7 +8,7 @@ templates:
   - process-logs-deployment.yaml
   - process-metrics-deployment.yaml
   - process-traces-deployment.yaml
-  - sweeper-deployment.yaml
+  - control-plane-deployment.yaml
   - query-api-deployment.yaml
   - query-worker-deployment.yaml
   - grafana-deployment.yaml
@@ -16,7 +16,6 @@ templates:
   - pubsub-sqs-deployment.yaml
   - pubsub-azure-deployment.yaml
   - pubsub-gcp-deployment.yaml
-  - monitoring-deployment.yaml
 tests:
   # Global Health Probe Configuration Tests
   - it: should not have health probes when globally disabled
@@ -25,12 +24,22 @@ tests:
     templates:
       - process-logs-deployment.yaml
       - query-api-deployment.yaml
-      - monitoring-deployment.yaml
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].livenessProbe
       - isNull:
           path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should not have monitoring health probes when globally disabled
+    set:
+      global.healthProbes.enabled: false
+    templates:
+      - control-plane-deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].livenessProbe
+      - isNull:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].readinessProbe
 
   - it: should have health probes when globally enabled
     set:
@@ -98,20 +107,20 @@ tests:
   # Monitoring Service Special Case
   - it: should configure monitoring service health probes with custom endpoints
     set:
-      global.healthProbes.enabled: false  # monitoring uses its own config
-      monitoring.healthProbes.enabled: true
+      global.healthProbes.enabled: false
+      controlPlane.healthProbes.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          path: spec.template.spec.containers[?(@.name=="monitoring")].livenessProbe.httpGet.path
           value: "/livez"
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: "healthcheck"
+          path: spec.template.spec.containers[?(@.name=="monitoring")].livenessProbe.httpGet.port
+          value: "hc-mon"
       - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          path: spec.template.spec.containers[?(@.name=="monitoring")].readinessProbe.httpGet.path
           value: "/readyz"
       - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: "healthcheck"
+          path: spec.template.spec.containers[?(@.name=="monitoring")].readinessProbe.httpGet.port
+          value: "hc-mon"

--- a/lakerunner/tests/license_test.yaml
+++ b/lakerunner/tests/license_test.yaml
@@ -7,7 +7,7 @@ templates:
   - license-secret.yaml
   - license-validation.yaml
   - process-logs-deployment.yaml
-  - sweeper-deployment.yaml
+  - control-plane-deployment.yaml
   - setup-job.yaml
 tests:
   # Secret creation tests
@@ -97,10 +97,10 @@ tests:
     set:
       license.data: '{"key":"value"}'
     templates:
-      - sweeper-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].volumeMounts
+          path: spec.template.spec.containers[?(@.name=="sweeper")].volumeMounts
           content:
             name: license
             mountPath: /app/license

--- a/lakerunner/tests/monitoring_test.yaml
+++ b/lakerunner/tests/monitoring_test.yaml
@@ -5,50 +5,49 @@ set:
   cloudProvider.aws.region: us-west-2
   license.data: '{"key":"test"}'
 templates:
-  - monitoring-deployment.yaml
+  - control-plane-deployment.yaml
+  - deprecation-warnings.yaml
 tests:
   # Conditional Rendering Tests
-  - it: should render monitoring deployment when enabled
-    set:
-      monitoring.enabled: true
+  # monitoring is colocated in the control-plane pod; its container is always
+  # rendered as part of the control-plane Deployment.
+  - it: should render monitoring container in the control-plane deployment
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - isKind:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-lakerunner-monitoring
+          value: RELEASE-NAME-lakerunner-control-plane
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].name
+          value: monitoring
 
-  - it: should not render monitoring resources when disabled
+  - it: should fail when legacy monitoring.enabled is configured
     set:
       monitoring.enabled: false
     templates:
-      - monitoring-deployment.yaml
+      - deprecation-warnings.yaml
     asserts:
-      - hasDocuments:
-          count: 0
+      - failedTemplate:
+          errorPattern: "monitoring.enabled"
 
   # Resource Configuration Tests
   - it: should set default resources
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - isNotNull:
-          path: spec.template.spec.containers[0].resources.requests.cpu
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.requests.cpu
       - isNotNull:
-          path: spec.template.spec.containers[0].resources.requests.memory
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.requests.memory
       - isNotNull:
-          path: spec.template.spec.containers[0].resources.limits.cpu
-      - isNotNull:
-          path: spec.template.spec.containers[0].resources.limits.memory
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.limits.memory
 
   - it: should allow custom resource configuration
     set:
-      monitoring.enabled: true
-      monitoring.resources:
+      controlPlane.resources.monitoring:
         requests:
           cpu: "200m"
           memory: "256Mi"
@@ -56,84 +55,80 @@ tests:
           cpu: "500m"
           memory: "512Mi"
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].resources.requests.cpu
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.requests.cpu
           value: "200m"
       - equal:
-          path: spec.template.spec.containers[0].resources.requests.memory
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.requests.memory
           value: "256Mi"
       - equal:
-          path: spec.template.spec.containers[0].resources.limits.cpu
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.limits.cpu
           value: "500m"
       - equal:
-          path: spec.template.spec.containers[0].resources.limits.memory
+          path: spec.template.spec.containers[?(@.name=="monitoring")].resources.limits.memory
           value: "512Mi"
 
   # Port Configuration Tests
   - it: should expose only the healthcheck container port
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - lengthEqual:
-          path: spec.template.spec.containers[0].ports
+          path: spec.template.spec.containers[?(@.name=="monitoring")].ports
           count: 1
       - equal:
-          path: spec.template.spec.containers[0].ports[0].name
-          value: healthcheck
+          path: spec.template.spec.containers[?(@.name=="monitoring")].ports[0].name
+          value: hc-mon
 
   # Database Secret Configuration Tests
   - it: should configure database environment variables
     set:
-      monitoring.enabled: true
       database.lrdb.host: "test-db-host"
       database.lrdb.port: "5432"
       database.lrdb.name: "test-db"
       database.lrdb.username: "test-user"
       database.lrdb.sslMode: "require"
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_HOST
             value: "test-db-host"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_PORT
             value: "5432"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_DBNAME
             value: "test-db"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_USER
             value: "test-user"
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_SSLMODE
             value: "require"
 
   - it: should reference database password from secret
     set:
-      monitoring.enabled: true
       database.create: true
       database.secretName: "postgresql-secret"
       database.passwordKey: "password"
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_PASSWORD
             valueFrom:
@@ -143,15 +138,14 @@ tests:
 
   - it: should use existing secret name when database.create is false
     set:
-      monitoring.enabled: true
       database.create: false
       database.secretName: "existing-db-secret"
       database.passwordKey: "db-password"
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: LRDB_PASSWORD
             valueFrom:
@@ -161,10 +155,8 @@ tests:
 
   # Security Context Tests
   - it: should apply security context
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -179,66 +171,59 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 65532
       - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.allowPrivilegeEscalation
           value: false
       - contains:
-          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.capabilities.drop
           content: "ALL"
       - equal:
-          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.seccompProfile.type
           value: "RuntimeDefault"
 
   # Image Configuration Tests
   - it: should use default image
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="monitoring")].image
           pattern: "^ghcr\\.io/cardinalhq/lakerunner:"
 
   - it: should allow custom image configuration
     set:
-      monitoring.enabled: true
-      monitoring.image:
+      controlPlane.image:
         repository: "custom.registry.io/monitoring"
         tag: "v2.0.0"
         pullPolicy: "Always"
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="monitoring")].image
           pattern: "^custom\\.registry\\.io/monitoring:v2\\.0\\.0$"
       - equal:
-          path: spec.template.spec.containers[0].imagePullPolicy
+          path: spec.template.spec.containers[?(@.name=="monitoring")].imagePullPolicy
           value: "Always"
 
   # Command and Args Tests
   - it: should configure correct command and args
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].command[0]
+          path: spec.template.spec.containers[?(@.name=="monitoring")].command[0]
           value: "/app/bin/lakerunner"
       - contains:
-          path: spec.template.spec.containers[0].args
+          path: spec.template.spec.containers[?(@.name=="monitoring")].args
           content: "monitoring"
       - contains:
-          path: spec.template.spec.containers[0].args
+          path: spec.template.spec.containers[?(@.name=="monitoring")].args
           content: "serve"
 
   # Replica Configuration Tests
   - it: should set default replica count
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
           path: spec.replicas
@@ -246,10 +231,9 @@ tests:
 
   - it: should allow custom replica count
     set:
-      monitoring.enabled: true
-      monitoring.replicas: 3
+      controlPlane.replicas: 3
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
           path: spec.replicas
@@ -257,39 +241,33 @@ tests:
 
   # Labels and Selectors Tests
   - it: should set correct labels and selectors
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/component"]
-          value: "monitoring"
+          value: "control-plane"
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]
-          value: "monitoring"
+          value: "control-plane"
 
   # Environment Variables Tests
   - it: should set OTEL_SERVICE_NAME
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: OTEL_SERVICE_NAME
             value: RELEASE-NAME-lakerunner-monitoring
 
   - it: should set TMPDIR
-    set:
-      monitoring.enabled: true
     templates:
-      - monitoring-deployment.yaml
+      - control-plane-deployment.yaml
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[?(@.name=="monitoring")].env
           content:
             name: TMPDIR
             value: /scratch

--- a/lakerunner/tests/security_test.yaml
+++ b/lakerunner/tests/security_test.yaml
@@ -10,8 +10,7 @@ templates:
   - process-logs-deployment.yaml
   - process-metrics-deployment.yaml
   - process-traces-deployment.yaml
-  - sweeper-deployment.yaml
-  - monitoring-deployment.yaml
+  - control-plane-deployment.yaml
   # PubSub components
   - pubsub-http-deployment.yaml
   - pubsub-sqs-deployment.yaml
@@ -32,14 +31,7 @@ tests:
       - process-logs-deployment.yaml
       - process-metrics-deployment.yaml
       - process-traces-deployment.yaml
-      - sweeper-deployment.yaml
-      - monitoring-deployment.yaml
-    set:
-      processLogs.enabled: true
-      processMetrics.enabled: true
-      processTraces.enabled: true
-      sweeper.enabled: true
-      monitoring.enabled: true
+      - control-plane-deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -57,14 +49,6 @@ tests:
       - process-logs-deployment.yaml
       - process-metrics-deployment.yaml
       - process-traces-deployment.yaml
-      - sweeper-deployment.yaml
-      - monitoring-deployment.yaml
-    set:
-      processLogs.enabled: true
-      processMetrics.enabled: true
-      processTraces.enabled: true
-      sweeper.enabled: true
-      monitoring.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
@@ -74,6 +58,29 @@ tests:
           value: "ALL"
       - equal:
           path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: "RuntimeDefault"
+
+  - it: should set container security context for control-plane components
+    templates:
+      - control-plane-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.capabilities.drop[0]
+          value: "ALL"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="monitoring")].securityContext.seccompProfile.type
+          value: "RuntimeDefault"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sweeper")].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sweeper")].securityContext.capabilities.drop[0]
+          value: "ALL"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sweeper")].securityContext.seccompProfile.type
           value: "RuntimeDefault"
 
   # Test PubSub components

--- a/lakerunner/tests/service-configuration_test.yaml
+++ b/lakerunner/tests/service-configuration_test.yaml
@@ -12,8 +12,6 @@ tests:
   - it: should use ClusterIP by default for admin-api service
     templates:
       - admin-api-service.yaml
-    set:
-      adminApi.enabled: true
     asserts:
       - equal:
           path: spec.type
@@ -23,7 +21,6 @@ tests:
     templates:
       - admin-api-service.yaml
     set:
-      adminApi.enabled: true
       adminApi.service.type: LoadBalancer
     asserts:
       - equal:
@@ -34,7 +31,6 @@ tests:
     templates:
       - admin-api-service.yaml
     set:
-      adminApi.enabled: true
       adminApi.service.type: LoadBalancer
       adminApi.service.loadBalancerIP: "10.0.0.101"
     asserts:
@@ -46,7 +42,6 @@ tests:
     templates:
       - admin-api-service.yaml
     set:
-      adminApi.enabled: true
       adminApi.service.type: LoadBalancer
       adminApi.service.loadBalancerSourceRanges:
         - "10.0.0.0/8"
@@ -60,7 +55,6 @@ tests:
     templates:
       - admin-api-service.yaml
     set:
-      adminApi.enabled: true
       adminApi.service.type: NodePort
       adminApi.service.nodePort: 30091
     asserts:
@@ -75,7 +69,6 @@ tests:
     templates:
       - admin-api-service.yaml
     set:
-      adminApi.enabled: true
       adminApi.service.annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     asserts:


### PR DESCRIPTION
## What

Repairs the lakerunner chart's broken Helm unit tests. On main, **9 suites / 52 tests fail** because the standalone `admin-api`/`alert-evaluator`/`monitoring`/`sweeper` Deployments were long ago merged into a single `control-plane-deployment.yaml` (four containers in one pod), but the test suites still referenced the removed `*-deployment.yaml` templates and `containers[0]`.

This PR fixes **8 of the 9** suites. The 9th (`scaling_test.yaml`) is fixed in the companion autoscaling PR (cardinalhq/charts#233) to keep that change with the autoscaler work — so the two PRs together make `helm unittest` fully green.

## Changes (tests only)

- Repoint stale suites at `control-plane-deployment.yaml`.
- Select the merged containers **by name** (`containers[?(@.name=="monitoring")]`, `sweeper`, `alert-evaluator`, `admin-api`) instead of brittle indices.
- Remap moved value keys: `monitoring.resources` → `controlPlane.resources.monitoring`, `monitoring.image` → `controlPlane.image`, `monitoring.replicas` → `controlPlane.replicas`.
- Align assertions with actual rendered output: monitoring/sweeper containers are **CPU-requests-only** (no `limits.cpu`); the monitoring probe port is `hc-mon` gated by `controlPlane.healthProbes.enabled`; the admin-api service renders unconditionally.
- Legacy `*.enabled` toggle tests (for components that are now always present) are repurposed to assert the chart's **deprecation-`fail`** behavior on those removed keys, mirroring the existing `notificationSender` test — rather than deleted.

**No `templates/` or `values.yaml` changes** — the chart is correct; only the tests were stale. No assertion was weakened to pass; each reworded assertion checks the same thing at its correct new location.

## Verification

`helm unittest .` → **21/22 suites pass** (only `scaling_test.yaml` remains, fixed in #233). `helm lint` clean.

## Companion

- cardinalhq/charts#233 — autoscaling mode + HPA rendering; also fixes `scaling_test.yaml`.
- cardinalhq/lakerunner#945 — app-side report-only support.