### PR TITLE
lakerunner: chart 3.16.15, appVersion v1.59.0

### DIFF
--- a/lakerunner/Chart.yaml
+++ b/lakerunner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakerunner
 description: A Helm chart for LakeRunner - a log and metrics processing platform
 type: application
-version: "3.16.14"
-appVersion: "v1.58.3"
+version: "3.16.15"
+appVersion: "v1.59.0"
 keywords:
   - lakerunner
   - logs


### PR DESCRIPTION
Bump for lakerunner/v1.59.0 release (lkrn-only logs/traces ingest+compaction).