### PR TITLE
flamethrower: bump chart to 0.3.0

### DIFF
--- a/flamethrower/Chart.yaml
+++ b/flamethrower/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flamethrower
 description: OTLP signal flood generator for calibration tests
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/cardinalhq/flamethrower
 sources:
   - https://github.com/cardinalhq/flamethrower


### PR DESCRIPTION
Tracks flamethrower [v0.3.0](https://github.com/cardinalhq/flamethrower/releases/tag/v0.3.0) (adds the `serve` flood-control UI subcommand).

- `version`: 0.2.0 → 0.3.0
- `appVersion`: 0.2.0 → 0.3.0 (pulls image `public.ecr.aws/cardinalhq.io/flamethrower:v0.3.0`)

lint + helm-unittest (12 tests) pass.