### PR TITLE
lakerunner: chart 3.16.3, appVersion v1.54.0

### DIFF
--- a/lakerunner/Changelog.md
+++ b/lakerunner/Changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.16.3
+
+* **CHANGED**: trimmed the `-scaler` Role down to what the workloads actually
+  use. Removed the `deployments`/`deployments/scale` patch/update grant (dead
+  since the in-product PI autoscaler was removed in 3.16.0 — HPA scaling is done
+  by the kube-controller-manager, not the workload ServiceAccount), plus the
+  unused `pods` read and `coordination.k8s.io` `leases` grant. Service discovery
+  (`services`, `endpointslices`) is retained. perch's Deployment access is
+  unaffected — it comes from `perch-clusterrole`, not this Role.
+* **NEW**: the Role now grants read (`get`/`list`/`watch`) on
+  `autoscaling` `horizontalpodautoscalers` in the release namespace.
+
 ## 3.16.2
 
 * **CHANGED**: HPA default CPU target

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.2"
+version: "3.16.3"
 appVersion: "v1.54.0"
 keywords:
   - lakerunner

--- a/lakerunner/templates/role.yaml
+++ b/lakerunner/templates/role.yaml
@@ -6,18 +6,17 @@ metadata:
     {{- include "lakerunner.labels" . | nindent 4 }}
   {{ include "lakerunner.annotations" . | nindent 2 }}
 rules:
+  # query-api / query-worker discover peer workers via Services + EndpointSlices.
   - apiGroups: [""]
-    resources: ["pods", "services"]
+    resources: ["services"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "deployments/scale"]
-    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "create", "update"]
+  # Read the process-* HorizontalPodAutoscalers in this namespace.
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/lakerunner/tests/security_test.yaml
+++ b/lakerunner/tests/security_test.yaml
@@ -188,8 +188,22 @@ tests:
           path: rules
           content:
             apiGroups: [""]
-            resources: ["pods", "services"]
+            resources: ["services"]
             verbs: ["get", "list", "watch"]
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["autoscaling"]
+            resources: ["horizontalpodautoscalers"]
+            verbs: ["get", "list", "watch"]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments", "deployments/scale"]
+            verbs: ["get", "list", "watch", "patch", "update"]
         documentIndex: 0
 
   - it: should use correct service account in pods


### PR DESCRIPTION
Trims the `-scaler` Role to what the workloads in `../lakerunner` (main @ 84aa5e10) actually use, and adds read access to HorizontalPodAutoscalers for upcoming use.

Verified against the lakerunner source:
- **Removed `apps: deployments, deployments/scale` patch/update** — the only `/scale` (UpdateScale) caller is `perfbench`, which the chart doesn't deploy; perch's Deployment get/list/watch/patch comes from `perch-clusterrole`, not this Role. Dead since the PI autoscaler was removed in 3.16.0.
- **Removed `pods` read** — no `.Pods()` API call exists in the codebase.
- **Removed `coordination.k8s.io: leases`** — no leader-election/lease usage; work coordination is the gRPC `workcoordpb` control stream.
- **Kept `services` + `endpointslices` read** — used by query-api/query-worker peer discovery (`queryapi/kubernetes_discovery.go`).
- **Added `autoscaling: horizontalpodautoscalers` get/list/watch** — for reading the process-* HPAs in-namespace (near-future use).

Role name left as `-scaler` to avoid churning the RoleBinding. Lint + 292 unit tests pass (security_test updated). Chart 3.16.3 published to ECR.