### PR TITLE
lakerunner: chart 3.16.13, appVersion v1.58.3

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.12"
-appVersion: "v1.58.2"
+version: "3.16.13"
+appVersion: "v1.58.3"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.58.3 release (compactionstats rolling 24h window).