### PR TITLE
flamethrower: fix default image tag (appVersion v0.3.0)

### DIFF
--- a/flamethrower/Chart.yaml
+++ b/flamethrower/Chart.yaml
@@ -2,8 +2,12 @@ apiVersion: v2
 name: flamethrower
 description: OTLP signal flood generator for calibration tests
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+# appVersion is the app's released image tag; flamethrower images are
+# published v-prefixed (v0.3.0). The image helper defaults image.tag to
+# this, so it must carry the v or the default pulls the chart artifact
+# (same OCI repo, tag 0.3.0) instead of the image.
+appVersion: "v0.3.0"
 home: https://github.com/cardinalhq/flamethrower
 sources:
   - https://github.com/cardinalhq/flamethrower


### PR DESCRIPTION
The image helper defaults `image.tag` to `appVersion`, but flamethrower images are published v-prefixed (`v0.3.0`). With `appVersion: 0.3.0`, the default resolved to `flamethrower:0.3.0` — which is the **chart OCI artifact** in the same repo, not the image. Pods crashed with `exec: "serve": executable file not found`.

- `appVersion: "0.3.0"` → `"v0.3.0"` (default image now resolves to the real image)
- `version: 0.3.0` → `0.3.1` (chart behavior change → new release)

Verified: with no overrides the chart now renders `image: .../flamethrower:v0.3.0`; `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)