### PR TITLE
hpa: scope process-* scaling to own container

### DIFF
--- a/conductor/Chart.yaml
+++ b/conductor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: conductor
 description: Unified Helm chart for CardinalHQ LakeRunner + Maestro
 type: application
-version: "0.2.0"
+version: "0.2.1"
 # appVersion is nominal only — component image tags are pinned per-component in values.yaml
 # (lakerunner v1.57.1 / maestro v1.64.0 as of this release). Both lakerunner.* and
 # maestro.* image helpers would otherwise default the tag to this.

--- a/conductor/templates/lakerunner/process-hpa.yaml
+++ b/conductor/templates/lakerunner/process-hpa.yaml
@@ -33,9 +33,12 @@ spec:
   minReplicas: {{ $as.minReplicas | default 1 }}
   maxReplicas: {{ $as.maxReplicas | default 1 }}
   metrics:
-    - type: Resource
-      resource:
+    # ContainerResource scopes scaling to our own container so an injected
+    # sidecar (e.g. istio) does not skew the utilization calculation.
+    - type: ContainerResource
+      containerResource:
         name: cpu
+        container: {{ $svc.component }}
         target:
           type: Utilization
           averageUtilization: {{ $target }}

--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.13"
+version: "3.16.14"
 appVersion: "v1.58.3"
 keywords:
   - lakerunner

--- a/lakerunner/templates/process-hpa.yaml
+++ b/lakerunner/templates/process-hpa.yaml
@@ -33,9 +33,12 @@ spec:
   minReplicas: {{ $as.minReplicas | default 1 }}
   maxReplicas: {{ $as.maxReplicas | default 1 }}
   metrics:
-    - type: Resource
-      resource:
+    # ContainerResource scopes scaling to our own container so an injected
+    # sidecar (e.g. istio) does not skew the utilization calculation.
+    - type: ContainerResource
+      containerResource:
         name: cpu
+        container: {{ $svc.component }}
         target:
           type: Utilization
           averageUtilization: {{ $target }}

--- a/lakerunner/tests/process-hpa_test.yaml
+++ b/lakerunner/tests/process-hpa_test.yaml
@@ -46,9 +46,25 @@ tests:
           value: 10
         documentIndex: 0
       - equal:
-          path: spec.metrics[0].resource.target.averageUtilization
+          path: spec.metrics[0].containerResource.target.averageUtilization
           value: 80
         documentIndex: 0
+      - equal:
+          path: spec.metrics[0].type
+          value: ContainerResource
+        documentIndex: 0
+      - equal:
+          path: spec.metrics[0].containerResource.container
+          value: process-logs
+        documentIndex: 0
+      - equal:
+          path: spec.metrics[0].containerResource.container
+          value: process-metrics
+        documentIndex: 1
+      - equal:
+          path: spec.metrics[0].containerResource.container
+          value: process-traces
+        documentIndex: 2
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
           value: 120
@@ -81,7 +97,7 @@ tests:
           value: 25
         documentIndex: 0
       - equal:
-          path: spec.metrics[0].resource.target.averageUtilization
+          path: spec.metrics[0].containerResource.target.averageUtilization
           value: 70
         documentIndex: 0
 
@@ -104,7 +120,7 @@ tests:
       global.autoscaling.hpa: null
     asserts:
       - equal:
-          path: spec.metrics[0].resource.target.averageUtilization
+          path: spec.metrics[0].containerResource.target.averageUtilization
           value: 85
         documentIndex: 0
       - notExists:


### PR DESCRIPTION
## What

HPA `process-*` workers now use `ContainerResource` (was pod-wide `Resource`) for the CPU metric, naming our container explicitly. An injected sidecar (e.g. istio-proxy) no longer skews the utilization calculation.

Applies to both the `lakerunner` and `conductor` charts.

## Version bumps
- lakerunner: 3.16.13 → 3.16.14
- conductor: 0.2.0 → 0.2.1

(appVersion unchanged — no app image change.)

## Compatibility
`ContainerResource` HPA metrics are GA on Kubernetes ≥ 1.27. Prod (aws-prod-us-east-2-global) is v1.35 — supported.

## Tests
- `helm unittest lakerunner -f tests/process-hpa_test.yaml` — 6/6 pass
- `helm lint` — both charts clean