### PR TITLE
conductor: re-converge to lakerunner v1.57.1 / maestro v1.64.0

### DIFF
--- a/conductor/Chart.yaml
+++ b/conductor/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v2
 name: conductor
 description: Unified Helm chart for CardinalHQ LakeRunner + Maestro
 type: application
-version: "0.1.0"
+version: "0.2.0"
 # appVersion is nominal only — component image tags are pinned per-component in values.yaml
-# (both lakerunner.* and maestro.* image helpers would otherwise default the tag to this).
-appVersion: "v1.53.0"
+# (lakerunner v1.57.1 / maestro v1.64.0 as of this release). Both lakerunner.* and
+# maestro.* image helpers would otherwise default the tag to this.
+appVersion: "v1.64.0"
 keywords:
   - lakerunner
   - maestro

--- a/conductor/templates/_helpers-lakerunner.tpl
+++ b/conductor/templates/_helpers-lakerunner.tpl
@@ -569,38 +569,6 @@ Usage: {{ include "lakerunner.image" (list .Values.componentName.image .) }}
 {{- end -}}
 
 {{/*
-Generate autoscaler environment variables for the monitoring deployment.
-Emits LAKERUNNER_AUTOSCALER_* env vars for all worker services. When a
-signal's processing is disabled, its MIN/MAX replicas are emitted as 0
-so the autoscaler treats it as scaled-to-zero.
-Usage: {{ include "lakerunner.autoscalerEnv" . }}
-*/}}
-{{- define "lakerunner.autoscalerEnv" -}}
-- name: LAKERUNNER_AUTOSCALER_ENABLED
-  value: "true"
-- name: LAKERUNNER_AUTOSCALER_OBSERVE_ONLY
-  value: {{ .Values.monitoring.autoscaler.observeOnly | quote }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT
-  value: {{ include "lakerunner.fullname" . }}-process-logs
-- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS
-  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS
-  value: {{ if .Values.processLogs.enabled }}{{ .Values.processLogs.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT
-  value: {{ include "lakerunner.fullname" . }}-process-metrics
-- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS
-  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS
-  value: {{ if .Values.processMetrics.enabled }}{{ .Values.processMetrics.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT
-  value: {{ include "lakerunner.fullname" . }}-process-traces
-- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS
-  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.minReplicas | quote }}{{ else }}"0"{{ end }}
-- name: LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS
-  value: {{ if .Values.processTraces.enabled }}{{ .Values.processTraces.autoscaling.maxReplicas | quote }}{{ else }}"0"{{ end }}
-{{- end -}}
-
-{{/*
 Emit the LAKERUNNER_SCRATCH_DISK_SIZE_BYTES env var for scratch-using services.
 
 Behavior (issue #783):

--- a/conductor/templates/lakerunner/control-plane-deployment.yaml
+++ b/conductor/templates/lakerunner/control-plane-deployment.yaml
@@ -207,7 +207,6 @@ spec:
           {{- end }}
           - name: PPROF_PORT
             value: {{ $pprofMon | quote }}
-          {{- include "lakerunner.autoscalerEnv" . | nindent 10 }}
           {{- include "lakerunner.injectEnv" (list . (dict "env" (.Values.monitoring.env | default list) "resources" .Values.controlPlane.resources.monitoring)) | nindent 8 }}
           {{- include "lakerunner.cardinalTelemetryEnv" . | nindent 10 }}
         {{- include "lakerunner.healthProbes" (list . .Values.controlPlane "hc-mon") | nindent 8 }}

--- a/conductor/templates/lakerunner/deprecation-warnings.yaml
+++ b/conductor/templates/lakerunner/deprecation-warnings.yaml
@@ -93,7 +93,7 @@ To fix this error:
 
   Service-specific keys are still read from their own blocks:
     adminApi.port, adminApi.service, alertEvaluator.queryApiUrl,
-    alertEvaluator.env, monitoring.autoscaler
+    alertEvaluator.env, monitoring.env
 
 ================================================================================
 ` (join ", " $cp)) }}

--- a/conductor/templates/lakerunner/process-hpa.yaml
+++ b/conductor/templates/lakerunner/process-hpa.yaml
@@ -1,0 +1,47 @@
+{{- /*
+HorizontalPodAutoscalers for the process-* workers. Bounds come from each
+service's autoscaling.minReplicas/maxReplicas; the CPU target and behavior
+default from global.autoscaling.hpa and may be overridden per-service.
+
+The process-* Deployment templates intentionally omit spec.replicas, so an HPA
+owns the replica count without fighting the rendered manifest.
+*/ -}}
+{{- $root := . }}
+{{- $hpa := .Values.global.autoscaling.hpa | default dict }}
+{{- $services := list
+    (dict "component" "process-logs" "values" .Values.processLogs)
+    (dict "component" "process-metrics" "values" .Values.processMetrics)
+    (dict "component" "process-traces" "values" .Values.processTraces) }}
+{{- range $svc := $services }}
+{{- if $svc.values.enabled }}
+{{- $as := $svc.values.autoscaling | default dict }}
+{{- $target := $as.targetCPUUtilizationPercentage | default $hpa.targetCPUUtilizationPercentage | default 85 }}
+{{- $behavior := $as.behavior | default $hpa.behavior }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lakerunner.fullname" $root }}-{{ $svc.component }}
+  labels:
+    {{- include "lakerunner.labelsWithComponent" (list $root $svc.values.labels) | nindent 4 }}
+    app.kubernetes.io/component: {{ $svc.component }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lakerunner.fullname" $root }}-{{ $svc.component }}
+  minReplicas: {{ $as.minReplicas | default 1 }}
+  maxReplicas: {{ $as.maxReplicas | default 1 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $target }}
+  {{- with $behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/conductor/tests/values-unified.yaml
+++ b/conductor/tests/values-unified.yaml
@@ -8,3 +8,9 @@ license:
 # maestro database (namespaced to avoid colliding with lakerunner's nested database.lrdb)
 maestroDatabase:
   host: db.example.com
+# bootstrap is active by default (mode: auto); org id + owner email are required
+# so the maestro deployment renders its MAESTRO_BOOTSTRAP_* env.
+bootstrap:
+  org:
+    id: "00000000-0000-0000-0000-000000000000"
+    ownerEmail: "test@example.com"

--- a/conductor/values.yaml
+++ b/conductor/values.yaml
@@ -5,6 +5,36 @@
 
 # Global settings
 global:
+  # Settings for the HorizontalPodAutoscalers. One HPA is created per enabled
+  # process-* worker (see lakerunner/process-hpa.yaml); its min/max come from
+  # that service's autoscaling.minReplicas/maxReplicas.
+  autoscaling:
+    # targetCPUUtilizationPercentage and behavior here are the defaults for all
+    # three process-* workers and can be overridden per-service under
+    # processLogs/processMetrics/processTraces.autoscaling.
+    hpa:
+      # Target average CPU as a percentage of the pod's cpu request.
+      targetCPUUtilizationPercentage: 80
+      # HPA v2 scaling behavior. Defaults favor fast scale-up and a damped
+      # 2-minute scale-down window to avoid replica flapping.
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 30
+            - type: Pods
+              value: 8
+              periodSeconds: 30
+        scaleDown:
+          stabilizationWindowSeconds: 120
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
   # Global resource configuration
   resources:
     # Whether to render resource limits and requests in deployments
@@ -33,7 +63,7 @@ global:
     # Pinned explicitly here so lakerunner images do NOT default to the unified
     # Chart.appVersion (which tracks maestro). Mirrors the legacy lakerunner
     # chart's appVersion. Per-component image.tag still wins over this.
-    tag: "v1.41.6"
+    tag: "v1.57.1"
     # Default pull policy for all images
     pullPolicy: "IfNotPresent"
   # Global temporary storage (scratch / DuckDB temp / cache) configuration.
@@ -847,7 +877,7 @@ objectStore:
 # Entrypoint selects which component to run.
 image:
   repository: public.ecr.aws/cardinalhq.io/maestro
-  tag: "v1.53.1"   # pinned (mirrors legacy maestro appVersion); do not rely on Chart.appVersion
+  tag: "v1.64.0"   # pinned (mirrors legacy maestro appVersion); do not rely on Chart.appVersion
   pullPolicy: IfNotPresent
 
 # Maestro API server + UI configuration

--- a/docs/superpowers/specs/2026-06-19-conductor-reconverge-design.md
+++ b/docs/superpowers/specs/2026-06-19-conductor-reconverge-design.md
@@ -1,0 +1,132 @@
+# Conductor Re-converge (Foundation Phase) — Design
+
+**Date:** 2026-06-19
+**Status:** Draft (awaiting user review)
+**Branch:** `feat/conductor-reconverge`
+
+## 1. Goal
+
+The unified `conductor` chart has drifted from the standalone `lakerunner` and
+`maestro` charts it was vendored from. Conductor was last synced on 2026-06-07
+(PR #198, commit `67ac8da`) at lakerunner v1.41.x / maestro v1.53.1; the
+standalone charts have since advanced ~16 releases each to **lakerunner v1.57.1
+(chart 3.16.8)** and **maestro v1.64.0 (chart 0.9.23)**.
+
+Bring conductor back to parity with the current standalone charts, unpin its
+stale image tags, and **prove a fresh install Just Works end-to-end** against the
+existing `test/fresh-install` harness on the `kubepi` cluster.
+
+This is the **foundation** for retiring the split charts. Per the agreed
+direction: once conductor can replace the production install (via a later
+one-time migration), the split model is dropped and conductor becomes the sole
+chart. That migration and the split-chart retirement are **out of scope here**.
+
+## 2. Context & constraints
+
+- **Monolithic design is retained** (per the 2026-06-05 unified-chart design,
+  §3): conductor vendors lakerunner + maestro templates into
+  `templates/lakerunner/` and `templates/maestro/`, with a `templates/bootstrap/`
+  glue layer and shared `templates/shared/` SA+RBAC. Subchart/umbrella and
+  codegen approaches were rejected — there is no point depending on or
+  generating from charts that are about to be deleted.
+- **Split charts remain the source of truth** for the LR/maestro halves until
+  cutover. Conductor tracks them; they do not track conductor.
+- **External infra only.** "Just Works" means: operator supplies external
+  Postgres + S3-compatible object store + license; the chart bootstraps schema,
+  admin key, and provisioning. No bundled Postgres/object store in the chart
+  (the test harness supplies them as fixtures).
+- **No CI added** in this phase (decided: split charts retiring soon; rely on
+  this re-converge + manual discipline).
+
+## 3. Divergence survey (measured)
+
+Most vendored templates are **byte-identical** to current standalone. The drift
+that needs reconciling, by file:
+
+**lakerunner** (`templates/lakerunner/`):
+- `configdb-secret.yaml`, `postgresql-secret.yaml`, `storageprofile-configmap.yaml`
+- `control-plane-deployment.yaml` (conductor adds a stale `autoscalerEnv`; standalone
+  reworked autoscaling to `global.autoscaling.mode hpa|worklane`)
+- `process-logs-deployment.yaml`, `deprecation-warnings.yaml`
+- `_helpers-lakerunner.tpl` (conductor +84 lines vs standalone)
+
+**maestro** (`templates/maestro/`):
+- `maestro-deployment.yaml` — largest: standalone renamed `persistence.*`/`data`
+  volume → `temporaryStorage.*`/`scratch`; conductor adds the
+  `MAESTRO_BOOTSTRAP_*` env block gated on `conductor.bootstrapEnabled` (KEEP).
+- `maestro-pvc.yaml`, `secret.yaml`, `dex-deployment.yaml`,
+  `github-cache-statefulset.yaml`, `_helpers-maestro.tpl`
+
+**chart-level:**
+- `values.yaml` — image tags pinned to v1.41.6 / v1.53.1; missing new standalone
+  keys (e.g. `temporaryStorage`, `autoscaling.mode`).
+- **Missing template:** conductor has no `process-hpa.yaml`, but standalone now
+  defaults `global.autoscaling.mode: hpa`. Without it conductor won't autoscale.
+  Must be added with the conductor transform.
+
+**Intentionally dropped (must stay dropped):** grafana (`grafana-*`), bundled
+`collector.yaml`, perch (`perch-*`), and `setup-job.yaml`.
+
+## 4. Reconcile method — three-way merge per file
+
+The drift is **bidirectional** (conductor is ahead in glue, behind in upstream
+evolution), so a blind copy-from-standalone would regress conductor's wiring.
+For each vendored file, perform a three-way merge:
+
+- **base** = standalone template tree at commit `67ac8da` (last conductor sync)
+- **theirs** = current standalone (`main`: lakerunner v1.57.1 / maestro v1.64.0)
+- **ours** = current conductor vendored copy
+
+Rule: **absorb** standalone evolution (`theirs` vs `base`) while **preserving**
+every conductor transform (`ours` vs `base`):
+- subdir layout (`templates/lakerunner/`, `templates/maestro/`)
+- helper namespacing (`_helpers-lakerunner.tpl`, `_helpers-maestro.tpl`)
+- bootstrap wiring (`conductor.bootstrapEnabled`, `MAESTRO_BOOTSTRAP_*`,
+  admin-key secret refs, `conductor.queryApiUrl`/`adminApiUrl` includes)
+- dropped components (grafana/collector/perch/setup-job)
+- conductor image defaults (ecr-public)
+
+Byte-identical files are no-ops. Each reconciled file is verified to still render
+(`helm template`) and to keep its conductor-specific hunks.
+
+## 5. Image versioning
+
+LR and maestro have distinct appVersions but conductor has a single nominal
+`appVersion`. Pin per-family explicitly in `values.yaml`:
+- lakerunner image tag → `v1.57.1`
+- maestro image tag → `v1.64.0`
+
+Bump conductor chart version `0.1.0 → 0.2.0`. Update the `appVersion` comment in
+`Chart.yaml` to the new nominal pair.
+
+## 6. Verification (in order)
+
+1. `helm lint conductor`
+2. `helm template conductor` with each of `conductor/tests/values-{lakerunner,maestro,unified}.yaml`
+3. `conductor/tests/render-parity.sh conductor/tests/values-lakerunner.yaml
+   conductor/tests/values-maestro.yaml conductor/tests/values-unified.yaml`
+   — expected LEGACY-ONLY = grafana/collector/perch resources + the 2 legacy
+   ServiceAccounts + legacy scaler Role/RoleBinding; expected UNIFIED-ONLY = one
+   release-named SA/Role/RoleBinding. No other diffs.
+4. `NS=conductor-fresh bash test/fresh-install/00-run.sh` on `kubepi` →
+   **`FRESH-INSTALL PASS`** (collector → rustfs → pubsub-http → process-* →
+   queryable via query-api direct AND maestro proxy).
+
+## 7. Out of scope (follow-ups)
+
+- One-time prod migration / adoption script and split-chart retirement.
+- Adoption (`test/adoption`) and failure-mode (`test/failure-modes`) test runs.
+- CI drift-guard.
+
+## 8. Risks
+
+- **values.yaml + helpers merges are the riskiest** (largest, most logic). The
+  three-way merge plus `helm template`/lint after each contains this.
+- **New standalone templates.** Confirmed (`comm` against `67ac8da`):
+  `process-hpa.yaml` is the *only* template added to standalone since vendoring
+  (lakerunner side; none on maestro side). It must be vendored in with the
+  conductor transform. No other hidden additions.
+- **Fresh-install env coupling.** The harness requires the `kubepi` context
+  (available) and the sibling `conductor` repo for license minting (present at
+  `/Users/mgraff/git/github/cardinalhq/conductor`). Postgres needs `pgvector`;
+  the fixture already provides it.


### PR DESCRIPTION
Re-converges the unified `conductor` chart with the standalone charts (it had drifted ~16 releases behind since the last sync at PR #198).

## What
- Three-way merged all diverged vendored templates (base `67ac8da` → current standalone), absorbing upstream evolution (autoscaling rework) while preserving conductor's bootstrap glue.
- Added `process-hpa.yaml` (only template standalone added since vendoring) + `global.autoscaling.hpa`.
- Unpinned stale images → lakerunner **v1.57.1** / maestro **v1.64.0**; chart `0.1.0 → 0.2.0`.
- Fixed stale `values-unified.yaml` parity fixture (now-required `bootstrap.org` fields).

## Verification
- `helm lint` clean · renders (29 resources, 3 HPAs) · `render-parity.sh` clean (all diffs intentional).
- **Fresh-install e2e PASS on kubepi**: collector → rustfs → pubsub-http → process-* → queryable via query-api **direct** and maestro **proxy**. Bootstrap chain worked (migrations, admin-key seed, maestro org provisioning).

Design spec: `docs/superpowers/specs/2026-06-19-conductor-reconverge-design.md`.

Note: main bumped maestro to v1.64.3 during this work; this PR pins v1.64.0 (what was e2e-validated). Trivial follow-up patch bump.