### PR TITLE
lakerunner: chart 3.16.12, appVersion v1.58.2

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.11"
-appVersion: "v1.58.1"
+version: "3.16.12"
+appVersion: "v1.58.2"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.58.2 release (force-recompact unpublish-guard fix).