### PR TITLE
lakerunner: chart 3.16.2, HPA CPU target 90 -> 80

### DIFF
--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.16.2
+
+* **CHANGED**: HPA default CPU target
+  `global.autoscaling.hpa.targetCPUUtilizationPercentage` 90 → 80. The 90%
+  target left no burst headroom and, combined with the controller's default
+  10% tolerance, pushed the effective scale-up trigger to ~99% — pods ran
+  pinned near saturation before a second replica was added. 80% gives the
+  process-* workers room to scale before they saturate.
+
 ## 3.16.0
 
 * **CHANGED**: the process-* workers are now always scaled by a

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.1"
+version: "3.16.2"
 appVersion: "v1.54.0"
 keywords:
   - lakerunner

--- a/lakerunner/tests/process-hpa_test.yaml
+++ b/lakerunner/tests/process-hpa_test.yaml
@@ -47,7 +47,7 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
-          value: 90
+          value: 80
         documentIndex: 0
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds

--- a/lakerunner/values.yaml
+++ b/lakerunner/values.yaml
@@ -13,7 +13,7 @@ global:
     # processLogs/processMetrics/processTraces.autoscaling.
     hpa:
       # Target average CPU as a percentage of the pod's cpu request.
-      targetCPUUtilizationPercentage: 90
+      targetCPUUtilizationPercentage: 80
       # HPA v2 scaling behavior. Defaults favor fast scale-up and a damped
       # 2-minute scale-down window to avoid replica flapping.
       behavior:


### PR DESCRIPTION
Lowers the default HPA CPU target `global.autoscaling.hpa.targetCPUUtilizationPercentage` 90 → 80.

At a 90% target the HPA controller's default 10% tolerance meant scale-up didn't trigger until utilization exceeded ~99%, so the process-* workers ran pinned near saturation (observed at 96-97% with a single replica) before a second pod was added. 80% gives the workers room to scale before saturating.

- values.yaml default 90 → 80
- process-hpa unit test default assertion updated
- chart version 3.16.1 → 3.16.2 (appVersion unchanged)
- Changelog entry added

Lint + 292 unit tests pass. Chart 3.16.2 already published to ECR.